### PR TITLE
Modifying Environment test to fix failures and increase coverage

### DIFF
--- a/tests/cases/core/EnvironmentTest.php
+++ b/tests/cases/core/EnvironmentTest.php
@@ -101,12 +101,16 @@ class EnvironmentTest extends \lithium\test\Unit {
 		$this->assertTrue(Environment::is('test'));
 
 		$request = new MockRequest();
-		$request->argv = array(0 => 'test');
+		$request->command = 'test';
 		Environment::set($request);
 		$this->assertTrue(Environment::is('test'));
 
 		$request = new MockRequest();
-		$request->argv = array(0 => 'something');
+		$request->env = 'test';
+		Environment::set($request);
+		$this->assertTrue(Environment::is('test'));
+
+		$request = new MockRequest(array('TERM' => true));
 		Environment::set($request);
 		$this->assertTrue(Environment::is('development'));
 


### PR DESCRIPTION
I was getting two failures in the `Environment` test case as of 31c2945eac5787cc32f0ef63edafdb1fcacb8201

> Assertion 'assertTrue' failed in lithium\tests\cases\core\EnvironmentTest::testEnvironmentDetection() on line 106
> 
> Assertion 'assertTrue' failed in lithium\tests\cases\core\EnvironmentTest::testEnvironmentDetection() on line 111

Looks like the `Environment` class detectors don't look at `argv` and was causing the issue. This commit fixes those issues and increases code coverage on the class.
