### PR TITLE
Added 'blacklist' option to Model::save() (in addition to the already available 'whitelist' option)

### DIFF
--- a/data/Model.php
+++ b/data/Model.php
@@ -734,6 +734,11 @@ class Model extends \lithium\core\StaticObject {
 	 *         `$validates` property of the model.
 	 *        - `'whitelist'` _array_: An array of fields that are allowed to be saved to this
 	 *          record.
+	 *        - `'blacklist'` _array_: As the name suggests, this option provides the opposite
+	 *          functionality of `'whitelist'`. Both lists play along nicely.  You could for
+	 *          example provide a `'whitelist'` and then filter some values in that list via
+	 *          `'blacklist`'. Keep in mind, `'whitelist'` will always be processed first. See
+	 *          QueryTest::testWhiteandBlacklistingTogether() for example usage.
 	 *
 	 * @return boolean Returns `true` on a successful save operation, `false` on failure.
 	 * @filter
@@ -746,6 +751,7 @@ class Model extends \lithium\core\StaticObject {
 		$defaults = array(
 			'validate' => true,
 			'whitelist' => null,
+			'blacklist' => null,
 			'callbacks' => true,
 			'locked' => $self->_meta['locked']
 		);

--- a/tests/cases/data/model/QueryTest.php
+++ b/tests/cases/data/model/QueryTest.php
@@ -274,6 +274,7 @@ class QueryTest extends \lithium\test\Unit {
 			'source',
 			'type',
 			'whitelist',
+			'blacklist',
 			'relationships'
 		);
 		$result = array_keys($export);
@@ -393,6 +394,47 @@ class QueryTest extends \lithium\test\Unit {
 		$query = new Query(compact('data') + array('whitelist' => array('foo', 'bar')));
 		$this->assertEqual(array('foo' => 1, 'bar' => 2), $query->data());
 	}
+
+	/**
+	 * Tests that assigning a blacklist to a query properly restricts the list of data fields that
+	 * the query exposes.
+	 *
+	 * @return void
+	 */
+	public function testBlacklisting() {
+		$data = array('foo' => 1, 'bar' => 2);
+		$query = new Query(compact('data'));
+		$this->assertEqual($data, $query->data());
+
+		$query = new Query(compact('data') + array('blacklist' => array('foo')));
+		$this->assertEqual(array('bar' => 2), $query->data());
+	}
+
+	/**
+	 * Tests the ability to combine whitelists and blacklists.
+	 *
+	 * @return void
+	 */
+	public function testWhiteandBlacklistingTogether() {
+		$data = array('foo' => 1, 'bar' => 2, 'baz' => 3, 'foz' => 4);
+
+		$query = new Query(compact('data'));
+		$this->assertEqual($data, $query->data());
+
+		$query = new Query(compact('data') + array(
+			'whitelist' => array('foo', 'bar', 'baz'),
+			'blacklist' => array('baz')
+		));
+		$this->assertEqual(array('foo' => 1, 'bar' => 2), $query->data());
+
+		$query = new Query(compact('data') + array(
+			'blacklist' => array('foo'),
+			'whitelist' => array('foo', 'bar')
+		));
+		$this->assertEqual(array('bar' => 2), $query->data());
+	}
+
+
 
 	/**
 	 * Tests basic property accessors and mutators.


### PR DESCRIPTION
Hello, guys.

I needed a blacklist option for model::save() - but noticed that there is only a whitelist option as of yet. So I decided to implement one and share it with you lot. I'm sure you can come up with some use cases for this option, if not, give me a whisp on IRC. More info available in the unit tests and Dockblocks. Also included are some unit tests to make sure whitelists and blacklist play along nicely...

Best regards,

Ciaro Vermeire
