### PR TITLE
Inspector::lines windows compatibility

### DIFF
--- a/analysis/Inspector.php
+++ b/analysis/Inspector.php
@@ -338,8 +338,8 @@ class Inspector extends \lithium\core\StaticObject {
 	public static function lines($data, $lines) {
 		$c = array();
 
-		if(strpos($data, PHP_EOL) !== false) {
-			$c = explode(PHP_EOL, $data); 
+		if (strpos($data, PHP_EOL) !== false) {
+			$c = explode(PHP_EOL, PHP_EOL . $data); 
 		} else {
 			if (!file_exists($data)) {
 				$data = Libraries::path($data);
@@ -349,7 +349,7 @@ class Inspector extends \lithium\core\StaticObject {
 			}
 
 			$file = new SplFileObject($data);
-			foreach($file as $current) {
+			foreach ($file as $current) {
 				$c[$file->key()+1] = rtrim($file->current());
 			}
 		}

--- a/tests/cases/analysis/InspectorTest.php
+++ b/tests/cases/analysis/InspectorTest.php
@@ -97,6 +97,11 @@ class InspectorTest extends \lithium\test\Unit {
 		$expected = array(14 => 'class InspectorTest extends \lithium\test\Unit {');
 		$this->assertEqual($expected, $result);
 
+		$lines = 'This is the first line.' . PHP_EOL . 'And this the second.';
+		$result = Inspector::lines($lines, array(2));
+		$expected = array(2 => 'And this the second.');
+		$this->assertEqual($expected, $result);
+
 		$this->expectException('/Missing argument 2/');
 		$this->assertNull(Inspector::lines('\lithium\core\Foo'));
 		$this->assertNull(Inspector::lines(__CLASS__, array()));


### PR DESCRIPTION
This passes the tests on windows too and also makes it more general in terms of line endings. I also added a test that shows how to pass a string to it (which is also supported but was not tested).
