### PR TITLE
CouchDB compatibility issue fix

### DIFF
--- a/data/source/http/adapter/CouchDb.php
+++ b/data/source/http/adapter/CouchDb.php
@@ -220,6 +220,7 @@ class CouchDb extends \lithium\data\source\Http {
 		$params = compact('query', 'options');
 		$conn =& $this->connection;
 		$config = $this->_config;
+		
 		return $this->_filter(__METHOD__, $params, function($self, $params) use (&$conn, $config) {
 			$query = $params['query'];
 			$options = $params['options'];
@@ -241,8 +242,9 @@ class CouchDb extends \lithium\data\source\Http {
 			if (isset($result['_id'])) {
 				$data = array($result);
 			} elseif (isset($result['rows'])) {
-				$data = array_map(function($row) { return $row['doc']; }, $result['rows']);
-
+				$data = array_map(function($row) { 
+					return isset($row['doc'])? $row['doc'] : $row['value']; 
+				}, $result['rows']);
 				unset($result['rows']);
 				$stats = $result;
 			}


### PR DESCRIPTION
I opened up an issue at https://github.com/UnionOfRAD/lithium/issues/46

I think this might be due to a change in document structure in version 1.1? I don't know if older versions are  with these changes, but I have allowed for the case where backwards compatibility might be needed. Could someone test this on an older version of couch db. My tests now pass on 1.1 and of course the CrudTest.
