### PR TITLE
Support for MySQL SET statements.

### DIFF
--- a/data/source/Database.php
+++ b/data/source/Database.php
@@ -299,6 +299,10 @@ abstract class Database extends \lithium\data\Source {
 			}
 			$result = $self->invokeMethod('_execute', array($sql));
 
+			// @hack: If the query was not supposed to return anything (ie. a SET statement), MySQL returns true.
+			if(is_string($query) AND $result === true)
+				return true;
+
 			switch ($return) {
 				case 'resource':
 					return $result;

--- a/tests/cases/data/source/database/adapter/MySqlTest.php
+++ b/tests/cases/data/source/database/adapter/MySqlTest.php
@@ -253,6 +253,17 @@ class MySqlTest extends \lithium\test\Unit {
 		);
 		$this->assertEqual($expected, $result);
 	}
+
+	/**
+	* Tests SQL vars.
+	* */
+	public function testSqlVars() {
+		$this->assertTrue($this->db->read('SET @var = 42'));
+
+		$result = $this->db->read('SELECT @var AS result;');
+		$expected = array(array('result' => 42));
+		$this->assertEqual($expected, $result);
+	}
 }
 
 ?>


### PR DESCRIPTION
Hi,

I'm developing an app where I need to run complex custom queries and I
came across a bug : using SET makes lithium crash because it tries to
use the result as a resource.

Maybe read() is not the appropriate method for this but I don't see an
other way to execute a raw query.

This fixes Database and adds a simple test case that makes the whole app crash with this error:

```
Fatal error: Call to a member function resource() on a non-object in lithium/data/source/database/adapter/MySql.php on line 273
```
