### PR TITLE
Correctly inflect leaves/leaf

### DIFF
--- a/tests/cases/util/InflectorTest.php
+++ b/tests/cases/util/InflectorTest.php
@@ -59,6 +59,7 @@ class InflectorTest extends \lithium\test\Unit {
 		$this->assertEqual(Inflector::singularize('gloves'), 'glove');
 		$this->assertEqual(Inflector::singularize('doves'), 'dove');
 		$this->assertEqual(Inflector::singularize('lives'), 'life');
+		$this->assertEqual(Inflector::singularize('leaves'), 'leaf');
 		$this->assertEqual(Inflector::singularize('knives'), 'knife');
 		$this->assertEqual(Inflector::singularize('wolves'), 'wolf');
 		$this->assertEqual(Inflector::singularize('shelves'), 'shelf');
@@ -104,6 +105,7 @@ class InflectorTest extends \lithium\test\Unit {
 		$this->assertEqual(Inflector::pluralize('person'), 'people');
 		$this->assertEqual(Inflector::pluralize('people'), 'people');
 		$this->assertEqual(Inflector::pluralize('glove'), 'gloves');
+		$this->assertEqual(Inflector::pluralize('leaf'), 'leaves');
 		$this->assertEqual(Inflector::pluralize(''), '');
 
 		$result = Inflector::pluralize('errata');

--- a/util/Inflector.php
+++ b/util/Inflector.php
@@ -164,7 +164,7 @@ class Inflector {
 			'child' => 'children', 'corpus' => 'corpuses', 'cow' => 'cows',
 			'ganglion' => 'ganglions', 'genie' => 'genies', 'genus' => 'genera',
 			'graffito' => 'graffiti', 'hoof' => 'hoofs', 'loaf' => 'loaves', 'man' => 'men',
-			'money' => 'monies', 'mongoose' => 'mongooses', 'move' => 'moves',
+			'leaf' => 'leaves', 'money' => 'monies', 'mongoose' => 'mongooses', 'move' => 'moves',
 			'mythos' => 'mythoi', 'numen' => 'numina', 'occiput' => 'occiputs',
 			'octopus' => 'octopuses', 'opus' => 'opuses', 'ox' => 'oxen', 'penis' => 'penises',
 			'person' => 'people', 'sex' => 'sexes', 'soliloquy' => 'soliloquies',


### PR DESCRIPTION
Previous inflecting leaves & leaf would fail like so:

leaves => leafe
leaf => leafs

Added irregular inflection rule to handle this.
