### PR TITLE
Updated Request::env() to return LOCAL_ADDR when SERVER_ADDR isn't set

### DIFF
--- a/action/Request.php
+++ b/action/Request.php
@@ -259,7 +259,7 @@ class Request extends \lithium\net\http\Request {
 				}
 				return false;
 			case 'SERVER_ADDR':
-				if ($this->_env['SERVER_ADDR'] == '') {
+				if (empty($this->_env['SERVER_ADDR']) && !empty($this->_env['LOCAL_ADDR'])) {
 					return $this->_env['LOCAL_ADDR'];
 				}
 				return $this->_env['SERVER_ADDR'];


### PR DESCRIPTION
If SERVER_ADDR isn't present, Request::env() now returns LOCAL_ADDR. Provoked specifically by IIS 7.
