### PR TITLE
fixing controller rendering of requests with a type set

### DIFF
--- a/action/Controller.php
+++ b/action/Controller.php
@@ -144,7 +144,7 @@ class Controller extends \lithium\core\Object {
 			$this->_render['type'] = $this->request->accepts();
 			return;
 		}
-		$this->_render['type'] = $this->request->type ?: 'html';
+		$this->_render['type'] = $this->request->type() ?: 'html';
 	}
 
 	/**

--- a/tests/cases/action/ControllerTest.php
+++ b/tests/cases/action/ControllerTest.php
@@ -22,9 +22,12 @@ class ControllerTest extends \lithium\test\Unit {
 	 */
 	public function testConstructionWithCustomRequest() {
 		$request = new MockControllerRequest();
+		$request->type('test');
 		$postsController = new MockPostsController(compact('request'));
 		$result = get_class($postsController->request);
 		$this->assertEqual($result, 'lithium\tests\mocks\action\MockControllerRequest');
+		$render = $postsController->access('_render');
+		$this->assertEqual($request->type(), $render['type']);
 	}
 
 	/**


### PR DESCRIPTION
I found that the Controller::init() was looking at $this->request->type instead of $this->request->type().  Test case appended to ControllerTest::testConstructionWithCustomRequest which seemed appropriate.
