### PR TITLE
Update tests that relied on lithify.me to google.com

### DIFF
--- a/test/Unit.php
+++ b/test/Unit.php
@@ -964,7 +964,7 @@ class Unit extends \lithium\core\Object {
 	/**
 	 * Checks for a working internet connection.
 	 *
-	 * This method is used to check for a working connection to lithify.me, both
+	 * This method is used to check for a working connection to google.com, both
 	 * testing for proper dns resolution and reading the actual URL.
 	 *
 	 * @param array $config Override the default URI to check.
@@ -973,7 +973,7 @@ class Unit extends \lithium\core\Object {
 	protected function _hasNetwork($config = array()) {
 		$defaults = array(
 			'scheme' => 'http',
-			'host' => 'lithify.me'
+			'host' => 'google.com'
 		);
 		$config += $defaults;
 

--- a/tests/cases/net/socket/ContextTest.php
+++ b/tests/cases/net/socket/ContextTest.php
@@ -17,7 +17,7 @@ class ContextTest extends \lithium\test\Unit {
 	protected $_testConfig = array(
 		'persistent' => false,
 		'scheme' => 'http',
-		'host' => 'lithify.me',
+		'host' => 'google.com',
 		'port' => 80,
 		'timeout' => 4,
 		'classes' => array('request' => 'lithium\net\http\Request')

--- a/tests/cases/net/socket/CurlTest.php
+++ b/tests/cases/net/socket/CurlTest.php
@@ -16,7 +16,7 @@ class CurlTest extends \lithium\test\Unit {
 	protected $_testConfig = array(
 		'persistent' => false,
 		'scheme' => 'http',
-		'host' => 'lithify.me',
+		'host' => 'google.com',
 		'port' => 80,
 		'timeout' => 2,
 		'classes' => array('request' => 'lithium\net\http\Request')

--- a/tests/cases/net/socket/StreamTest.php
+++ b/tests/cases/net/socket/StreamTest.php
@@ -17,7 +17,7 @@ class StreamTest extends \lithium\test\Unit {
 	protected $_testConfig = array(
 		'persistent' => false,
 		'scheme' => 'http',
-		'host' => 'lithify.me',
+		'host' => 'google.com',
 		'port' => 80,
 		'timeout' => 2,
 		'classes' => array('request' => 'lithium\net\http\Request')

--- a/tests/integration/net/SocketTest.php
+++ b/tests/integration/net/SocketTest.php
@@ -17,7 +17,7 @@ class SocketTest extends \lithium\test\Integration {
 	protected $_testConfig = array(
 		'persistent' => false,
 		'scheme' => 'http',
-		'host' => 'www.lithify.me',
+		'host' => 'google.com',
 		'port' => 80,
 		'timeout' => 1,
 		'classes' => array(
@@ -37,12 +37,12 @@ class SocketTest extends \lithium\test\Integration {
 		$response = $socket->send();
 		$this->assertTrue($response instanceof \lithium\net\http\Response);
 
-		$expected = 'www.lithify.me';
+		$expected = 'google.com';
 		$result = $response->host;
 		$this->assertEqual($expected, $result);
 
 		$result = $response->body();
-		$this->assertPattern("/<title[^>]*>.*Lithium.*<\/title>/im", (string) $result);
+		$this->assertPattern("/<title[^>]*>.*Google.*<\/title>/im", (string) $result);
 	}
 
 	public function testCurlAdapter() {
@@ -54,12 +54,12 @@ class SocketTest extends \lithium\test\Integration {
 		$response = $socket->send();
 		$this->assertTrue($response instanceof \lithium\net\http\Response);
 
-		$expected = 'www.lithify.me';
+		$expected = 'google.com';
 		$result = $response->host;
 		$this->assertEqual($expected, $result);
 
 		$result = $response->body();
-		$this->assertPattern("/<title[^>]*>.*Lithium.*<\/title>/im", (string) $result);
+		$this->assertPattern("/<title[^>]*>.*<\/title>/im", (string) $result);
 	}
 
 	public function testStreamAdapter() {
@@ -68,12 +68,12 @@ class SocketTest extends \lithium\test\Integration {
 		$response = $socket->send();
 		$this->assertTrue($response instanceof \lithium\net\http\Response);
 
-		$expected = 'www.lithify.me';
+		$expected = 'google.com';
 		$result = $response->host;
 		$this->assertEqual($expected, $result);
 
 		$result = $response->body();
-		$this->assertPattern("/<title[^>]*>.*Lithium.*<\/title>/im", (string) $result);
+		$this->assertPattern("/<title[^>]*>.*<\/title>/im", (string) $result);
 	}
 }
 


### PR DESCRIPTION
Some `Socket` tests relied on lithify.me responses.
4 fails because of lithify.me response time.

This commit updates those to rely on google.com responses for more robust tests, in case lithify.me is down or don't respond in a timely fashion.
As well as test\Unit::_hasNetwork()

```
--------------------------------------------------------------------------------
Test
--------------------------------------------------------------------------------
Running test(s) in `lithium\tests\cases\net\socket`... done.

Results
87 / 87 passes
0 fails and 0 exceptions

--------------------------------------------------------------------------------
Test
--------------------------------------------------------------------------------
Running test(s) in `lithium\tests\integration\net`... done.

Results
15 / 15 passes
0 fails and 0 exceptions
```
