### PR TITLE
Fixing inconsistency with paths in Media::type() option defaults

### DIFF
--- a/net/http/Media.php
+++ b/net/http/Media.php
@@ -8,6 +8,7 @@
 
 namespace lithium\net\http;
 
+use lithium\util\Set;
 use lithium\util\String;
 use lithium\core\Libraries;
 use lithium\net\http\MediaException;
@@ -114,7 +115,7 @@ class Media extends \lithium\core\StaticObject {
 	 *
 	 * {{{ embed:lithium\tests\cases\net\http\MediaTest::testMediaTypes(19-20) }}}
 	 *
-	 * {{{ embed:lithium\tests\cases\net\http\MediaTest::testMediaTypes(35-36) }}}
+	 * {{{ embed:lithium\tests\cases\net\http\MediaTest::testMediaTypes(40-41) }}}
 	 *
 	 * Alternatively, can be used to detect the type name of a registered content type:
 	 * {{{
@@ -192,17 +193,24 @@ class Media extends \lithium\core\StaticObject {
 	 *        should be the "primary" type, and will be used as the `Content-type` header of any
 	 *        `Response` objects served through this type.
 	 * @param array $options Optional.  The handling options for this media type. Possible keys are:
+	 *        - `'view'` _string_: Specifies the view class to use when rendering this content.
+	 *          Note that no `'view'` class is specified by default.  If you want to
+	 *          render templates using Lithium's default view class, use
+	 *          `'lithium\template\View'`
 	 *        - `'decode'` _mixed_: A (string) function name or (object) closure that handles
 	 *          decoding or unserializing content from this format.
 	 *        - `'encode'` _mixed_: A (string) function name or (object) closure that handles
 	 *          encoding or serializing content into this format.
 	 *        - `'cast'` _boolean_: Used with `'encode'`. If `true`, all data passed into the
 	 *          specified encode function is first cast to array structures.
-	 *        - `'layout'` _mixed_: Specifies one or more `String::insert()`-style paths to use when
-	 *          searching for layout files (either a string or array of strings).
-	 *        - `'template'` _mixed_: Specifies one or more `String::insert()`-style paths to use
-	 *          when searching for template files (either a string or array of strings).
-	 *        - `'view'` _string_: Specifies the view class to use when rendering this content.
+	 *        - `'paths'` _array_: Optional key/value pairs mapping paths for
+	 *          `'template'`, `'layout'`, and `'element'` template files.  Any keys ommitted
+	 *          will use the default path.  The values should be `String::insert()`-style
+	 *          paths or an array of `String::insert()`-style paths.  If it is an array,
+	 *          each path will be tried in the order specified until a template is found.
+	 *          This is useful for allowing custom templates while falling back on
+	 *          default templates if no custom template was found.  If you want to
+	 *          render templates without a layout, use a `false` value for `'layout'`.
 	 *        - `'conditions'` _array_: Optional key/value pairs used as assertions in content
 	 *          negotiation. See the above section on **Content Negotiation**.
 	 * @return mixed If `$content` and `$options` are empty, returns an array with `'content'` and
@@ -214,8 +222,11 @@ class Media extends \lithium\core\StaticObject {
 	public static function type($type, $content = null, array $options = array()) {
 		$defaults = array(
 			'view' => false,
-			'template' => false,
-			'layout' => false,
+			'paths' => array(
+				'template' => '{:library}/views/{:controller}/{:template}.{:type}.php',
+				'layout'   => '{:library}/views/layouts/{:layout}.{:type}.php',
+				'element'  => '{:library}/views/elements/{:template}.{:type}.php'
+			),
 			'encode' => false,
 			'decode' => false,
 			'cast'   => true,
@@ -240,7 +251,7 @@ class Media extends \lithium\core\StaticObject {
 		if ($content) {
 			static::$_types[$type] = $content;
 		}
-		static::$_handlers[$type] = $options ? ($options + $defaults) : array();
+		static::$_handlers[$type] = $options ? Set::merge($defaults, $options) : array();
 	}
 
 	/**

--- a/tests/cases/net/http/MediaTest.php
+++ b/tests/cases/net/http/MediaTest.php
@@ -51,7 +51,7 @@ class MediaTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result['options']);
 
 		// Add a custom media type with a custom view class:
-		Media::type('my', 'text/x-my', array('view' => 'my\custom\View', 'layout' => false));
+		Media::type('my', 'text/x-my', array('view' => 'my\custom\View', 'paths' => array('layout' => false)));
 
 		$result = Media::types();
 		$this->assertTrue(in_array('my', $result));
@@ -61,7 +61,12 @@ class MediaTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result['content']);
 
 		$expected = array(
-			'view' => 'my\custom\View', 'template' => null, 'layout' => null,
+			'view' => 'my\custom\View',
+			'paths' => array(
+				'template' => '{:library}/views/{:controller}/{:template}.{:type}.php',
+				'layout' => false,
+				'element' => '{:library}/views/elements/{:template}.{:type}.php'
+			),
 			'encode' => null, 'decode' => null, 'cast' => true, 'conditions' => array()
 		);
 		$this->assertEqual($expected, $result['options']);

--- a/tests/integration/net/http/MediaTest.php
+++ b/tests/integration/net/http/MediaTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2012, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\tests\integration\net\http;
+
+use lithium\template\View;
+use lithium\net\http\Media;
+use lithium\net\http\Response;
+
+class MediaTest extends \lithium\test\Integration {
+
+	/**
+	 * This tests that setting custom paths and disabling layout
+	 * via `\lithium\net\http\Media::type()` is handled properly
+	 * by the default `\lithium\template\View` class and `File`
+	 * rendered adapter.
+	 */
+	public function testMediaTypeViewRender() {
+		Media::type('view-integration-test', 'lithium/viewtest', array(
+			'view' => 'lithium\template\View',
+			'paths' => array(
+				'layout' => false,
+				'template' => array(
+					'{:library}/tests/mocks/template/view/adapters/{:template}.{:type}.php',
+					'{:library}/tests/mocks/template/view/adapters/{:template}.html.php',
+				)
+			)
+		));
+
+		// testing no layout with a custom type template
+		$response = new Response();
+		$response->type('view-integration-test');
+		Media::render($response, array(), array(
+			'layout' => true,
+			'library' => 'lithium',
+			'template' => 'testTypeFile'
+		));
+		$this->assertEqual('This is a type test.', $response->body());
+
+		// testing the template falls back to the html template
+		$response = new Response();
+		$response->type('view-integration-test');
+		Media::render($response, array(), array(
+			'layout' => true,
+			'library' => 'lithium',
+			'template' => 'testFile'
+		));
+		$this->assertEqual('This is a test.', $response->body());
+
+		// testing with a layout
+		Media::type('view-integration-test', 'lithium/viewtest', array(
+			'view' => 'lithium\template\View',
+			'paths' => array(
+				'layout' => '{:library}/tests/mocks/template/view/adapters/testLayoutFile.html.php',
+				'template' => array(
+					'{:library}/tests/mocks/template/view/adapters/{:template}.{:type}.php',
+					'{:library}/tests/mocks/template/view/adapters/{:template}.html.php',
+				)
+			)
+		));
+		$response = new Response();
+		$response->type('view-integration-test');
+		Media::render($response, array(), array(
+			'layout' => true,
+			'library' => 'lithium',
+			'template' => 'testTypeFile'
+		));
+		$this->assertEqual("Layout top.\nThis is a type test.Layout bottom.", $response->body());
+	}
+}
+
+?>

--- a/tests/mocks/template/view/adapters/testLayoutFile.html.php
+++ b/tests/mocks/template/view/adapters/testLayoutFile.html.php
@@ -1,0 +1,3 @@
+Layout top.
+<?=$this->content(); ?>
+Layout bottom.

--- a/tests/mocks/template/view/adapters/testTypeFile.view-integration-test.php
+++ b/tests/mocks/template/view/adapters/testTypeFile.view-integration-test.php
@@ -1,0 +1,1 @@
+This is a type test.


### PR DESCRIPTION
See issue #283 for discussion.  If you look at the docs and defaults for Media::type, you'll see it has 'template' and 'layout' as top level items for the $options for defining a new media type. But, if you look at Media::_handlers, the 'default' type has 'template' and 'layout' as well as 'element' inside a 'paths' key.

I updated the defaults, api doc, and tests for Media::type to use a 'paths' key instead of 'template' and 'layout' keys.  I made use of lithium\util\Set::merge to deep merging of the options so you don't need to redefine all paths if you just want to turn off the layout.

I originally wanted to preserve the 'template' and 'layout' keys for backwards compatibility... but it seems to be that they weren't working anyway, so this has been broken for some time if it was ever working at all.  If you disagree, let me know and I can look into it some more.

Thanks,
Rob
