### PR TITLE
Test case for Bug in DocumentArray::offsetSet()

### DIFF
--- a/tests/cases/data/collection/DocumentArrayTest.php
+++ b/tests/cases/data/collection/DocumentArrayTest.php
@@ -62,6 +62,15 @@ class DocumentArrayTest extends \lithium\test\Unit {
 		$expected = array(0 => 'Hello', 6 => 'Hello again!');
 		$this->assertIdentical($expected, $doc->data());
 	}
+
+    public function testOffsetSet() {
+        $data   = array('change me', 'foo', 'bar');
+        $doc    = new DocumentArray(compact('data'));
+        $doc[0] = 'new me';
+
+        $expected = array(0 => 'new me', 1 => 'foo', 2 => 'bar');
+        $this->assertIdentical($expected, $doc->data());
+    }
 }
 
 ?>


### PR DESCRIPTION
Line 177 `if ($offset)` prevents you from changing index zero and instead appends it to the end of the array.
