### PR TITLE
Fix some tests to pass on Windows.

### DIFF
--- a/analysis/Inspector.php
+++ b/analysis/Inspector.php
@@ -335,16 +335,16 @@ class Inspector extends \lithium\core\StaticObject {
 	 * @todo Add an $options parameter with a 'context' flag, to pull in n lines of context.
 	 */
 	public static function lines($data, $lines) {
-		if (!strpos($data, PHP_EOL)) {
+		if (!strpos($data, "\n")) {
 			if (!file_exists($data)) {
 				$data = Libraries::path($data);
 				if (!file_exists($data)) {
 					return null;
 				}
 			}
-			$data = PHP_EOL . file_get_contents($data);
+			$data = "\n" . file_get_contents($data);
 		}
-		$c = explode(PHP_EOL, $data);
+		$c = explode("\n", $data);
 
 		if (!count($c) || !count($lines)) {
 			return null;

--- a/test/Unit.php
+++ b/test/Unit.php
@@ -945,7 +945,7 @@ class Unit extends \lithium\core\Object {
 		$iterator = new RecursiveIteratorIterator($dirs, RecursiveIteratorIterator::CHILD_FIRST);
 
 		foreach ($iterator as $item) {
-			if ($item->getPathname() === "{$path}/empty" || $iterator->isDot()) {
+			if ($item->getPathname() === $path.DIRECTORY_SEPARATOR.'empty' || $iterator->isDot()) {
 				continue;
 			}
 			($item->isDir()) ? rmdir($item->getPathname()) : unlink($item->getPathname());

--- a/tests/cases/storage/session/adapter/CookieTest.php
+++ b/tests/cases/storage/session/adapter/CookieTest.php
@@ -26,9 +26,7 @@ class CookieTest extends \lithium\test\Unit {
 
 	public function setUp() {
 		$this->cookie = new Cookie();
-		$app_path = str_replace("\\", "/", LITHIUM_APP_PATH);
-		$path = explode('/', $app_path);
-		$this->name = end($path) . 'cookie';
+		$this->name = basename(LITHIUM_APP_PATH) . 'cookie';
 	}
 
 	public function tearDown() {

--- a/tests/cases/storage/session/adapter/PhpTest.php
+++ b/tests/cases/storage/session/adapter/PhpTest.php
@@ -60,9 +60,7 @@ class PhpTest extends \lithium\test\Unit {
 		$this->assertTrue(empty($id));
 
 		$result = ini_get('session.name');
-		$app_path = str_replace("\\", "/", LITHIUM_APP_PATH);
-		$path = explode('/', $app_path);
-		$this->assertEqual(end($path), $result);
+		$this->assertEqual(basename(LITHIUM_APP_PATH), $result);
 
 		$result = ini_get('session.cookie_lifetime');
 		$this->assertEqual(0, (integer) $result);


### PR DESCRIPTION
Fix Inpector::lines to tests pass when using UNIX line endings on Windows. (PHP_EOL should only be used for output, PHP handles input automatically).
Fix Unit::_cleanUp so app/resources/tmp/tests/empty file is not deleted on Windows.
Refactor CookieTest and PhpTest to simplify custom cookie name.
