### PR TITLE
Fatal error fix for empty Media encode value

### DIFF
--- a/net/http/Media.php
+++ b/net/http/Media.php
@@ -653,7 +653,7 @@ class Media extends \lithium\core\StaticObject {
 				$handler = $self::invokeMethod('_handlers', array($handler));
 			}
 
-			if (!$handler || !empty($handler['encode'])) {
+			if (!$handler || empty($handler['encode'])) {
 				return null;
 			}
 

--- a/tests/cases/net/http/MediaTest.php
+++ b/tests/cases/net/http/MediaTest.php
@@ -354,6 +354,26 @@ class MediaTest extends \lithium\test\Unit {
 		$this->assertEqual('application/csv; charset=UTF-8', $result);
 	}
 
+	public function testEmptyEncode() {
+		$handler = Media::type('empty', 'empty/encode');
+		$this->assertNull(Media::encode($handler, array()));
+
+		$handler = Media::type('empty', 'empty/encode', array(
+			'encode' => null
+		));
+		$this->assertNull(Media::encode($handler, array()));
+
+		$handler = Media::type('empty', 'empty/encode', array(
+			'encode' => false
+		));
+		$this->assertNull(Media::encode($handler, array()));
+
+		$handler = Media::type('empty', 'empty/encode', array(
+			'encode' => ""
+		));
+		$this->assertNull(Media::encode($handler, array()));
+	}
+
 	/**
 	 * Tests that rendering plain text correctly returns the render data as-is.
 	 *
@@ -483,7 +503,10 @@ class MediaTest extends \lithium\test\Unit {
 
 	public function testCustomWebroot() {
 		Libraries::add('defaultStyleApp', array('path' => LITHIUM_APP_PATH, 'bootstrap' => false));
-		$this->assertEqual(realpath(LITHIUM_APP_PATH . '/webroot'), realpath(Media::webroot('defaultStyleApp')));
+		$this->assertEqual(
+			realpath(LITHIUM_APP_PATH . '/webroot'),
+			realpath(Media::webroot('defaultStyleApp'))
+		);
 
 		Libraries::add('customWebRootApp', array(
 			'path' => LITHIUM_APP_PATH,


### PR DESCRIPTION
See #386.  This commit adds test cases (and also fixes a pretty serious typo I made when changing `!isset` to `!empty` -- which needed to be just `empty` - I gave myself several floggings for that one).
