### PR TITLE
Fix failing GroupTest test

### DIFF
--- a/tests/cases/test/GroupTest.php
+++ b/tests/cases/test/GroupTest.php
@@ -55,6 +55,7 @@ class GroupTest extends \lithium\test\Unit {
 			'lithium\tests\cases\g11n\catalog\AdapterTest',
 			'lithium\tests\cases\g11n\catalog\adapter\CodeTest',
 			'lithium\tests\cases\g11n\catalog\adapter\GettextTest',
+			'lithium\tests\cases\g11n\catalog\adapter\MemoryTest',
 			'lithium\tests\cases\g11n\catalog\adapter\PhpTest'
 		);
 		$this->assertEqual($expected, $result);
@@ -67,6 +68,7 @@ class GroupTest extends \lithium\test\Unit {
 			'lithium\tests\cases\g11n\catalog\AdapterTest',
 			'lithium\tests\cases\g11n\catalog\adapter\CodeTest',
 			'lithium\tests\cases\g11n\catalog\adapter\GettextTest',
+			'lithium\tests\cases\g11n\catalog\adapter\MemoryTest',
 			'lithium\tests\cases\g11n\catalog\adapter\PhpTest',
 			'lithium\tests\cases\data\ModelTest'
 		);


### PR DESCRIPTION
Since there is now a MemoryTest (3fcbe36d6cf8e0cf47475206a4a389aadc5dd392), `GroupTest::testAddByString()` fail.

```
Results
140 / 142 passes
2 fails and 0 exceptions

Assertion `assertEqual` failed in `lithium\tests\cases\test\GroupTest::testAddByString()` on line 60:

Assertion `assertEqual` failed in `lithium\tests\cases\test\GroupTest::testAddByString()` on line 73:
```

After

```
Running test(s) in `lithium\tests\cases\test`... done.

Results
142 / 142 passes
0 fails and 0 exceptions
```
