### PR TITLE
Fixed a bug where SQL values in IN clauses were not escaped properly

### DIFF
--- a/data/source/Database.php
+++ b/data/source/Database.php
@@ -547,8 +547,6 @@ abstract class Database extends \lithium\data\Source {
 	public function _processConditions($key, $value, $schema, $glue = 'AND') {
 		$constraintTypes =& $this->_constraintTypes;
 
-
-
 		switch (true) {
 			case (is_numeric($key) && is_string($value)):
 				return $value;

--- a/tests/cases/data/source/DatabaseTest.php
+++ b/tests/cases/data/source/DatabaseTest.php
@@ -95,7 +95,7 @@ class DatabaseTest extends \lithium\test\Unit {
 
 		$result = $this->db->value('1.1', array('type' => 'float'));
 		$this->assertIdentical(1.1, $result);
-		
+
 		$result = $this->db->value('1', array('type' => 'string'));
 		$this->assertIdentical("'1'", $result);
 	}
@@ -558,12 +558,12 @@ class DatabaseTest extends \lithium\test\Unit {
 		$sql .= "({id} = 0 OR {title} = 'value2' OR ({author_id} = 1 AND {created} = '2')";
 		$sql .= " OR ({title} = 'value2') OR (title IS NULL)) AND {id} = 3 AND author_id = 0;";
 		$this->assertEqual($sql, $this->db->renderCommand($query));
-		
+
 		$query = new Query(array(
 			'type' => 'read', 'model' => $this->_model,
 			'conditions' => array('title' => array('0900'))
 		));
-		
+
 		$sql = "SELECT * FROM {mock_database_posts} AS {MockDatabasePost} WHERE title IN ('0900');";
 		$this->assertEqual($sql, $this->db->renderCommand($query));
 	}


### PR DESCRIPTION
Fixed a bug where values in IN clauses were not escaped properly in the Database DS

There is an issue in the Database datasource where queries generated by the conditions method would not have properly escaped values in their IN clause.  This is due to a mistake where $schema was not properly being passed to the value method.

The tests committed here will show the bug and fail, my patch to Database.php makes those tests pass.
