### PR TITLE
Assertion 'assertEqual' failed in lithium\tests\cases\test\GroupTest::testAddEmptyTestsRun() on line 131

### DIFF
--- a/tests/cases/test/GroupTest.php
+++ b/tests/cases/test/GroupTest.php
@@ -124,11 +124,10 @@ class GroupTest extends \lithium\test\Unit {
 		$expected = 'lithium\tests\mocks\test\MockUnitTest';
 		$result = $results[0][0]['class'];
 		$this->assertEqual($expected, $result);
-
-		$expected = str_replace('\\', '/', LITHIUM_LIBRARY_PATH);
-		$expected = realpath($expected . '/lithium/tests/mocks/test/MockUnitTest.php');
+		
+		$expected = realpath(LITHIUM_LIBRARY_PATH . '/lithium/tests/mocks/test/MockUnitTest.php');
 		$result = $results[0][0]['file'];
-		$this->assertEqual($expected, str_replace('\\', '/', $result));
+		$this->assertEqual(str_replace('\\', '/', $expected), str_replace('\\', '/', $result));
 	}
 
 	public function testGroupAllForLithium() {


### PR DESCRIPTION
wanted to pass along this patch that fixes a failing test on my windows environment
