### PR TITLE
Fixed radio buttons so that they are checked if they are true in the bou...

### DIFF
--- a/template/helper/Form.php
+++ b/template/helper/Form.php
@@ -496,6 +496,26 @@ class Form extends \lithium\template\Helper {
 	}
 
 	/**
+	 * Generates an HTML `<input type="radio" />` object.
+	 * @param string $name The name of the field
+	 * @param array $options All options to be passed to the render
+	 * @return string Returns a `<input />` tag with the given name and attributes 
+	 */
+	public function radio($name, array $options = array()) {
+		list($name, $options, $template) = $this->_defaults(__FUNCTION__, $name, $options);
+
+		$default = $options['value'];
+
+		if (!isset($options['checked'])) {
+			if ($this->_binding && $bound = $this->_binding->data($name)) {
+				$options['checked'] = ($bound == $default);
+			}
+		}
+
+		return $this->_render(__METHOD__, $template, compact('name', 'options'));
+	}
+
+	/**
 	 * Generates a `<select />` list using the `$list` parameter for the `<option />` tags. The
 	 * default selection will be set to the value of `$options['value']`, if specified.
 	 *


### PR DESCRIPTION
...nd data

As the title says I have created a patch to check the radio buttons if the bound data is true. 
I had an issue before where when I saved a form with radio buttons then tried to edit it later the radio buttons would not be checked.

This is because there was no radio() method in form so instead it just renders the radio template. 
This commit fixes that. 
