### PR TITLE
C-style comments are being identified as executable code in the code coverage analysis

### DIFF
--- a/analysis/Inspector.php
+++ b/analysis/Inspector.php
@@ -203,14 +203,14 @@ class Inspector extends \lithium\core\StaticObject {
 
 		if ($options['filter'] && $class->getFileName()) {
 			$file = file_get_contents($class->getFileName());
-                        preg_match_all('/^\s*\/\*(.*)\*\//msU', $file, $multilineComments);                        
-                        $replacements = array();
+			preg_match_all('/^\s*\/\*(.*)\*\//msU', $file, $multilineComments);                        
+			$replacements = array();
                         
-                        foreach ($multilineComments[1] as $multilineComment) {
-                            $replacements[] = preg_replace('/^/m', '// ', $multilineComment);
-                        }
-                        
-                        $file = explode("\n", "\n" . str_replace($multilineComments[1], $replacements, $file));
+			foreach ($multilineComments[1] as $multilineComment) {
+				$replacements[] = preg_replace('/^/m', '// ', $multilineComment);
+			}
+
+			$file = explode("\n", "\n" . str_replace($multilineComments[1], $replacements, $file));
 			$lines = array_intersect_key($file, array_flip($result));
 			$result = array_keys(array_filter($lines, function($line) use ($options) {
 				$line = trim($line);

--- a/tests/cases/analysis/InspectorTest.php
+++ b/tests/cases/analysis/InspectorTest.php
@@ -76,10 +76,10 @@ class InspectorTest extends \lithium\test\Unit {
 	public function testExecutableLines() {
 		do {
 			// These lines should be ignored
-                        /* Should also ignore C-style comments like this */
-                        /**
-                         * And also multi-line comments like this
-                         */
+            /* Should also ignore C-style comments like this */
+            /**
+             * And also multi-line comments like this
+            */
 		} while (false);
 
 		$result = Inspector::executable($this, array('methods' => __FUNCTION__));


### PR DESCRIPTION
lithium\analysis\Inspector should identify C-style comments as non-executable.
