### PR TITLE
Cast select values to strings for 'selected' comparison

### DIFF
--- a/template/helper/Form.php
+++ b/template/helper/Form.php
@@ -582,7 +582,7 @@ class Form extends \lithium\template\Helper {
 		$defaults = array('value' => '1', 'hidden' => true);
 		$options += $defaults;
 		$default = $options['value'];
-        $dataname = $name;
+		$dataname = $name;
 		$out = '';
 
 		list($name, $options, $template) = $this->_defaults(__FUNCTION__, $name, $options);

--- a/tests/cases/template/helper/FormTest.php
+++ b/tests/cases/template/helper/FormTest.php
@@ -383,17 +383,17 @@ class FormTest extends \lithium\test\Unit {
 			))
 		));
 
-        $document = new Document(array('model' => $this->_model, 'data' => array('subdocument' => array('foo' => true))));
-        $this->form->create($document);
+		$document = new Document(array('model' => $this->_model, 'data' => array('subdocument' => array('foo' => true))));
+		$this->form->create($document);
 
-        $result = $this->form->checkbox('subdocument.foo');
-        $this->assertTags($result, array(
-            array('input' => array('type' => 'hidden', 'value' => '', 'name' => 'subdocument[foo]')),
-            array('input' => array(
-                'type' => 'checkbox', 'value' => '1', 'name' => 'subdocument[foo]',
-                'checked' => 'checked', 'id' => 'MockFormPostSubdocumentFoo'
-            ))            
-        ));
+		$result = $this->form->checkbox('subdocument.foo');
+		$this->assertTags($result, array(
+			array('input' => array('type' => 'hidden', 'value' => '', 'name' => 'subdocument[foo]')),
+			array('input' => array(
+				'type' => 'checkbox', 'value' => '1', 'name' => 'subdocument[foo]',
+				'checked' => 'checked', 'id' => 'MockFormPostSubdocumentFoo'
+			))
+		));
 	}
 
 	public function testCustomCheckbox() {


### PR DESCRIPTION
When trying to determine which option of a select box should be selected, we should be int/string agnostic because it all looks the same in HTML. 
