### PR TITLE
Fixed for issue #348

### DIFF
--- a/net/http/Media.php
+++ b/net/http/Media.php
@@ -763,7 +763,7 @@ class Media extends \lithium\core\StaticObject {
 			'js'           => array('application/javascript', 'text/javascript'),
 			'text'         => array('text/plain'),
 			'txt'          => array('alias' => 'text'),
-			'xml'          => array('application/xml', 'text/xml')
+			'xml'          => array('application/xml', 'application/soap+xml', 'text/xml')
 		);
 
 		if (!$type) {

--- a/net/http/Response.php
+++ b/net/http/Response.php
@@ -21,13 +21,6 @@ class Response extends \lithium\net\http\Message {
 	public $status = array('code' => 200, 'message' => 'OK');
 
 	/**
-	 * Content Type.
-	 *
-	 * @var string
-	 */
-	public $type = 'text/html';
-
-	/**
 	 * Character encoding.
 	 *
 	 * @var string
@@ -111,8 +104,10 @@ class Response extends \lithium\net\http\Message {
 			preg_match($pattern, $this->headers['Content-Type'], $match);
 
 			if (isset($match[1])) {
-				$this->type = trim($match[1]);
-				$this->body = $this->_decode($this->body);
+				$this->type(trim($match[1]));
+				if (is_string($this->body) && trim($this->body) !== '') {
+					$this->body = $this->_decode($this->body);
+				}
 			}
 			if (isset($match[3])) {
 				$this->encoding = strtoupper(trim($match[3]));
@@ -243,9 +238,6 @@ class Response extends \lithium\net\http\Message {
 	* @return string
 	*/
 	public function __toString() {
-		if ($this->type != 'text/html' && !isset($this->headers['Content-Type'])) {
-			$this->headers['Content-Type'] = $this->type;
-		}
 		$first = "{$this->protocol} {$this->status['code']} {$this->status['message']}";
 		$response = array($first, join("\r\n", $this->headers()), "", $this->body());
 		return join("\r\n", $response);

--- a/tests/cases/net/http/ResponseTest.php
+++ b/tests/cases/net/http/ResponseTest.php
@@ -51,33 +51,33 @@ class ResponseTest extends \lithium\test\Unit {
 		$response = new Response(array('headers' => array(
 			'Content-Type' => 'text/xml;charset=UTF-8'
 		)));
-		$this->assertEqual('text/xml', $response->type);
+		$this->assertEqual('xml', $response->type());
 		$this->assertEqual('UTF-8', $response->encoding);
 
 		$response = new Response(array('headers' => array(
 			'Content-Type' => 'application/soap+xml; charset=iso-8859-1'
 		)));
-		$this->assertEqual('application/soap+xml', $response->type);
+		$this->assertEqual('xml', $response->type());
 		$this->assertEqual('ISO-8859-1', $response->encoding);
 
 		// Content type WITHOUT space between type and charset
 		$response = new Response(array('headers' => array(
 			'Content-Type' => 'application/json;charset=iso-8859-1'
 		)));
-		$this->assertEqual('application/json', $response->type);
+		$this->assertEqual('json', $response->type());
 		$this->assertEqual('ISO-8859-1', $response->encoding);
 
 		// Content type WITH ONE space between type and charset
 		$response = new Response(array('headers' => array(
 			'Content-Type' => 'application/json; charset=iso-8859-1'
 		)));
-		$this->assertEqual('application/json', $response->type);
+		$this->assertEqual('json', $response->type());
 		$this->assertEqual('ISO-8859-1', $response->encoding);
 
 		$response = new Response(array('headers' => array(
 			'Content-Type' => 'application/json;     charset=iso-8859-1'
 		)));
-		$this->assertEqual('application/json', $response->type);
+		$this->assertEqual('json', $response->type());
 		$this->assertEqual('ISO-8859-1', $response->encoding);
 	}
 
@@ -85,7 +85,7 @@ class ResponseTest extends \lithium\test\Unit {
 		$response = new Response(array('headers' => array(
 			'Content-Type' => 'application/json'
 		)));
-		$this->assertEqual('application/json', $response->type);
+		$this->assertEqual('json', $response->type());
 		$this->assertEqual('UTF-8', $response->encoding); //default
 	}
 
@@ -109,7 +109,7 @@ class ResponseTest extends \lithium\test\Unit {
 
 		$response = new Response(compact('message'));
 		$this->assertEqual($message, (string) $response);
-		$this->assertEqual('application/json', $response->type);
+		$this->assertEqual('json', $response->type());
 		$this->assertEqual('ISO-8859-1', $response->encoding);
 
 		$body = 'Not a Message';
@@ -212,7 +212,7 @@ class ResponseTest extends \lithium\test\Unit {
 	}
 
 	public function testTypeHeader() {
-		$response = new Response(array('type' => 'application/json'));
+		$response = new Response(array('headers' => array('Content-Type' => 'application/json')));
 		$result = (string) $response;
 		$this->assertPattern('/^HTTP\/1\.1 200 OK/', $result);
 		$this->assertPattern('/Content-Type: application\/json\s+$/ms', $result);


### PR DESCRIPTION
Removed public var `Response::$type` in favor of `Message::$_type` and `Response::type()`
