### PR TITLE
Change Media encode decode default from false to null

### DIFF
--- a/net/http/Media.php
+++ b/net/http/Media.php
@@ -227,8 +227,8 @@ class Media extends \lithium\core\StaticObject {
 				'layout'   => '{:library}/views/layouts/{:layout}.{:type}.php',
 				'element'  => '{:library}/views/elements/{:template}.{:type}.php'
 			),
-			'encode' => false,
-			'decode' => false,
+			'encode' => null,
+			'decode' => null,
 			'cast'   => true,
 			'conditions' => array()
 		);
@@ -799,8 +799,8 @@ class Media extends \lithium\core\StaticObject {
 		$handlers = static::$_handlers + array(
 			'default' => array(
 				'view'     => 'lithium\template\View',
-				'encode'   => false,
-				'decode'   => false,
+				'encode'   => null,
+				'decode'   => null,
 				'cast'     => false,
 				'paths'    => array(
 					'template' => '{:library}/views/{:controller}/{:template}.{:type}.php',

--- a/tests/cases/net/http/MediaTest.php
+++ b/tests/cases/net/http/MediaTest.php
@@ -68,7 +68,7 @@ class MediaTest extends \lithium\test\Unit {
 			),
 			'encode' => null, 'decode' => null, 'cast' => true, 'conditions' => array()
 		);
-		$this->assertEqual($expected, $result['options']);
+		$this->assertIdentical($expected, $result['options']);
 
 		// Remove a custom media type:
 		Media::type('my', false);
@@ -483,7 +483,10 @@ class MediaTest extends \lithium\test\Unit {
 
 	public function testCustomWebroot() {
 		Libraries::add('defaultStyleApp', array('path' => LITHIUM_APP_PATH, 'bootstrap' => false));
-		$this->assertEqual(realpath(LITHIUM_APP_PATH . '/webroot'), realpath(Media::webroot('defaultStyleApp')));
+		$this->assertEqual(
+			realpath(LITHIUM_APP_PATH . '/webroot'),
+			realpath(Media::webroot('defaultStyleApp'))
+		);
 
 		Libraries::add('customWebRootApp', array(
 			'path' => LITHIUM_APP_PATH,


### PR DESCRIPTION
Media handler defaults for encode and decode need to be null and not false.  Media::encode checks for `!isset($handler['encode'])` to ignore the handler.  A `false` value fails that check and then causes a fatal error - Function name must be a string - because it tries to invoke the `false` value.

Interesting to note that assertEqual on line 71 of tests/cases/net/http/MediaTests.php didn't fail because it was using `null` for 'encode' and 'decode' but the actual for those was `false` - the assertEqual doesn't pick up on the difference between `null` and `false`.

I also changed a line in the `MediaTest` unit test that might have caught this, but was using `assertEqual` instead of `assertIdentical`.  Probably want to be careful about that since `assertEqual` doesn't pick up on a difference between `null` and `false`.  There was also a line in MediaTest with 101 chars, so I broke that into multiple lines.
