### PR TITLE
Fixing Document->rewind

### DIFF
--- a/data/entity/Document.php
+++ b/data/entity/Document.php
@@ -366,6 +366,7 @@ class Document extends \lithium\data\Entity implements \Iterator, \ArrayAccess {
 	 * @return mixed The current item after rewinding.
 	 */
 	public function rewind() {
+		reset($this->_data);
 		reset($this->_updated);
 		$this->_valid = (count($this->_updated) > 0);
 		return current($this->_updated);

--- a/tests/cases/data/entity/DocumentTest.php
+++ b/tests/cases/data/entity/DocumentTest.php
@@ -540,6 +540,12 @@ class DocumentTest extends \lithium\test\Unit {
 			$this->assertEqual(next($keys), $key);
 			$this->assertEqual(next($values), $value);
 		}
+		reset($keys);
+		reset($values);
+		foreach ($doc as $key => $value) {
+			$this->assertEqual(next($keys), $key);
+			$this->assertEqual(next($values), $value);
+		}
 	}
 
 	public function testExport() {


### PR DESCRIPTION
Fixing Document rewind bug I found while iterating properties in Document with foreach more than once (Document->rewind was not resetting $this->_data).  Added an additional iteration of foreach in DocumentTest::testPropertyIteration to make sure it doesn't resurface.
