### PR TITLE
Database::read() should NOT return false when 'limit' is used and there are no results.

### DIFF
--- a/data/source/Database.php
+++ b/data/source/Database.php
@@ -286,14 +286,13 @@ abstract class Database extends \lithium\data\Source {
 							)
 						));
 					$ids = $self->read($subQuery, array('subquery' => true));
-					if (!$ids->count()) {
-						return false;
+					if ($ids->count()) {
+						$idData = $ids->data();
+						$ids = array_map(function($index) use ($key) {
+								return $index[$key];
+							}, $idData);
+						$query->limit(false)->conditions(array("{$name}.{$key}" => $ids));
 					}
-					$idData = $ids->data();
-					$ids = array_map(function($index) use ($key) {
-							return $index[$key];
-						}, $idData);
-					$query->limit(false)->conditions(array("{$name}.{$key}" => $ids));
 				}
 				$sql = $self->renderCommand($query);
 			}

--- a/tests/cases/data/source/DatabaseTest.php
+++ b/tests/cases/data/source/DatabaseTest.php
@@ -664,7 +664,7 @@ class DatabaseTest extends \lithium\test\Unit {
 			'limit' => 1
 		);
 		$result = $this->db->read(new Query($options), $options);
-		$this->assertFalse($result);
+		$this->assertTrue($result instanceof RecordSet);
 	}
 
 	public function testGroup() {


### PR DESCRIPTION
Side-effect of this patch is that 2 queries are executed even if no results are returned in the first query. I wasn't sure if there would be any negative side-effects with only running the first query.
