### PR TITLE
Improving Locale::lookup() so it better detects alternative locales

### DIFF
--- a/g11n/Locale.php
+++ b/g11n/Locale.php
@@ -191,12 +191,22 @@ class Locale extends \lithium\core\StaticObject {
 	 */
 	public static function lookup($locales, $locale) {
 		$tags = static::decompose($locale);
-
-		while (count($tags) > 0) {
+		$count = count($tags);
+		while ($count > 0) {
+			if (($key = array_search(static::compose($tags), $locales)) !== false) {
+				return $locales[$key];
+			} elseif ($count == 1) {
+				foreach($locales as $currentLocale) {
+					if (strpos($currentLocale, current($tags) . '_') === 0) {
+						return $currentLocale;
+					}
+				}
+			}
 			if (($key = array_search(static::compose($tags), $locales)) !== false) {
 				return $locales[$key];
 			}
 			array_pop($tags);
+			$count = count($tags);
 		}
 	}
 

--- a/tests/cases/g11n/LocaleTest.php
+++ b/tests/cases/g11n/LocaleTest.php
@@ -220,6 +220,30 @@ class LocaleTest extends \lithium\test\Unit {
 			'zh_Hans_HK_REVISED'
 		);
 		$this->assertEqual('zh_Hans_HK', $result);
+
+		$result = Locale::lookup(
+			array('en', 'en_UK', 'en_US', 'es', 'es_AR'),
+			'en'
+		);
+		$this->assertEqual('en', $result);
+
+		$result = Locale::lookup(
+			array('en', 'en_UK', 'en_US', 'es', 'es_AR'),
+			'en_UK'
+		);
+		$this->assertEqual('en_UK', $result);
+
+		$result = Locale::lookup(
+			array('en', 'en_UK', 'en_US', 'es', 'es_AR'),
+			'es_ES'
+		);
+		$this->assertEqual('es', $result);
+
+		$result = Locale::lookup(
+			array('en', 'en_UK', 'en_US', 'es_AR'),
+			'es_ES'
+		);
+		$this->assertEqual('es_AR', $result);
 	}
 
 	public function testPreferredFromActionRequest() {
@@ -345,6 +369,12 @@ class LocaleTest extends \lithium\test\Unit {
 			array('zh_Hans_HK_REVISED', 'zh_Hans_HK', 'zh', 'en')
 		);
 		$this->assertEqual('zh', $result);
+
+		$result = Locale::preferred(
+			array('es_ES', 'en'),
+			array('da', 'en_GB', 'en', 'es_AR')
+		);
+		$this->assertEqual('es_AR', $result);
 	}
 }
 


### PR DESCRIPTION
This fix improves locale negotiation by optimizing the `Locale::lookup()` code so horizontal matching is better treated. This means that if the locale to search is `es_ES` against available locales `es_AR`, `en_US`, `en`, without this pull request the best match would simply be `en`. With this pull request, it correctly returns `es_AR`.

Check the `testLookup()` and `testPreferredAvailableNegotiation()` tests for more examples.
