### PR TITLE
Reset MockDispatcher rules to avoid conflicts with potential existing ones

### DIFF
--- a/tests/mocks/action/MockDispatcher.php
+++ b/tests/mocks/action/MockDispatcher.php
@@ -12,7 +12,11 @@ use stdClass;
 
 class MockDispatcher extends \lithium\action\Dispatcher {
 
-	// Reset MockDispatcher rules
+	/**
+	 * Reset Dispatcher's rules.
+	 *
+	 * @var array
+	 */
 	protected static $_rules = array();
 
 	public static $dispatched = array();


### PR DESCRIPTION
Having custom Dispatcher rules set for an app, will cause `DispatcherTest::testConfigManipulation()` fail on line 121 as `MockDisptacher` doesn't isolate rules and inherit them from `Dispatcher` 

Running Lithium's tests from a console is OK but running them from a browser interfere with the app config.

190 / 190 green for action
