### PR TITLE
Fixing lithium\util\Validator::check to allow null values when skipEmpty 

### DIFF
--- a/tests/cases/util/ValidatorTest.php
+++ b/tests/cases/util/ValidatorTest.php
@@ -955,6 +955,27 @@ class ValidatorTest extends \lithium\test\Unit {
 		$result = Validator::check($data, $rules);
 		$this->assertTrue(empty($result));
 	}
+	
+	public function testCheckSkipEmpty() {
+		$rules = array(
+			'email' => array('email', 'skipEmpty' => true, 'message' => 'email is not valid')
+		);
+		
+		// empty string should pass
+		$data = array('email' => '');
+		$result = Validator::check($data, $rules);
+		$this->assertTrue(empty($result));
+		
+		// null value should pass
+		$data = array('email' => null);
+		$result = Validator::check($data, $rules);
+		$this->assertTrue(empty($result));
+		
+		// string with spaces should NOT pass
+		$data = array('email' => ' ');
+		$result = Validator::check($data, $rules);
+		$this->assertFalse(empty($result));
+	}
 
 	public function testCheckMultipleHasErrors() {
 		$rules = array(

--- a/util/Validator.php
+++ b/util/Validator.php
@@ -454,7 +454,7 @@ class Validator extends \lithium\core\StaticObject {
 				if ($events && $rule['on'] && !array_intersect($events, (array) $rule['on'])) {
 					continue;
 				}
-				if (!isset($values[$field])) {
+				if (!array_key_exists($field, $values)) {
 					if ($rule['required']) {
 						$errors[$field][] = $rule['message'] ?: $key;
 					}


### PR DESCRIPTION
Fixing lithium\util\Validator::check to allow null values when skipEmpty == true.
