### PR TITLE
BUGFIX: unable set customized template when strings field-* exists.

### DIFF
--- a/template/helper/Form.php
+++ b/template/helper/Form.php
@@ -406,6 +406,7 @@ class Form extends \lithium\template\Helper {
 			'list' => null
 		);
 		$type = isset($options['type']) ? $options['type'] : $defaults['type'];
+		$custom_template = isset($options['template']) ? $options['template'] : null;
 
 		if ($this->_context->strings('field-' . $type)) {
 			$options['template'] = 'field-' . $type;
@@ -415,6 +416,9 @@ class Form extends \lithium\template\Helper {
 
 		if ($options['template'] != $defaults['template']) {
 			$template = $options['template'];
+		}
+		if ($custom_template) {
+			$template = $custom_template;
 		}
 
 		$wrap = $options['wrap'];

--- a/tests/cases/template/helper/FormTest.php
+++ b/tests/cases/template/helper/FormTest.php
@@ -1079,6 +1079,23 @@ class FormTest extends \lithium\test\Unit {
 			'label' => array('for' => 'UserName'), 'User Name', '/label'
 		));
 	}
+
+    /**
+     * Test that field already defined template strings with special types (e.g. radio, checkbox, 
+     * etc.) and passed customize template, and the template must apply.
+     */
+	public function testRadioTypeFieldWithCustomTemplate() {
+		$result = $this->form->field('name', array(
+			'template' => '<span{:wrap}>{:label}: {:input}{:error}</span>',
+			'type' => 'radio'
+		));
+		$this->assertTags($result, array(
+			'span' => array(),
+			'label' => array('for' => 'Name'), 'Name', '/label', ':',
+			'input' => array('type' => 'radio', 'name' => 'name', 'id' => 'Name')
+		));
+	}
+
 }
 
 ?>


### PR DESCRIPTION
lithium\template\helper\Form::field() always overwrite `template` field of $options when set up with strings field-\* exists. Expected field-\* strings are used as default selection, and we can customize template in runtime no matter what `type` specified in $options.
