### PR TITLE
Test and fix that deals with issue #278

### DIFF
--- a/tests/cases/util/InflectorTest.php
+++ b/tests/cases/util/InflectorTest.php
@@ -106,6 +106,7 @@ class InflectorTest extends \lithium\test\Unit {
 		$this->assertEqual(Inflector::pluralize('people'), 'people');
 		$this->assertEqual(Inflector::pluralize('glove'), 'gloves');
 		$this->assertEqual(Inflector::pluralize('leaf'), 'leaves');
+		$this->assertEqual(Inflector::pluralize('ContactPeople'), 'ContactPeople');
 		$this->assertEqual(Inflector::pluralize(''), '');
 
 		$result = Inflector::pluralize('errata');

--- a/util/Inflector.php
+++ b/util/Inflector.php
@@ -280,7 +280,7 @@ class Inflector {
 			$regexIrregular = static::_enclose(join( '|', array_keys($irregular)));
 			static::$_plural += compact('regexUninflected', 'regexIrregular');
 		}
-		if (preg_match('/^(' . $regexUninflected . ')$/i', $word, $regs)) {
+		if (preg_match('/(' . $regexUninflected . ')$/i', $word, $regs)) {
 			return static::$_pluralized[$word] = $word;
 		}
 		if (preg_match('/(.*)\\b(' . $regexIrregular . ')$/i', $word, $regs)) {


### PR DESCRIPTION
Actually the bad guy was Inflector::pluralize() which was wanting the whole word to match the whole word as an irregular and not just the end of it. This simple fix should deal with the issue.
