### PR TITLE
Fixing socket persistence in `net\http\Service`.

### DIFF
--- a/net/http/Service.php
+++ b/net/http/Service.php
@@ -146,11 +146,16 @@ class Service extends \lithium\core\Object {
 	public function &connection($config = array()) {
 		$config += $this->_config;
 
-		try {
-			$this->connection = Libraries::instance('socket', $config['socket'], $config);
-		} catch (ClassNotFoundException $e) {
-			$this->connection = null;
+		if(empty($this->connection)) {
+			try {
+				$this->connection = Libraries::instance('socket', $config['socket'], $config);
+			} catch (ClassNotFoundException $e) {
+				$this->connection = null;
+			}
+		} else {
+			$this->connection->_config = array_merge($this->connection->_config, $config);
 		}
+
 		return $this->connection;
 	}
 

--- a/tests/cases/net/http/ServiceTest.php
+++ b/tests/cases/net/http/ServiceTest.php
@@ -212,6 +212,8 @@ class ServiceTest extends \lithium\test\Unit {
 		$connection = $http->connection(array('scheme' => 'https'));
 		$config = $connection->config();
 		$this->assertEqual('https', $config['scheme']);
+
+		$this->assertEqual($http->connection(), $connection);
 	}
 
 	public function testSendConfiguringConnection() {


### PR DESCRIPTION
The `Service` `Socket::set()` function does not work as intended, a `Socket` instance is created each time a request is sent.
