### PR TITLE
Patch for Unit::_cleanup()

### DIFF
--- a/test/Unit.php
+++ b/test/Unit.php
@@ -945,7 +945,10 @@ class Unit extends \lithium\core\Object {
 		$iterator = new RecursiveIteratorIterator($dirs, RecursiveIteratorIterator::CHILD_FIRST);
 
 		foreach ($iterator as $item) {
-			if ($item->getPathname() === "{$path}/empty" || $iterator->isDot()) {
+			/*
+			 * Uses DIRECTORY_SEPARATOR to ensure correct path on Windows
+			 */
+			if ($item->getPathname() === $path . DIRECTORY_SEPARATOR . 'empty' || $iterator->isDot()) {
 				continue;
 			}
 			($item->isDir()) ? rmdir($item->getPathname()) : unlink($item->getPathname());


### PR DESCRIPTION
Fix Unit::_cleanUp() so "app/resources/tmp/tests/empty" file is not deleted on Windows.
