### PR TITLE
Environment detection for the console

### DIFF
--- a/console/Command.php
+++ b/console/Command.php
@@ -9,6 +9,7 @@
 namespace lithium\console;
 
 use Exception;
+use lithium\core\Environment;
 use lithium\console\command\Help;
 
 /**
@@ -75,7 +76,6 @@ class Command extends \lithium\core\Object {
 	 */
 	protected function _init() {
 		parent::_init();
-
 		$this->request = $this->_config['request'];
 		$resp = $this->_config['response'];
 		$this->response = is_object($resp) ? $resp : $this->_instance('response', $resp);
@@ -104,6 +104,9 @@ class Command extends \lithium\core\Object {
 	 */
 	public function __invoke($action, $args = array(), $options = array()) {
 		try {
+			$message = 'Lithium console started in the ' . Environment::get() .' environment.';
+			$message .= ' Use the --env=environment key to alter this.';
+			$this->out($message);
 			$this->response->status = 1;
 			$result = $this->invokeMethod($action, $args);
 

--- a/console/Dispatcher.php
+++ b/console/Dispatcher.php
@@ -9,6 +9,7 @@
 namespace lithium\console;
 
 use lithium\core\Libraries;
+use lithium\core\Environment;
 use UnexpectedValueException;
 
 /**
@@ -82,9 +83,8 @@ class Dispatcher extends \lithium\core\StaticObject {
 		$options += $defaults;
 		$classes = static::$_classes;
 		$params = compact('request', 'options');
-		$method = __FUNCTION__;
 
-		return static::_filter($method, $params, function($self, $params) use ($classes) {
+		return static::_filter(__FUNCTION__, $params, function($self, $params) use ($classes) {
 			$request = $params['request'];
 			$options = $params['options'];
 
@@ -170,6 +170,7 @@ class Dispatcher extends \lithium\core\StaticObject {
 	 */
 	protected static function _call($callable, $request, $params) {
 		$params = compact('callable', 'request', 'params');
+		Environment::set($request);
 		return static::_filter(__FUNCTION__, $params, function($self, $params) {
 			if (is_callable($callable = $params['callable'])) {
 				$request = $params['request'];

--- a/core/Environment.php
+++ b/core/Environment.php
@@ -278,7 +278,14 @@ class Environment {
 	protected static function _detector() {
 		return static::$_detector ?: function($request) {
 			$isLocal = in_array($request->env('SERVER_ADDR'), array('::1', '127.0.0.1'));
+			$isCli = is_array($request->argv) && !empty($request->argv);
 			switch (true) {
+				case (isset($request->params['env'])):
+					return $request->params['env'];
+				case ($isCli && $request->argv[0] == 'test'):
+					return 'test';
+				case ($isCli):
+					return 'development';
 				case (preg_match('/^test\//', $request->url) && $isLocal):
 					return 'test';
 				case ($isLocal):

--- a/tests/cases/core/EnvironmentTest.php
+++ b/tests/cases/core/EnvironmentTest.php
@@ -99,6 +99,21 @@ class EnvironmentTest extends \lithium\test\Unit {
 		$request->url = 'test/myTest';
 		Environment::set($request);
 		$this->assertTrue(Environment::is('test'));
+		
+		$request = new MockRequest();
+		$request->argv = array(0 => 'test');
+		Environment::set($request);
+		$this->assertTrue(Environment::is('test'));
+		
+		$request = new MockRequest();
+		$request->argv = array(0 => 'something');
+		Environment::set($request);
+		$this->assertTrue(Environment::is('development'));
+		
+		$request = new MockRequest();
+		$request->params = array('env' => 'production');
+		Environment::set($request);
+		$this->assertTrue(Environment::is('production'));
 	}
 
 	/**

--- a/tests/mocks/core/MockRequest.php
+++ b/tests/mocks/core/MockRequest.php
@@ -11,6 +11,10 @@ namespace lithium\tests\mocks\core;
 class MockRequest extends \lithium\core\Object {
 	
 	public $url = null;
+	
+	public $params = array();
+	
+	public $argv = array();
 
 	public function env($key) {
 		if(isset($this->_config[$key])) {


### PR DESCRIPTION
This deals with issue #21 and #53 where the environment is not automatically set. I have made changes to the Environment detector and console dispatcher to deal with this. I have added tests. Environment tests and console tests all seem to pass. 

Now it defaults to development allowing you to add the --env flag to change this. Tests are automatically run in the test environment.
