### PR TITLE
silent access-try to '/dev/urandom'

### DIFF
--- a/util/String.php
+++ b/util/String.php
@@ -124,7 +124,7 @@ class String {
 		switch (true) {
 			case isset(static::$_source):
 				return static::$_source;
-			case is_readable('/dev/urandom') && $fp = fopen('/dev/urandom', 'rb'):
+			case @is_readable('/dev/urandom') && $fp = @fopen('/dev/urandom', 'rb'):
 				return static::$_source = function($bytes) use (&$fp) {
 					return fread($fp, $bytes);
 				};


### PR DESCRIPTION
when php is forced to show detailed reports (.htaccess >> php_value error_reporting 8191 && php_flag display_errors on) I always get a warning because my php is not allowed to access '/dev/urandom'. so i call it silent it.
