### PR TITLE
PHPs ini_set is used only if session has not already been started

### DIFF
--- a/storage/session/adapter/Php.php
+++ b/storage/session/adapter/Php.php
@@ -56,12 +56,14 @@ class Php extends \lithium\core\Object {
 		if (!isset($config['session.name'])) {
 			$config['session.name'] = basename(LITHIUM_APP_PATH);
 		}
-		foreach ($config as $key => $value) {
-			if (strpos($key, 'session.') === false) {
-				continue;
-			}
-			if (ini_set($key, $value) === false) {
-				throw new ConfigException("Could not initialize the session.");
+		if(!self::isStarted()) {
+			foreach ($config as $key => $value) {
+				if (strpos($key, 'session.') === false) {
+					continue;
+				}
+				if (ini_set($key, $value) === false) {
+					throw new ConfigException("Could not initialize the session.");
+				}
 			}
 		}
 	}


### PR DESCRIPTION
We have set up sessions to use Redis like this:

``` php
Session::config(array(
    'default' => array(
        'adapter' => 'Php',
        'session.save_handler' => 'redis',
        'session.save_path' => 'tcp://localhost:6379?timeout=2&prefix=OP_',
    ),
);
```

Which sometimes produces an error (Warning: A session is active. You cannot change the session module's ini settings at this time), because the session is (re)started before ini_set() is used to set 'session.*' parameters. Maybe a more elegant solution would be to not call Php adapters _init() at all, if the session already exists, but this works for us.
