### PR TITLE
fixing controller rendering of requests with a set type

### DIFF
--- a/action/Controller.php
+++ b/action/Controller.php
@@ -144,7 +144,13 @@ class Controller extends \lithium\core\Object {
 			$this->_render['type'] = $this->request->accepts();
 			return;
 		}
-		$this->_render['type'] = $this->request->type ?: 'html';
+		$type = $this->request->type() ?: 'html';
+		$media = $this->_classes['media'];
+		$handler = $media::type($type);
+		if (isset($handler['options']['responseType'])) {
+			$type = $handler['options']['responseType'];
+		}
+		$this->_render['type'] = $type;
 	}
 
 	/**

--- a/net/http/Media.php
+++ b/net/http/Media.php
@@ -115,7 +115,7 @@ class Media extends \lithium\core\StaticObject {
 	 *
 	 * {{{ embed:lithium\tests\cases\net\http\MediaTest::testMediaTypes(19-20) }}}
 	 *
-	 * {{{ embed:lithium\tests\cases\net\http\MediaTest::testMediaTypes(40-41) }}}
+	 * {{{ embed:lithium\tests\cases\net\http\MediaTest::testMediaTypes(44-45) }}}
 	 *
 	 * Alternatively, can be used to detect the type name of a registered content type:
 	 * {{{
@@ -213,6 +213,13 @@ class Media extends \lithium\core\StaticObject {
 	 *          render templates without a layout, use a `false` value for `'layout'`.
 	 *        - `'conditions'` _array_: Optional key/value pairs used as assertions in content
 	 *          negotiation. See the above section on **Content Negotiation**.
+	 *        - `'responseType'` _string_: Optional default type to use for responses to
+	 *          this type.  Primarily used by `lithium\action\Controller::_init()`
+	 *          when setting the `$_render['type']`.  It is almost always
+	 *          the same as the request type with 'form' being a notable
+	 *          exception.  However, the HTTP way is to use content negotion and the
+	 *          Accept header to determine the appropriate response type.  See the above
+	 *          section on **Content Negotiation**.
 	 * @return mixed If `$content` and `$options` are empty, returns an array with `'content'` and
 	 *         `'options'` keys, where `'content'` is the content-type(s) that correspond to
 	 *         `$type` (can be a string or array, if multiple content-types are available), and
@@ -230,7 +237,8 @@ class Media extends \lithium\core\StaticObject {
 			'encode' => false,
 			'decode' => false,
 			'cast'   => true,
-			'conditions' => array()
+			'conditions' => array(),
+			'responseType' => null
 		);
 
 		if ($content === false) {
@@ -824,7 +832,8 @@ class Media extends \lithium\core\StaticObject {
 					$decoded = array();
 					parse_str($data, $decoded);
 					return $decoded;
-				}
+				},
+				'responseType' => 'html'
 			)
 		);
 

--- a/tests/cases/action/ControllerTest.php
+++ b/tests/cases/action/ControllerTest.php
@@ -23,9 +23,12 @@ class ControllerTest extends \lithium\test\Unit {
 	 */
 	public function testConstructionWithCustomRequest() {
 		$request = new MockControllerRequest();
+		$request->type('test');
 		$postsController = new MockPostsController(compact('request'));
 		$result = get_class($postsController->request);
 		$this->assertEqual($result, 'lithium\tests\mocks\action\MockControllerRequest');
+		$render = $postsController->access('_render');
+		$this->assertEqual($request->type(), $render['type']);
 	}
 
 	/**

--- a/tests/cases/net/http/MediaTest.php
+++ b/tests/cases/net/http/MediaTest.php
@@ -70,7 +70,8 @@ class MediaTest extends \lithium\test\Unit {
 				'layout' => false,
 				'element' => '{:library}/views/elements/{:template}.{:type}.php'
 			),
-			'encode' => null, 'decode' => null, 'cast' => true, 'conditions' => array()
+			'encode' => null, 'decode' => null, 'cast' => true,
+			'conditions' => array(), 'responseType' => null
 		);
 		$this->assertEqual($expected, $result['options']);
 

--- a/tests/integration/net/http/MediaTest.php
+++ b/tests/integration/net/http/MediaTest.php
@@ -8,6 +8,8 @@
 
 namespace lithium\tests\integration\net\http;
 
+use lithium\action\Controller;
+use lithium\action\Request;
 use lithium\net\http\Media;
 use lithium\net\http\Response;
 
@@ -70,6 +72,26 @@ class MediaTest extends \lithium\test\Integration {
 			'template' => 'testTypeFile'
 		));
 		$this->assertEqual("Layout top.\nThis is a type test.Layout bottom.", $response->body());
+	}
+
+	public function testControllerResponseType() {
+		$request = new Request();
+		$request->type = 'text/html';
+		$controller = new Controller(compact('request'));
+		$controller->render(array('head' => true));
+		$this->assertEqual('html', $controller->response->type());
+
+		$request = new Request();
+		$request->type = 'multipart/form-data';
+		$controller = new Controller(compact('request'));
+		$controller->render(array('head' => true));
+		$this->assertEqual('html', $controller->response->type());
+
+		$request = new Request();
+		$request->type = 'application/json';
+		$controller = new Controller(compact('request'));
+		$controller->render(array('head' => true));
+		$this->assertEqual('json', $controller->response->type());
 	}
 }
 


### PR DESCRIPTION
If you set the request type manually in the dispatch cycle, it was not being honored by `Controller` which would always use text/html.  This change fixes that.  It was found that it broke form requests, so the `Media` class type config was updated to include `responseType` as an option.  This is currently only needed for `form` requests where the incoming type is 'form' but the response type needs to be 'html'.  Integration and unit tests were added.

This is a second attempt (first being #282 which didn't account for the issue with form request types).
