### PR TITLE
Changing Validator::check to correctly handle NULL values

### DIFF
--- a/util/Validator.php
+++ b/util/Validator.php
@@ -464,7 +464,7 @@ class Validator extends \lithium\core\StaticObject {
 					if ($events && $rule['on'] && !array_intersect($events, (array) $rule['on'])) {
 						continue;
 					}
-					if (!isset($values[$field])) {
+					if (!array_key_exists($field, $values)) {
 						if ($rule['required']) {
 							$errors[$field][] = $rule['message'] ?: $key;
 						}


### PR DESCRIPTION
I was receiving a `Validator` test failure in 31c2945eac5787cc32f0ef63edafdb1fcacb8201. The failure is described below:

> Assertion 'assertTrue' failed in lithium\tests\cases\util\ValidatorTest::testCheckSkipEmpty() on line 972

...and from the code test, only slightly modified for brevity's sake...

``` php
  $rules = array(
    'email' => array('email', 'skipEmpty' => true, 'message' => 'email is not valid')
  );

  // null value should pass
  $data = array('email' => null);
  $result = Validator::check($data, $rules);
  $this->assertTrue(empty($result));
```

The `Validator` uses `isset` to check if the array has the field available, thing is that PHP ignores `NULL` values and says it doesn't exist. This change simply changes the check to `array_key_exists` which works as expected.
