### PR TITLE
Fix a regression on Validator::check and skipEmpty option

### DIFF
--- a/util/Validator.php
+++ b/util/Validator.php
@@ -464,7 +464,7 @@ class Validator extends \lithium\core\StaticObject {
 					if ($events && $rule['on'] && !array_intersect($events, (array) $rule['on'])) {
 						continue;
 					}
-					if (!isset($values[$field])) {
+					if (!array_key_exists($field, $values)) {
 						if ($rule['required']) {
 							$errors[$field][] = $rule['message'] ?: $key;
 						}


### PR DESCRIPTION
There is 1 failing test in `ValidatorTest::testCheckSkipEmpty()`

```
Running test(s) in `lithium\tests\cases\util`... done.

Results
1335 / 1336 passes
1 fail and 0 exceptions

Assertion `assertTrue` failed in `lithium\tests\cases\util\ValidatorTest::testCheckSkipEmpty()` on line 973:
expected: true
result: false
```

due to a regression introduced on 011811c2bcd2ded9da5522cb8058976f5300855a, which was fixed before on 180526d816dc67323474637dcab82c7434d7eadf

The fix make tests green again on util

```
Running test(s) in `lithium\tests\cases\util`... done.

Results
1336 / 1336 passes
0 fails and 0 exceptions
```
