### PR TITLE
Form helper is now aware of radio inputs

### DIFF
--- a/template/helper/Form.php
+++ b/template/helper/Form.php
@@ -55,7 +55,7 @@ class Form extends \lithium\template\Helper {
 		'legend'         => '<legend>{:content}</legend>',
 		'option-group'   => '<optgroup label="{:label}"{:options}>{:raw}</optgroup>',
 		'password'       => '<input type="password" name="{:name}"{:options} />',
-		'radio'          => '<input type="radio" name="{:name}" {:options} />',
+		'radio'          => '<input type="radio" name="{:name}"{:options} />',
 		'select'         => '<select name="{:name}"{:options}>{:raw}</select>',
 		'select-empty'   => '<option value=""{:options}>&nbsp;</option>',
 		'select-multi'   => '<select name="{:name}[]"{:options}>{:raw}</select>',
@@ -574,7 +574,7 @@ class Form extends \lithium\template\Helper {
 	 * @param array $options Options to be used when generating the checkbox `<input />` element:
 	 *              - `'checked'` _boolean_: Whether or not the field should be checked by default.
 	 *              - `'value'` _mixed_: if specified, it will be used as the 'value' html
-	 *                attribute and no hidden input field will be added
+	 *                attribute and no hidden input field will be added.
 	 *              - Any other options specified are rendered as HTML attributes of the element.
 	 * @return string Returns a `<input />` tag with the given name and HTML attributes.
 	 */
@@ -597,6 +597,35 @@ class Form extends \lithium\template\Helper {
 		}
 		$options['value'] = $scope['value'];
 		return $out . $this->_render(__METHOD__, $template, compact('name', 'options'));
+	}
+
+	/**
+	 * Generates an HTML `<input type="radio" />` object.
+	 *
+	 * @param string $name The name of the field
+	 * @param array $options All options to be used when generating the radio `<input />` element:
+	 *              - `'checked'` _boolean_: Whether or not the field should be selected by default.
+	 *              - `'value'` _mixed_: if specified, it will be used as the 'value' html
+	 *                attribute. Defaults to `1`
+	 *              - Any other options specified are rendered as HTML attributes of the element.
+	 * @return string Returns a `<input />` tag with the given name and attributes
+	 */
+	public function radio($name, array $options = array()) {
+		$defaults = array('value' => '1');
+		$options += $defaults;
+		$default = $options['value'];
+
+		list($name, $options, $template) = $this->_defaults(__FUNCTION__, $name, $options);
+		list($scope, $options) = $this->_options($defaults, $options);
+
+		if (!isset($options['checked'])) {
+			if ($this->_binding && $bound = $this->_binding->data($name)) {
+				$options['checked'] = ($bound == $default);
+			}
+		}
+
+		$options['value'] = $scope['value'];
+		return $this->_render(__METHOD__, $template, compact('name', 'options'));
 	}
 
 	/**

--- a/tests/cases/template/helper/FormTest.php
+++ b/tests/cases/template/helper/FormTest.php
@@ -468,6 +468,108 @@ class FormTest extends \lithium\test\Unit {
 		));
 	}
 
+	public function testRadioGeneration() {
+		$result = $this->form->radio('foo');
+		$this->assertTags($result, array(
+			array('input' => array('type' => 'radio', 'value' => '1', 'name' => 'foo', 'id' => 'Foo'))
+		));
+
+		$result = $this->form->radio('foo', array('checked' => false));
+		$this->assertTags($result, array(
+			array('input' => array('type' => 'radio', 'value' => '1', 'name' => 'foo', 'id' => 'Foo'))
+		));
+
+		$result = $this->form->radio('foo', array('checked' => true));
+		$this->assertTags($result, array(
+			array('input' => array('type' => 'radio', 'value' => '1', 'name' => 'foo', 'checked' => 'checked', 'id' => 'Foo'))
+		));
+
+		$record = new Record(array('model' => $this->_model, 'data' => array('foo' => true)));
+		$this->form->create($record);
+
+		$result = $this->form->radio('foo');
+		$this->assertTags($result, array(
+			array('input' => array(
+				'type' => 'radio', 'value' => '1', 'name' => 'foo',
+				'checked' => 'checked', 'id' => 'MockFormPostFoo'
+			))
+		));
+	}
+
+	public function testCustomRadio() {
+		$result = $this->form->radio('foo', array('value' => '1'));
+		$this->assertTags($result, array(
+			array('input' => array(
+				'type' => 'radio', 'value' => '1',  'name' => 'foo', 'id' => 'Foo'
+			))
+		));
+
+		$result = $this->form->radio('foo', array('checked' => true, 'value' => '1'));
+		$this->assertTags($result, array(
+			array('input' => array(
+				'type' => 'radio', 'value' => '1',  'name' => 'foo',
+				'checked' => 'checked', 'id' => 'Foo'
+			))
+		));
+
+		$record = new Record(array('model' => $this->_model, 'data' => array('foo' => true)));
+		$this->form->create($record);
+
+		$result = $this->form->radio('foo', array('value' => '1'));
+		$this->assertTags($result, array(
+			array('input' => array(
+				'type' => 'radio', 'value' => '1',  'name' => 'foo',
+				'id' => 'MockFormPostFoo', 'checked' => 'checked'
+			))
+		));
+
+		$result = $this->form->radio('foo', array('value' => true));
+		$this->assertTags($result, array(
+			array('input' => array(
+				'type' => 'radio', 'value' => '1',  'name' => 'foo',
+				'id' => 'MockFormPostFoo', 'checked' => 'checked'
+			))
+		));
+	}
+
+	public function testCustomValueRadio() {
+		$result = $this->form->radio('foo', array('value' => 'HERO'));
+		$this->assertTags($result, array(
+			array('input' => array(
+				'type' => 'radio', 'value' => 'HERO', 'name' => 'foo', 'id' => 'Foo'
+			))
+		));
+
+		$result = $this->form->radio('foo', array('value' => 'nose'));
+		$this->assertTags($result, array(
+			array('input' => array(
+				'type' => 'radio', 'value' => 'nose', 'name' => 'foo', 'id' => 'Foo'
+			))
+		));
+
+		$record = new Record(array('model' => $this->_model, 'data' => array('foo' => 'nose')));
+		$this->form->create($record);
+
+		$result = $this->form->radio('foo', array('value' => 'nose'));
+		$this->assertTags($result, array(
+			array('input' => array(
+				'type' => 'radio', 'value' => 'nose', 'name' => 'foo',
+				'id' => 'MockFormPostFoo', 'checked' => 'checked'
+			))
+		));
+
+		$record = new Record(array('model' => $this->_model, 'data' => array('foo' => 'foot')));
+		$this->form->create($record);
+
+		$result = $this->form->checkbox('foo', array('value' => 'nose'));
+		$this->assertTags($result, array(
+			array('input' => array('type' => 'hidden', 'value' => '', 'name' => 'foo')),
+			array('input' => array(
+				'type' => 'checkbox', 'value' => 'nose', 'name' => 'foo', 'id' => 'MockFormPostFoo'
+			))
+		));
+	}
+
 	public function testSelectGeneration() {
 		$result = $this->form->select('foo');
 
@@ -1091,7 +1193,7 @@ class FormTest extends \lithium\test\Unit {
 		$this->assertTags($result, array(
 			'span' => array(),
 			'label' => array('for' => 'Name'), 'Name', '/label', ':',
-			'input' => array('type' => 'radio', 'name' => 'name', 'id' => 'Name')
+			'input' => array('type' => 'radio', 'name' => 'name', 'id' => 'Name', 'value' => '1')
 		));
 	}
 }


### PR DESCRIPTION
Hugely inspired by @edude03 pull request #304.

I mainly added missing tests, based on checkbox() ones.
Updated the docblock with more precisions.
Added to radio() method a default `value = '1'`
