### PR TITLE
Escaping the database name for databases with periods.

### DIFF
--- a/data/source/database/adapter/MySql.php
+++ b/data/source/database/adapter/MySql.php
@@ -338,7 +338,7 @@ class MySql extends \lithium\data\source\Database {
 	protected function _execute($sql, array $options = array()) {
 		$defaults = array('buffered' => true);
 		$options += $defaults;
-		$this->connection->exec('USE ' . $this->_config['database']);
+		$this->connection->exec("USE  `{$this->_config['database']}`");
 
 		$conn = $this->connection;
 


### PR DESCRIPTION
Fixes issue #223 by adding backticks around the database name.
