### PR TITLE
$this->request->type confusion in Controller::_init

### DIFF
--- a/action/Controller.php
+++ b/action/Controller.php
@@ -144,7 +144,7 @@ class Controller extends \lithium\core\Object {
 			$this->_render['type'] = $this->request->accepts();
 			return;
 		}
-		$this->_render['type'] = $this->request->type ?: 'html';
+		$this->_render['type'] = $this->request->get('param:type') ?: 'html';
 	}
 
 	/**


### PR DESCRIPTION
Much thanks to @nateabele for clarifying #347.  This commit simply makes it a little more obvious that Controller::_init is looking for a param named 'type' in the request object and not a mistyped instance var or method.

Basically, what happened was led to it was this -

I was looking at `Controller::_init` to see how I could set the _render['type'] from somewhere in the bootstrap.  I saw `$this->request->type`, so I set `$request->type = 'something'` in my bootstrap, but it didn't work (because `$request->params['type']` was set and I didn't realize it was taking precedence via `Controller::__get()`).  So then I looked at `lithium\action\Request` and its parent classes and found that there was `$_type` and `type()` but no `$type` which led me to think it was a typo.

So anyway, to prevent that from happening to anyone else, I think this slight change should help make it clear.
