### PR TITLE
Add sanity check in Media::asset()

### DIFF
--- a/net/http/Media.php
+++ b/net/http/Media.php
@@ -442,7 +442,7 @@ class Media extends \lithium\core\StaticObject {
 				$file = $self::path($path, $type, $options);
 			}
 
-			if ($path[0] === '/') {
+			if (strlen($path) > 0 && $path[0] === '/') {
 				if ($options['base'] && strpos($path, $options['base']) !== 0) {
 					$path = "{$options['base']}{$path}";
 				}


### PR DESCRIPTION
I had a problem when i used Media::asset() in a way that was propably not originally intended. I wanted to use it to get the base path to the images directory and pass this path to JavaScript. Basically what i did is this:

```
<script type="text/javascript">
    var EE = {
        basePaths : {
            image : '<?php echo $this->path(Media::asset('', 'image')); ?>'
        }
    };
</script>
```

This produces a NOTICE in PHP. I added a sanity check in Media::asset() that prevents this Notice. From what i understand, this should not have side-effects. 
