### PR TITLE
Test case for updating an existing MongoDb document with an array

### DIFF
--- a/tests/cases/data/source/mongo_db/ExporterTest.php
+++ b/tests/cases/data/source/mongo_db/ExporterTest.php
@@ -154,6 +154,7 @@ class ExporterTest extends \lithium\test\Unit {
 
 		$doc->field = 'value';
 		$doc->objects[1]->foo = 'dib';
+		$doc->objects[] = array('foo' => 'bax');
 		$doc->deeply->nested = 'foo';
 		$doc->array = array('one');
 		$doc->newObject = new Document(array(
@@ -172,6 +173,7 @@ class ExporterTest extends \lithium\test\Unit {
 			'deeply.nested' => 'foo',
 			'array' => array('one'),
 			'objects.1.foo' => 'dib'
+			'objects.2' => array('foo' => 'bax')
 		);
 		$this->assertEqual($expected, $result['update']);
 	}


### PR DESCRIPTION
See issue #32.  I found that adding a new value that is an array to an existing MongoDb document does not save the value to the database.  Thanks a lot.
