### PR TITLE
Fix \lithium\action\Controller::render() so it doesn't modify the data array in certain situations

### DIFF
--- a/action/Controller.php
+++ b/action/Controller.php
@@ -256,7 +256,6 @@ class Controller extends \lithium\core\Object {
 			return;
 		}
 		$data = $this->_render['data'];
-		$data = (isset($data[0]) && count($data) == 1) ? $data[0] : $data;
 		$media::render($this->response, $data, $options + array('request' => $this->request));
 	}
 

--- a/tests/cases/action/ControllerTest.php
+++ b/tests/cases/action/ControllerTest.php
@@ -170,6 +170,25 @@ class ControllerTest extends \lithium\test\Unit {
 		);
 		$this->assertEqual($expected, $controller->response->data);
 	}
+	
+	/**
+	 * Verifies that Controller does not modify data when passed an array (or RecordSet) with a single element
+	 *
+	 * @return void
+	 */
+	public function testRenderWithDataSingleIndexedArray() {
+		$request = new Request();
+		$request->params['controller'] = 'lithium\tests\mocks\action\MockPostsController';
+
+		$controller = new MockPostsController(compact('request') + array('classes' => array(
+			'media' => 'lithium\tests\mocks\action\MockMediaClass'
+		)));
+
+		$expected = array(array('id' => 1));
+		$controller->render(array('data' => $expected));
+
+		$this->assertEqual($expected, $controller->response->data);
+	}
 
 	/**
 	 * Verifies that protected methods (i.e. prefixed with '_'), and methods declared in the


### PR DESCRIPTION
Fix \lithium\action\Controller so it doesn't modify the data array when there is only a single element in the array.

eg. Without this fix the following code:

``` php
$claims = Claims::all(array('limit' => 1));
$this->render(array('json' => $claims->to('array', array('indexed' => false))));
```

would produce:

```
{"id":"2","insurer_id":"1","status_id":"AA","claim_number":...
```

when it should really be an array with a single element:

```
[{"id":"2","insurer_id":"1","status_id":"AA","claim_number"...
```

This patch fixes the issue (and provides a test case).
