### PR TITLE
Entity->modified() dosn't take care of non modified fields

### DIFF
--- a/data/Entity.php
+++ b/data/Entity.php
@@ -368,13 +368,13 @@ class Entity extends \lithium\core\Object {
 	 *         `true` for changed fields.
 	 */
 	public function modified() {
-		$fields = array_fill_keys(array_keys($this->_updated), false);
+		$fields = array_fill_keys(array_keys($this->_data), false);
 		foreach ($this->_updated as $field => $value) {
 			if (is_object($value) && method_exists($value, 'modified')) {
 				$modified = $value->modified();
 				$fields[$field] = $modified === true || is_array($modified) && in_array(true, $modified, true);
 			} else {
-				$fields[$field] = !isset($this->_data[$field]) || $this->_data[$field] !== $this->_updated[$field];
+				$fields[$field] = !isset($fields[$field]) || $this->_data[$field] !== $this->_updated[$field];
 			}
 		}
 		return $fields;

--- a/tests/cases/data/entity/DocumentTest.php
+++ b/tests/cases/data/entity/DocumentTest.php
@@ -134,12 +134,15 @@ class DocumentTest extends \lithium\test\Unit {
 
 
 		$doc->id = 5;
+		$doc->content = null;
+		$doc->new = null;
 		$expected = array(
 			'id' => true,
 			'name' => false,
-			'content' => false,
+			'content' => true,
+			'new' => true,
 		);
-
+		
 		$this->assertEqual($expected, $doc->modified());
 	}
 


### PR DESCRIPTION
_Sorry for duplicate request, did not find a way to change previous to /dev/ :(_

I'm using some time expensive validators, which should only be executed if the underlying field really was changed.
So I tried to use `modified()`, but it always says that all fields of my entity are changed. Not surprising since the docblock says it always return true for all fields. But in combination with `sync()` it shouldn't do that. 

So changed the behavior of `Entity->modified()` to take care about real changes.

**DocumentTest**

``` php
public function testSyncModified() {
    $doc = new Document();
    $doc->id = 4;
    $doc->name = 'Four';
    $doc->content = 'Lorem ipsum four';

    $expected = array(
        'id' => true,
        'name' => true,
        'content' => true,
    );

    $this->assertEqual($expected, $doc->modified());
    $doc->sync();

    $this->assertEqual(array_fill_keys(array_keys($expected), false), $doc->modified());


    $doc->id = 5;
    $doc->content = null;
    $doc->new = null;
    $expected = array(
        'id' => true,
        'name' => false,
        'content' => true,
        'new' => true,
    );

    $this->assertEqual($expected, $doc->modified());
}
```
