### PR TITLE
Test case for inheritance of lazy filters

### DIFF
--- a/tests/cases/util/collection/FiltersTest.php
+++ b/tests/cases/util/collection/FiltersTest.php
@@ -63,6 +63,16 @@ class FiltersTest extends \lithium\test\Unit {
 		$result = $class::filteredMethod();
 		$this->assertEqual($expected, $result);
 	}
+
+	public function testLazyApplyInheritance() {
+		$class = 'lithium\tests\mocks\util\MockFilters';
+		$child = 'lithium\tests\mocks\util\MockFiltersExtended';
+		Filters::apply($class, 'filteredMethod', function($self, $params, $chain) {
+			return md5($chain->next($self, $params, $chain));
+		});
+		$this->assertEqual(md5('Working?'), $child::filteredMethod());
+	}
+
 }
 
 ?>

--- a/tests/mocks/util/MockFiltersExtended.php
+++ b/tests/mocks/util/MockFiltersExtended.php
@@ -1,0 +1,7 @@
+<?php
+
+	namespace lithium\tests\mocks\util;
+
+	class MockFiltersExtended extends MockFilters {
+
+	}


### PR DESCRIPTION
(_I horked up the last pull request range, this should be the correct commit range for this issue._) This test case attempts to check if inheritance for lazy filters is working. This is achieved by applying a filter to a method and then attempting to run that method on a class that extends from the aforementioned class.
