### PR TITLE
add 'having' to database adapter

### DIFF
--- a/data/model/Query.php
+++ b/data/model/Query.php
@@ -82,6 +82,7 @@ class Query extends \lithium\core\Object {
 		$defaults = array(
 			'calculate'  => null,
 			'conditions' => array(),
+			'having'     => array(),
 			'fields'     => array(),
 			'data'       => array(),
 			'model'      => null,
@@ -203,6 +204,24 @@ class Query extends \lithium\core\Object {
 			return $this;
 		}
 		return $this->_config['conditions'] ?: $this->_entityConditions();
+	}
+
+	/**
+	 * Set and get method for havings.
+	 *
+	 * If no havings are set in query, it will ask the bound entity for condition array.
+	 *
+	 * @param mixed $having String or array to append to existing having.
+	 * @return array Returns an array of all having applied to this query.
+	 */
+	public function having($having = null) {
+		if ($having) {
+			$having = (array) $having;
+			$this->_config['having'] = (array) $this->_config['having'];
+			$this->_config['having'] = array_merge($this->_config['having'], $having);
+			return $this;
+		}
+		return $this->_config['having'] ?: $this->_entityConditions();
 	}
 
 	/**

--- a/data/source/Database.php
+++ b/data/source/Database.php
@@ -150,7 +150,7 @@ abstract class Database extends \lithium\data\Source {
 		);
 		$this->_strings += array(
 			'read' => 'SELECT {:fields} FROM {:source} {:alias} {:joins} {:conditions} {:group} ' .
-			          '{:order} {:limit};{:comment}'
+			          '{:having} {:order} {:limit};{:comment}'
 		);
 		parent::__construct($config + $defaults);
 	}
@@ -572,6 +572,51 @@ abstract class Database extends \lithium\data\Source {
 		}
 		$result = join(" AND ", $result);
 		return ($options['prepend'] && $result) ? "WHERE {$result}" : $result;
+	}
+
+	/**
+	 * Returns a string of formatted havings to be inserted into the query statement. If the
+	 * query havings are defined as an array, key pairs are converted to SQL strings.
+	 *
+	 * Conversion rules are as follows:
+	 *
+	 * - If `$key` is numeric and `$value` is a string, `$value` is treated as a literal SQL
+	 *   fragment and returned.
+	 *
+	 * @param string|array $having The havings for this query.
+	 * @param object $context The current `lithium\data\model\Query` instance.
+	 * @param array $options
+	 *               - `prepend` _boolean_: Whether the return string should be prepended with the
+	 *                 `HAVING` keyword.
+	 * @return string Returns the `HAVING` clause of an SQL query.
+	 */
+	public function having($having, $context, array $options = array()) {
+		$defaults = array('prepend' => true);
+		$ops = $this->_operators;
+		$options += $defaults;
+		$model = $context->model();
+		$schema = $model ? $model::schema() : array();
+
+		switch (true) {
+			case empty($having):
+				return '';
+			case is_string($having):
+				return ($options['prepend']) ? "HAVING {$having}" : $having;
+			case !is_array($having):
+				return '';
+		}
+		$result = array();
+
+		foreach ($having as $key => $value) {
+			$schema[$key] = isset($schema[$key]) ? $schema[$key] : array();
+			$return = $this->_processConditions($key,$value, $schema);
+
+			if ($return) {
+				$result[] = $return;
+			}
+		}
+		$result = join(" AND ", $result);
+		return ($options['prepend'] && $result) ? "HAVING {$result}" : $result;
 	}
 
 	public function _processConditions($key, $value, $schema, $glue = 'AND') {


### PR DESCRIPTION
In our project we needed to add dynamic fields to the query, like this:

```
$params['options']['fields'] = array_merge(array_keys($schema), array(
    "lastactivity > DATE_SUB('2011-07-01 00:00:00', INTERVAL 2 HOUR) as is_online",
));
```

Reason is, we needed to have conditions on that field, which is not possible with a WHERE clause, but needs a HAVING clause, instead. Luckily i was able to achieve this, with just minor additions to these classes

```
lithium\data\source\Database
lithium\data\model\Query
```

Just wanted to share, what i did.
