### PR TITLE
Bug in auth-validators when a validator is set to false.

### DIFF
--- a/security/auth/adapter/Form.php
+++ b/security/auth/adapter/Form.php
@@ -289,6 +289,10 @@ class Form extends \lithium\core\Object {
 		};
 		$config['validators'] += compact('password');
 
+		$config['validators'] = array_filter($config['validators'], function($validator) {
+			return $validator !== false;
+		});
+
 		parent::__construct($config + $defaults);
 	}
 
@@ -413,7 +417,7 @@ class Form extends \lithium\core\Object {
 	 */
 	protected function _validate($user, array $data) {
 		foreach ($this->_validators as $field => $validator) {
-			if ($validator === false || !isset($this->_fields[$field]) || $field === 0) {
+			if (!isset($this->_fields[$field]) || $field === 0) {
 				continue;
 			}
 

--- a/tests/cases/security/auth/adapter/FormTest.php
+++ b/tests/cases/security/auth/adapter/FormTest.php
@@ -37,6 +37,7 @@ class FormTest extends \lithium\test\Unit {
 	public function testLogin() {
 		$subject = new Form(array(
 			'model' => __CLASS__,
+			'fields' => array('username'),
 			'validators' => array('password' => false)
 		));
 
@@ -61,6 +62,7 @@ class FormTest extends \lithium\test\Unit {
 	public function testLoginWithFilters() {
 		$subject = new Form(array(
 			'model' => __CLASS__,
+			'fields' => array('username'),
 			'filters' => array('username' => 'sha1'),
 			'validators' => array('password' => false)
 		));
@@ -129,7 +131,7 @@ class FormTest extends \lithium\test\Unit {
 	public function testGenericFilter() {
 		$subject = new Form(array(
 			'model' => __CLASS__,
-			'fields' => array('username', 'password', 'group'),
+			'fields' => array('username', 'secret', 'group'),
 			'filters' => array(
 				function($form) {
 					unset($form['secret']);
@@ -224,7 +226,7 @@ class FormTest extends \lithium\test\Unit {
 		));
 
 		$result = $subject->check($request);
-		$expected = array('username' => 'Bob', 'group' => 'editors');
+		$expected = array('username' => 'Bob', 'password' => 's3cure', 'group' => 'editors');
 		$this->assertEqual($expected, $result);
 	}
 


### PR DESCRIPTION
Setting `password` validator to false removes the default `password` validator. In this case it should also use the `password` field when querying from the database, but it doesn't.

I wrote a test for this issue and tried to fix it.
