### PR TITLE
Allowing zero-valued options and the empty param to play nice

### DIFF
--- a/template/helper/Form.php
+++ b/template/helper/Form.php
@@ -558,7 +558,8 @@ class Form extends \lithium\template\Helper {
 			}
 			$selected = (
 				(is_array($scope['value']) && in_array($value, $scope['value'])) ||
-				($scope['value'] == $value)
+				($scope['empty'] && empty($scope['value']) && $value === '') ||
+				($scope['value'] === (is_integer($value) ? (string) $value : $value) )
 			);
 			$options = $selected ? array('selected' => true) : array();
 			$params = compact('value', 'title', 'options');

--- a/tests/cases/template/helper/FormTest.php
+++ b/tests/cases/template/helper/FormTest.php
@@ -602,13 +602,16 @@ class FormTest extends \lithium\test\Unit {
 	}
 
 	public function testSelectWithEmptyOption() {
-		$result = $this->form->select('numbers', array('1' => 'first', '2' => 'second'), array(
+		$result = $this->form->select('numbers', array('zero', 'first', 'second'), array(
 			'empty' => true
 		));
 
 		$this->assertTags($result, array(
 			'select' => array('id' => 'Numbers', 'name' => 'numbers'),
 			array('option' => array('value' => '', 'selected' => 'selected')),
+			'/option',
+			array('option' => array('value' => '0')),
+			'zero',
 			'/option',
 			array('option' => array('value' => '1')),
 			'first',
@@ -619,7 +622,7 @@ class FormTest extends \lithium\test\Unit {
 			'/select'
 		));
 
-		$result = $this->form->select('numbers', array('1' => 'first', '2' => 'second'), array(
+		$result = $this->form->select('numbers', array('zero', 'first', 'second'), array(
 			'empty' => '> Make a selection'
 		));
 
@@ -627,6 +630,9 @@ class FormTest extends \lithium\test\Unit {
 			'select' => array('name' => 'numbers', 'id' => 'Numbers'),
 			array('option' => array('value' => '', 'selected' => 'selected')),
 			'&gt; Make a selection',
+			'/option',
+			array('option' => array('value' => '0')),
+			'zero',
 			'/option',
 			array('option' => array('value' => '1')),
 			'first',
@@ -960,7 +966,7 @@ class FormTest extends \lithium\test\Unit {
 			'div' => array(),
 			'label' => array('for' => 'States'), 'States', '/label',
 			'select' => array('name' => 'states', 'id' => 'States'),
-			array('option' => array('value' => '0', 'selected' => 'selected')),
+			array('option' => array('value' => '0')),
 			'CA',
 			'/option',
 			array('option' => array('value' => '1')),


### PR DESCRIPTION
with each other in the select form helper.

Tests modified to expect this to all work properly.
