### PR TITLE
Updated _mapRecord() to remove nulls caused by left joins in hasMany relationships

### DIFF
--- a/data/collection/RecordSet.php
+++ b/data/collection/RecordSet.php
@@ -358,9 +358,20 @@ class RecordSet extends \lithium\data\Collection {
 					$dataMap[$name] = $record;
 					continue;
 				}
-				$dataMap[$name][] = $record;
+				
+				// Remove nulls caused by left joins from hasMany relations
+                		if (array_filter($record)) {
+                    			$dataMap[$name][] = $record;
+                		}
 			}
 		} while ($data = $this->_result->next());
+		
+		// Insert an empty array where all hasMany records for a relationship were null
+	        foreach (array_filter(array_keys($this->_columns)) as $name) {
+	            if (! array_key_exists($name, $dataMap)) {
+	                $dataMap[$name] = array();
+	            }
+	        }
 
 		foreach ($dataMap as $name => $rel) {
 			$field = $relMap[$name]['fieldName'];


### PR DESCRIPTION
This patch removes null values when joining multiple relationships like so: model::all(array('with' => array('rel1', 'rel2', 'rel3', etc)));
