### PR TITLE
Modifying boolean validator to accept empty values

### DIFF
--- a/tests/cases/util/ValidatorTest.php
+++ b/tests/cases/util/ValidatorTest.php
@@ -253,6 +253,7 @@ class ValidatorTest extends \lithium\test\Unit {
 		$this->assertTrue(Validator::isBoolean('off'));
 		$this->assertTrue(Validator::isBoolean('yes'));
 		$this->assertTrue(Validator::isBoolean('no'));
+		$this->assertTrue(Validator::isBoolean(''));
 
 		$this->assertFalse(Validator::isBoolean('11'));
 		$this->assertFalse(Validator::isBoolean('-1'));

--- a/util/Validator.php
+++ b/util/Validator.php
@@ -246,7 +246,7 @@ class Validator extends \lithium\core\StaticObject {
 			'boolean'      => function($value) {
 				$bool = is_bool($value);
 				$filter = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
-				return ($bool || $filter !== null);
+				return ($bool || $filter !== null || empty($value));
 			},
 			'decimal' => function($value, $format = null, array $options = array()) {
 				if (isset($options['precision'])) {


### PR DESCRIPTION
Changed the `Validator`'s boolean validation in response to issue #86 so that it accepts empty strings/values as boolean.
