### PR TITLE
Consistent url using either $_GET['url'] or REQUEST_URI

### DIFF
--- a/action/Request.php
+++ b/action/Request.php
@@ -572,7 +572,9 @@ class Request extends \lithium\net\http\Request {
 			return rtrim($_GET['url'], '/');
 		}
 		if ($uri = $this->env('REQUEST_URI')) {
-			return str_replace($this->env('base'), '/', parse_url($uri, PHP_URL_PATH));
+			return trim(preg_replace(
+				'/^' . preg_quote($this->env('base'), '/') . '/', '', parse_url($uri, PHP_URL_PATH)
+			), '/') ?: '/';
 		}
 		return '/';
 	}

--- a/tests/cases/action/RequestTest.php
+++ b/tests/cases/action/RequestTest.php
@@ -145,17 +145,24 @@ class RequestTest extends \lithium\test\Unit {
 		unset($_GET['url']);
 		$request = new Request(array('env' => array(
 			'PHP_SELF' => '/test_app/app/webroot/index.php',
-			'REQUEST_URI' => '/test_app'
+			'REQUEST_URI' => '/test_app/'
 		)));
 		$this->assertEqual('/test_app', $request->env('base'));
 		$this->assertEqual('/', $request->url);
+
+		$request = new Request(array('env' => array(
+			'PHP_SELF' => '/test_app/app/webroot/index.php',
+			'REQUEST_URI' => '/test_app/pages/test_app'
+		)));
+		$this->assertEqual('/test_app', $request->env('base'));
+		$this->assertEqual('pages/test_app', $request->url);
 	}
 
 	public function testRequestWithoutUrlQueryParamAndNoApp() {
 		unset($_GET['url']);
 		$request = new Request(array('env' => array(
 			'PHP_SELF' => '/test_app/webroot/index.php',
-			'REQUEST_URI' => '/test_app'
+			'REQUEST_URI' => '/test_app/'
 		)));
 		$this->assertEqual('/test_app', $request->env('base'));
 		$this->assertEqual('/', $request->url);
@@ -165,7 +172,7 @@ class RequestTest extends \lithium\test\Unit {
 		unset($_GET['url']);
 		$request = new Request(array('env' => array(
 			'PHP_SELF' => '/test_app/index.php',
-			'REQUEST_URI' => '/test_app'
+			'REQUEST_URI' => '/test_app/'
 		)));
 		$this->assertEqual('/test_app', $request->env('base'));
 		$this->assertEqual('/', $request->url);


### PR DESCRIPTION
There were two issues when using `REQUEST_URI`:
1. All occurrences of base path was replaced with a `/` in the url.
2. Returned url wasn't consistent with the returned url using `$_GET['url']`.
