### PR TITLE
PHP Session adapter modifications

### DIFF
--- a/storage/session/adapter/Php.php
+++ b/storage/session/adapter/Php.php
@@ -11,6 +11,7 @@ namespace lithium\storage\session\adapter;
 use lithium\util\Set;
 use RuntimeException;
 use lithium\core\ConfigException;
+use lithium\util\Inflector;
 
 /**
  * A minimal adapter to interface with native PHP sessions.
@@ -28,7 +29,8 @@ class Php extends \lithium\core\Object {
 	 * @var array Keys are session ini settings, with the `session.` namespace.
 	 */
 	protected $_defaults = array(
-		'session.cookie_lifetime' => '0', 'session.cookie_httponly' => true
+		'session.cookie_lifetime' => '0',
+		'session.cookie_httponly' => true,
 	);
 
 	/**
@@ -40,6 +42,7 @@ class Php extends \lithium\core\Object {
 	 *        the `session.*` PHP ini settings here as key/value pairs.
 	 */
 	public function __construct(array $config = array()) {
+		$this->_defaults['session.name'] = basename(LITHIUM_APP_PATH);
 		parent::__construct($config + $this->_defaults);
 	}
 
@@ -53,9 +56,11 @@ class Php extends \lithium\core\Object {
 		$config = $this->_config;
 		unset($config['adapter'], $config['strategies'], $config['filters'], $config['init']);
 
-		if (!isset($config['session.name'])) {
-			$config['session.name'] = basename(LITHIUM_APP_PATH);
+		$config['session.name'] = Inflector::slug($config['session.name']);
+		if (is_numeric($config['session.name'])) {
+			$config['session.name'] = 'lithium' . $config['session.name'];
 		}
+
 		foreach ($config as $key => $value) {
 			if (strpos($key, 'session.') === false) {
 				continue;
@@ -64,6 +69,7 @@ class Php extends \lithium\core\Object {
 				throw new ConfigException("Could not initialize the session.");
 			}
 		}
+		$this->_config = $config;
 	}
 
 	/**

--- a/tests/cases/storage/session/adapter/PhpTest.php
+++ b/tests/cases/storage/session/adapter/PhpTest.php
@@ -68,6 +68,11 @@ class PhpTest extends \lithium\test\Unit {
 
 		$result = ini_get('session.cookie_httponly');
 		$this->assertTrue(1, (integer) $result);
+
+		$php = new Php(array(
+			'session.name' => '<>!@#.1234'
+		));
+		$this->assertFalse(is_numeric($php->_config['session.name']));
 	}
 
 	public function testCustomConfiguration() {


### PR DESCRIPTION
This fixes issue #218 while maintaining current functionality and only modifying the `session.name` value when it is invalid (non alpha-numeric)
- Set a `session.name` value after the `LITHIUM_APP_PATH`
- `Inflector::slug` the value to remove any non-alphanumeric characters.
- Check `is_numeric`, and if so, add "lithium" to the beginning of the value.

The last step is the only one a bit iffy, I didn't know want to prepend the value with so I just defaulted to "lithium" -- if this should be something else, let me know.
