### PR TITLE
Fixing $options array being ignored when using RecordSet::to('json', $options);

### DIFF
--- a/data/collection/RecordSet.php
+++ b/data/collection/RecordSet.php
@@ -225,7 +225,7 @@ class RecordSet extends \lithium\data\Collection {
 
 		switch ($format) {
 			case 'array':
-				$result = array_map(function($r) { return $r->to('array'); }, $this->_data);
+				$result = array_map(function($r) use ($options) { return $r->to('array', $options); }, $this->_data);
 				
 				if (!(is_scalar(current($this->_index)) && $options['indexed'])) {
 					break;

--- a/net/http/Media.php
+++ b/net/http/Media.php
@@ -646,11 +646,15 @@ class Media extends \lithium\core\StaticObject {
 				return null;
 			}
 
-			$cast = function($data) {
+			$cast = function($data) use ($response) {
 				if (!is_object($data)) {
 					return $data;
 				}
-				return method_exists($data, 'to') ? $data->to('array') : get_object_vars($data);
+				if (is_array($response)) {
+					return method_exists($data, 'to') ? $data->to('array', $response) : get_object_vars($data);
+				} else {
+					return method_exists($data, 'to') ? $data->to('array') : get_object_vars($data);
+				}
 			};
 
 			if (!isset($handler['cast']) || $handler['cast']) {

--- a/tests/cases/data/collection/RecordSetTest.php
+++ b/tests/cases/data/collection/RecordSetTest.php
@@ -383,10 +383,22 @@ class RecordSetTest extends \lithium\test\Unit {
 			4 => array('id' => 4, 'data' => 'data4')
 		);
 		$this->assertEqual($expected, $this->_recordSet->to('array'));
+		
+		$expected = array(
+			array('id' => 1, 'data' => 'data1'),
+			array('id' => 2, 'data' => 'data2'),
+			array('id' => 3, 'data' => 'data3'),
+			array('id' => 4, 'data' => 'data4')
+		);
+		$this->assertEqual($expected, $this->_recordSet->to('array', array('indexed' => false)));
 
 		$expected = '{"1":{"id":1,"data":"data1"},"2":{"id":2,"data":"data2"},'
 			. '"3":{"id":3,"data":"data3"},"4":{"id":4,"data":"data4"}}';
 		$this->assertEqual($expected, $this->_recordSet->to('json'));
+		
+		$expected = '[{"id":1,"data":"data1"},{"id":2,"data":"data2"},'
+			.	'{"id":3,"data":"data3"},{"id":4,"data":"data4"}]';
+		$this->assertEqual($expected, $this->_recordSet->to('json', array('indexed' => false)));
 	}
 
 	public function testRecordSetFindFilter() {


### PR DESCRIPTION
As a side note/question, why is 'indexed' => true the default option?

Maybe it would be better to have this globally configurable rather than hardcoded in the to() method?
