### PR TITLE
adding support for schemeless external urls

### DIFF
--- a/net/http/Media.php
+++ b/net/http/Media.php
@@ -425,7 +425,7 @@ class Media extends \lithium\core\StaticObject {
 			$options = $params['options'];
 			$library = $options['library'];
 
-			if (preg_match('/^[a-z0-9-]+:\/\//i', $path)) {
+			if (preg_match('/^(?:[a-z0-9-]+:)?\/\//i', $path)) {
 				return $path;
 			}
 			$config = Libraries::get($library);

--- a/tests/cases/net/http/MediaTest.php
+++ b/tests/cases/net/http/MediaTest.php
@@ -136,6 +136,10 @@ class MediaTest extends \lithium\test\Unit {
 		$expected = 'scheme://host/subpath/file';
 		$this->assertEqual($expected, $result);
 
+		$result = Media::asset('//host/subpath/file', 'js', array('base' => '/base'));
+		$expected = '//host/subpath/file';
+		$this->assertEqual($expected, $result);
+
 		$result = Media::asset('subpath/file', 'js');
 		$expected = '/js/subpath/file.js';
 		$this->assertEqual($expected, $result);


### PR DESCRIPTION
They've become very popular for providing an easy way to support automatically using the same scheme as the initial html page when accessed over http and https.  I use them and feel that Lithium needs to support them.
Cheers,
Rob
