### PR TITLE
Http Refactor

### DIFF
--- a/data/source/Http.php
+++ b/data/source/Http.php
@@ -136,9 +136,14 @@ class Http extends \lithium\data\Source {
 				$data = in_array($string['method'], array('post', 'put')) ? (array) $query : array();
 			}
 
-			$options += array('conditions' => null, 'limit' => null);
-			$data += (array) $options['conditions'] + (array) $options['limit'];
+			preg_match_all('/\{:(\w+)\}/', $string['path'], $matches);
+			$keys = array_flip($matches[1]);
 			$path = String::insert($string['path'], $options + $data, array('clean' => true));
+
+
+			$options += array('conditions' => null, 'limit' => null);
+			$data = array_diff_assoc($data, $keys);
+			$data += (array) $options['conditions'] + (array) $options['limit'];
 			return $conn->{$string['method']}($path, $data, $options);
 		};
 		return $this->_filter(__METHOD__, $params, $filter);

--- a/tests/cases/data/source/HttpTest.php
+++ b/tests/cases/data/source/HttpTest.php
@@ -203,8 +203,8 @@ class HttpTest extends \lithium\test\Unit {
 			'Connection: Close',
 			'User-Agent: Mozilla/5.0',
 			'Content-Type: application/x-www-form-urlencoded',
-			'Content-Length: 21',
-			'', 'id=1&title=Test+Title'
+			'Content-Length: 16',
+			'', 'title=Test+Title'
 		));
 		$result = (string) $http->last->request;
 		$this->assertEqual($expected, $result);


### PR DESCRIPTION
Refactored all crud functions to use Http::__call().  Also removed the ability of executing custom http methods on the data source.  These should be done with \lithium\net\http\Service.  
