### PR TITLE
Skip profiling tests if Xdebug is not loaded

### DIFF
--- a/tests/cases/test/filter/ComplexityTest.php
+++ b/tests/cases/test/filter/ComplexityTest.php
@@ -43,6 +43,14 @@ class ComplexityTest extends \lithium\test\Unit {
 	);
 
 	/**
+	 * Skip the tests if Xdebug extension is not loaded
+	 *
+	 */
+	public function skip() {
+		$this->skipIf(!extension_loaded('xdebug'), 'Xdebug is not enabled');
+	}
+
+	/**
 	 * Set up a new report which will later be used in the tests.
 	 *
 	 * @see lithium\test\Report

--- a/tests/integration/test/FilterTest.php
+++ b/tests/integration/test/FilterTest.php
@@ -13,6 +13,10 @@ use lithium\test\Report;
 
 class FilterTest extends \lithium\test\Integration {
 
+	public function skip() {
+		$this->skipIf(!extension_loaded('xdebug'), 'Xdebug is not enabled');
+	}
+
 	public function setUp() {
 		$this->report = new Report(array(
 			'title' => '\lithium\tests\mocks\test\MockFilterTest',


### PR DESCRIPTION
Running tests on a production server without Xdebug installed causes a Fatal error as test filters and profiling methods depends on it...
