### PR TITLE
Minor fix for a failing Request test when ran from cli

### DIFF
--- a/tests/cases/action/RequestTest.php
+++ b/tests/cases/action/RequestTest.php
@@ -1015,7 +1015,10 @@ class RequestTest extends \lithium\test\Unit {
 		$request = new Request(array(
 			'url' => 'foo/bar',
 			'base' => null,
-			'env' => array('HTTP_HOST' => 'example.com'),
+			'env' => array(
+				'HTTP_HOST' => 'example.com',
+				'PHP_SELF' => '/index.php'
+			),
 		));
 
 		$expected = 'http://example.com/foo/bar';


### PR DESCRIPTION
`RequestTest::testConvertToUrl()` fails when tests are run from cli (Travis btw)
The guilty test don't force a `base` path when constructing the Request.
Freezing `PHP_SELF` fix it.
#### Before

Running test(s) in `lithium\tests\cases\action`... done.

Results
189 / 190 passes
1 fail and 0 exceptions

Assertion `assertEqual` failed in `lithium\tests\cases\action\RequestTest::testConvertToUrl()` on line 1024:
expected: 'http://example.com/foo/bar'
result: 'http://example.com/usr/local/lib/li3/libraries/lithium/console/foo/bar'
#### After

Running test(s) in `lithium\tests\cases\action`... done.

Results
190 / 190 passes
0 fails and 0 exceptions
