### PR TITLE
Fix for error that occurs when querying a model and its relationships

### DIFF
--- a/data/source/Database.php
+++ b/data/source/Database.php
@@ -286,6 +286,9 @@ abstract class Database extends \lithium\data\Source {
 							)
 						));
 					$ids = $self->read($subQuery, array('subquery' => true));
+					if (!$ids->count()) {
+						return false;
+					}
 					$idData = $ids->data();
 					$ids = array_map(function($index) use ($key) {
 							return $index[$key];


### PR DESCRIPTION
Currently if you perform a `Model::first`, apply a condition to the primary model that returns zero records and request it to join in a `hasMany` relationship the `Database` class will construct an invalid query that results in an exception being thrown. 

This commit will interrupt the process if no matching records were found. This keeps an exception from occurring and still returns a proper `RecordSet` object to the caller.
