### PR TITLE
Fix To Form Auth Adapter Validation With Field Mapping

### DIFF
--- a/security/auth/adapter/Form.php
+++ b/security/auth/adapter/Form.php
@@ -326,7 +326,8 @@ class Form extends \lithium\core\Object {
 		$query = $this->_query;
 		$data = $this->_filters($credentials->data);
 
-		$conditions = $this->_scope + array_diff_key($data, $this->_validators);
+		$validate = array_flip(array_intersect_key($this->_fields, $this->_validators));
+		$conditions = $this->_scope + array_diff_key($data, $validate);
 		$user = $model::$query(compact('conditions') + $options);
 
 		if (!$user) {

--- a/tests/cases/security/auth/adapter/FormTest.php
+++ b/tests/cases/security/auth/adapter/FormTest.php
@@ -30,6 +30,23 @@ class FormTest extends \lithium\test\Unit {
 	}
 
 	/**
+	 * Used by `testValidatorWithFieldMapping` and makes sure that the
+	 * custom password field name isn't sent in the query
+	 *
+	 * @param array $options
+	 * @return object
+	 */
+	public static function validatorFieldMappingTest(array $options = array()) {
+		if (isset($options['conditions']['user.password'])) {
+			return null;
+		}
+		return new Record(array('data' => array(
+			'user.name' => 'Foo',
+			'user.password' => 'bar'
+		)));
+	}
+
+	/**
 	 * Tests a simple user lookup. Note that we're not using the password validator; due to the
 	 * limitations of this classes first() mock method, password will not be in the dataset
 	 * returned by Form::check().
@@ -365,6 +382,7 @@ class FormTest extends \lithium\test\Unit {
 	public function testValidatorWithFieldMapping() {
 		$subject = new Form(array(
 			'model' => __CLASS__,
+			'query' => 'validatorFieldMappingTest',
 			'fields' => array('name' => 'user.name', 'password' => 'user.password'),
 			'validators' => array(
 				'password' => function ($form, $data) {


### PR DESCRIPTION
Fixes #439.  Found that the existing `testValidatorWithFieldMapping` test wasn't making sure that the password wasn't sent in the query which is why the tests were passing previously.  It now maps the validator keys according to the field mapping to correctly remove the data used in post-query validation from the query.
