### PR TITLE
Quick fix for misnamed variable and some comment grammar fixes

### DIFF
--- a/action/Request.php
+++ b/action/Request.php
@@ -440,7 +440,7 @@ class Request extends \lithium\net\http\Request {
 
 	/**
 	 * Sets/Gets the content type. If `'type'` is null, the method will attempt to determine the
-	 * type first, from the params, then from the environment setting
+	 * type from the params, then from the environment setting
 	 *
 	 * @param string $type a full content type i.e. `'application/json'` or simple name `'json'`
 	 * @return string A simple content type name, i.e. `'html'`, `'xml'`, `'json'`, etc., depending

--- a/data/Connections.php
+++ b/data/Connections.php
@@ -19,7 +19,7 @@ use lithium\core\Libraries;
  * (using `Connections::add()`), it is most typical to define all connections at once, in
  * `config/bootstrap/connections.php`.
  *
- * THe `Connections` class handles adapter classes efficiently by only loading adapter classes and
+ * The `Connections` class handles adapter classes efficiently by only loading adapter classes and
  * creating instances when they are requested (using `Connections::get()`).
  *
  * Adapters are usually subclasses of `lithium\data\Source`.

--- a/net/http/Response.php
+++ b/net/http/Response.php
@@ -182,7 +182,7 @@ class Response extends \lithium\net\http\Message {
 		$keys = implode('|', array_keys($params));
 		$regex = '@(' . $keys . ')=(?:([\'"])([^\2]+?)\2|([^\s,]+))@';
 		preg_match_all($regex, $header, $matches, PREG_SET_ORDER);
-		$result = array();
+		$results = array();
 
 		foreach ($matches as $m) {
 			$results[$m[1]] = $m[3] ? $m[3] : $m[4];

--- a/net/http/Router.php
+++ b/net/http/Router.php
@@ -103,7 +103,7 @@ class Router extends \lithium\core\StaticObject {
 
 	/**
 	 * Wrapper method which takes a `Request` object, parses it through all attached `Route`
-	 * objects, and assigns the resulting parameters to the `Request` object, and returning it.
+	 * objects, assigns the resulting parameters to the `Request` object, and returns it.
 	 *
 	 * @param object $request A request object, usually an instance of `lithium\action\Request`.
 	 * @return object Returns a copy of the `Request` object with parameters applied.


### PR DESCRIPTION
net/http/Response.php was causing php to complain when "results" was uninitialized.

The rest are just fixes for oddly worded comments or mis-capitalized letters.
