### PR TITLE
MongoDB: allow for $and and $nor conditional operators

### DIFF
--- a/data/source/MongoDb.php
+++ b/data/source/MongoDb.php
@@ -79,14 +79,16 @@ class MongoDb extends \lithium\data\Source {
 	protected $_operators = array(
 		'<'   => '$lt',
 		'>'   => '$gt',
-		'<='  =>  '$lte',
+		'<='  => '$lte',
 		'>='  => '$gte',
 		'!='  => array('single' => '$ne', 'multiple' => '$nin'),
 		'<>'  => array('single' => '$ne', 'multiple' => '$nin'),
 		'or'  => '$or',
 		'||'  => '$or',
 		'not' => '$not',
-		'!'   =>  '$not'
+		'!'   => '$not',
+		'and' => '$and',
+		'&&'  => '$and'
 	);
 
 	/**
@@ -671,12 +673,23 @@ class MongoDb extends \lithium\data\Source {
 		$castOpts = compact('schema') + array('first' => true, 'arrays' => false);
 
 		foreach ($conditions as $key => $value) {
+			$operator = null;
 			if ($key === '$or' || $key === 'or' || $key === '||') {
-				foreach ($value as $i => $or) {
-					$value[$i] = $this->_conditions($or, $model, $schema, $context);
+				$operator = '$or';
+			}
+			if ($key === '$and' || $key === 'and' || $key === '&&') {
+				$operator = '$and';
+			}
+			if ($key === '$nor' || $key === 'nor') {
+				$operator = '$nor';
+			}
+			if ($operator) {
+				foreach ($value as $i => $op) {
+					$value[$i] = $this->_conditions($op, $model, $schema, $context);
 				}
 				unset($conditions[$key]);
-				$conditions['$or'] = $value;
+
+				$conditions[$operator] = $value;
 				continue;
 			}
 			if (is_object($value)) {

--- a/tests/cases/data/source/MongoDbTest.php
+++ b/tests/cases/data/source/MongoDbTest.php
@@ -186,6 +186,36 @@ class MongoDbTest extends \lithium\test\Unit {
 		$this->assertTrue(isset($result['key']));
 		$this->assertTrue(isset($result['key']['$in']));
 		$this->assertEqual($conditions['key'], $result['key']['$in']);
+
+		// test conditional operators (and, or, nor)
+		$conditions = array('$or' => array(
+			array('key' => 'value'),
+			array('other key' => 'another value')
+		));
+		$result = $this->db->conditions($conditions, null);
+		$this->assertTrue(isset($result['$or']));
+		$this->assertEqual($conditions['$or'][0]['key'], $result['$or'][0]['key']);
+
+		$conditions = array('$and' => array(
+			array('key' => 'value'),
+			array('other key' => 'another value')
+		));
+		$result = $this->db->conditions($conditions, null);
+		$this->assertTrue(isset($result['$and']));
+		$this->assertEqual($conditions['$and'][0]['key'], $result['$and'][0]['key']);
+
+		$conditions = array('$nor' => array(
+			array('key' => 'value'),
+			array('other key' => 'another value')
+		));
+		$result = $this->db->conditions($conditions, null);
+		$this->assertTrue(isset($result['$nor']));
+		$this->assertEqual($conditions['$nor'][0]['key'], $result['$nor'][0]['key']);
+
+		$conditions = array('key' => array('or' => array(1, 2)));
+		$result = $this->db->conditions($conditions, null);
+		$this->assertTrue(isset($result['key']['$or']));
+
 	}
 
 	public function testMongoConditionalOperators() {


### PR DESCRIPTION
Updated data/source/MongoDb.php to allow the use of $nor and $and ($and is new since Mongo 2.0). http://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-%24nor

Added tests, shoudn't break anything. 
