### PR TITLE
Fix Regression in Request::type()

### DIFF
--- a/net/http/Message.php
+++ b/net/http/Message.php
@@ -133,7 +133,7 @@ class Message extends \lithium\net\Message {
 	 *         on the content type of the request.
 	 */
 	public function type($type = null) {
-		if ($type == null) {
+		if ($type == null && $type !== false) {
 			return $this->_type;
 		}
 		if (strpos($type, '/')) {


### PR DESCRIPTION
I introduced a regression in my last commit f2a44de15a3fe8a5bf8a that doomed the strict comparison with `null` and thus broke the tests `ResponseTest:testTypeManipulation()` and `$this->response->type(false)` that resets the type of response.

Tests double checked :-)

Thanks guys
