### PR TITLE
MongoDb Exporter test case for adding an array to an existing document

### DIFF
--- a/tests/cases/data/source/mongo_db/ExporterTest.php
+++ b/tests/cases/data/source/mongo_db/ExporterTest.php
@@ -154,8 +154,10 @@ class ExporterTest extends \lithium\test\Unit {
 
 		$doc->field = 'value';
 		$doc->objects[1]->foo = 'dib';
+		$doc->objects[] = array('foo' => 'diz');
 		$doc->deeply->nested = 'foo';
 		$doc->deeply->nestedAgain = 'bar';
+		$doc->array = array('one');
 		$doc->newObject = new Document(array(
 			'exists' => false, 'data' => array('subField' => 'subValue')
 		));
@@ -173,7 +175,9 @@ class ExporterTest extends \lithium\test\Unit {
 			'field' => 'value',
 			'deeply.nested' => 'foo',
 			'deeply.nestedAgain' => 'bar',
-			'objects.1.foo' => 'dib'
+			'array' => array('one'),
+			'objects.1.foo' => 'dib',
+			'objects.2' => array('foo' => 'diz')
 		);
 		$this->assertEqual($expected, $result['update']);
 


### PR DESCRIPTION
Alrighty, take 2, this time on the data branch.  I found that adding a new value that is an array to an existing MongoDb document does not save the value to the database.  See issue #146.  Thanks a lot.
