### PR TITLE
Fixing double use of library key in Form::create().

### DIFF
--- a/template/helper/Form.php
+++ b/template/helper/Form.php
@@ -294,6 +294,11 @@ class Form extends \lithium\template\Helper {
 
 			$url = $scope['action'] ? array('action' => $scope['action']) : $scope['url'];
 			$options['method'] = strtolower($scope['method']);
+
+			if (is_array($url) && isset($url['library'])) {
+				unset($url['library']);
+			}
+
 			$args = array($extra['method'], $extra['tpl'], compact('url', 'options', 'append'));
 			$_options = $scope + $options;
 

--- a/tests/cases/template/helper/FormTest.php
+++ b/tests/cases/template/helper/FormTest.php
@@ -771,6 +771,30 @@ class FormTest extends \lithium\test\Unit {
 		)));
 	}
 
+	public function testFormCreateInSubmodule() {
+		Router::reset();
+		Router::connect('/users', array('controller' => 'submodule.Users'));
+		Router::connect('/users/{:action}', array('controller' => 'submodule.Users'));
+
+		$request = new Request();
+		$request->params = array(
+			'library' => 'submodule',
+			'controller' => 'submodule.Users',
+			'action' => 'index'
+		);
+		$request->persist = array('controller');
+
+		$context = new MockFormRenderer(compact('request'));
+		$form = new Form(compact('context'));
+
+		$result = $form->create();
+		
+		$this->assertTags($result, array('form' => array(
+			'action' => "/users",
+			'method' => 'post'
+		)));
+	}
+
 	public function testFormCreateWithMoreParamsButSpecifiedAction() {
 		$request = new Request();
 		$request->params = array('controller' => 'mock', 'action' => 'test', 'args' => array('1'));

--- a/tests/cases/template/helper/HtmlTest.php
+++ b/tests/cases/template/helper/HtmlTest.php
@@ -280,7 +280,7 @@ class HtmlTest extends \lithium\test\Unit {
 		$expected = '<script type="text/javascript" src="http://example.com/jquery.js"></script>';
 		$this->assertEqual($result, $expected);
 
-        $result = $this->html->script('//example.com/jquery.js');
+		$result = $this->html->script('//example.com/jquery.js');
 		$expected = '<script type="text/javascript" src="//example.com/jquery.js"></script>';
 		$this->assertEqual($result, $expected);
 


### PR DESCRIPTION
This will fix issue #374 and #321 (duplicate).
