### PR TITLE
Media encode !isset() check changed to !empty()

### DIFF
--- a/net/http/Media.php
+++ b/net/http/Media.php
@@ -653,7 +653,7 @@ class Media extends \lithium\core\StaticObject {
 				$handler = $self::invokeMethod('_handlers', array($handler));
 			}
 
-			if (!$handler || !isset($handler['encode'])) {
+			if (!$handler || !empty($handler['encode'])) {
 				return null;
 			}
 


### PR DESCRIPTION
There was a fatal error if `$handler['encode']` was `false`.
