### PR TITLE
Fix li3 script so that it handles directories with spaces in them.

### DIFF
--- a/console/li3
+++ b/console/li3
@@ -2,8 +2,8 @@
 #
 # Lithium: the most rad php framework
 #
-# @copyright     Copyright 2012, Union of RAD (http://union-of-rad.org)
+# @copyright     Copyright 2011, Union of RAD (http://union-of-rad.org)
 # @license       http://opensource.org/licenses/bsd-license.php The BSD License
 #
-SELF=$0; test -L $0 && SELF=$(readlink -n $0)
-php -f $(dirname $SELF)/lithium.php -- "$@"
+SELF=$0; test -L "$0" && SELF=$(readlink -n $0)
+php -f "$(dirname "$SELF")"/lithium.php -- "$@"


### PR DESCRIPTION
I found that if I tried to run li3 test from a directory with spaces in it that the shell script died.  So I added some quotes in appropriate places and it works now.  I was able to reproduce on Mac OS X and on ubuntu, so I assume it's not just me... :)  I don't know if there are any tests for the shell script, so if there are let me know and I'll submit some tests, too.
