### PR TITLE
$this->request->type confusion in Controller::_init

### DIFF
--- a/action/Controller.php
+++ b/action/Controller.php
@@ -144,7 +144,7 @@ class Controller extends \lithium\core\Object {
 			$this->_render['type'] = $this->request->accepts();
 			return;
 		}
-		$this->_render['type'] = $this->request->type ?: 'html';
+		$this->_render['type'] = $this->request->get('params:type') ?: 'html';
 	}
 
 	/**


### PR DESCRIPTION
Retry of #354, this time against the dev branch and without the typo.  Not sure how I managed to push a version that didn't pass tests.  My only thought is that I deleted my branch and recreated it and introduced a typo when I did that... pretty weak excuse.

Anyway, this passes all tests on my machine.
