### PR TITLE
Modifying `li3` to dereference relative symlinks correctly...

### DIFF
--- a/console/li3
+++ b/console/li3
@@ -5,5 +5,5 @@
 # @copyright     Copyright 2011, Union of RAD (http://union-of-rad.org)
 # @license       http://opensource.org/licenses/bsd-license.php The BSD License
 #
-SELF=$0; test -L $0 && SELF=$(readlink -n $0)
+SELF=$0; test -L $0 && SELF=$(readlink -nf $0)
 php -f $(dirname $SELF)/lithium.php -- "$@"


### PR DESCRIPTION
For example, say I have a standard lithium project with the following structure:

```
bin/li3 -> ../libraries/lithium/console/li3
libraries/lithium/console/li3
```

If I attempt to run `./bin/li3` I get the following error:

```
Could not open input file: ../lib/lithium/console/lithium.php
```

Passing the `-f` flag to `readlink` dereferences the symlink properly.
