### PR TITLE
Replaced net/http/Route::_compilePatterns() with a preg_match_all

### DIFF
--- a/tests/cases/net/http/RouteTest.php
+++ b/tests/cases/net/http/RouteTest.php
@@ -299,6 +299,25 @@ class RouteTest extends \lithium\test\Unit {
 			'handler' => null
 		);
 		$this->assertEqual($expected, $result);
+
+		$result = new Route(array(
+			'template' => '/images/image_{:width}x{:height}.{:format}',
+			'params' => array('format' => 'png')
+		));
+		$expected = array(
+			'template' => '/images/image_{:width}x{:height}.{:format}',
+			'pattern' => '@^/images/image_(?P<width>[^\\/]+)x(?P<height>[^\\/]+)\\.(?P<format>[^\\/]+)?$@',
+			'params' => array('format' => 'png', 'action' => 'index'),
+			'match' => array('action' => 'index'),
+			'meta' => array(),
+			'keys' => array('width' => 'width', 'height' => 'height', 'format' => 'format'),
+			'defaults' => array('format' => 'png'),
+			'subPatterns' => array(),
+			'persist' => array(),
+			'handler' => null
+		);
+		$result = $result->export();
+		$this->assertEqual($expected, $result);
 	}
 
 	/**


### PR DESCRIPTION
This should be a little faster, and cleaner, than the _compilePatterns method, and seems to work with all the tests.

Also I cleaned up the location of some of the variable definitions to that $this->_pattern is not set just to be overwritten in the '/' pattern case and $shortKeys is defined next to the loop that uses it.
