### PR TITLE
Fixed issue with windows console:

### DIFF
--- a/console/li3.bat
+++ b/console/li3.bat
@@ -5,5 +5,4 @@ rem
 rem @copyright     Copyright 2012, Union of RAD (http://union-of-rad.org)
 rem @license       http://opensource.org/licenses/bsd-license.php The BSD License
 rem
-cd %~dp0
 php -f "%~dp0lithium.php" %*


### PR DESCRIPTION
Removed unnecessary cd which caused 'li3 create' to use the wrong path
