### PR TITLE
Fix To $entity->modified() For Nested Data

### DIFF
--- a/data/Entity.php
+++ b/data/Entity.php
@@ -371,6 +371,10 @@ class Entity extends \lithium\core\Object {
 		$fields = array_fill_keys(array_keys($this->_data), false);
 		foreach ($this->_updated as $field => $value) {
 			if (is_object($value) && method_exists($value, 'modified')) {
+				if (!isset($this->_data[$field])) {
+					$fields[$field] = true;
+					continue;
+				}
 				$modified = $value->modified();
 				$fields[$field] = $modified === true || is_array($modified) && in_array(true, $modified, true);
 			} else {

--- a/tests/cases/data/entity/DocumentTest.php
+++ b/tests/cases/data/entity/DocumentTest.php
@@ -116,34 +116,77 @@ class DocumentTest extends \lithium\test\Unit {
 
 
 	public function testSyncModified() {
-		$doc = new Document();
+		$doc = new Document(array('model' => $this->_model));
 		$doc->id = 4;
 		$doc->name = 'Four';
 		$doc->content = 'Lorem ipsum four';
-
-		$expected = array(
-			'id' => true,
-			'name' => true,
-			'content' => true,
+		$doc->array = array(1, 2, 3, 4);
+		$doc->subdoc = array(
+			'setting' => 'something',
+			'foo' => 'bar',
+			'sub' => array(
+				'name' => 'A sub sub doc'
+			)
 		);
-		
+		$doc->subdocs = array(
+			array(
+				'id' => 1
+			),
+			array(
+				'id' => 2
+			),
+			array(
+				'id' => 3
+			),
+			array(
+				'id' => 4
+			)
+		);
+
+		$fields = array(
+			'id', 'name', 'content',
+			'array', 'subdoc', 'subdocs'
+		);
+		$expected = array_fill_keys($fields, true);
+
 		$this->assertEqual($expected, $doc->modified());
 		$doc->sync();
 
-		$this->assertEqual(array_fill_keys(array_keys($expected), false), $doc->modified());
-
+		$this->assertEqual(array_fill_keys($fields, false), $doc->modified());
 
 		$doc->id = 5;
 		$doc->content = null;
 		$doc->new = null;
-		$expected = array(
-			'id' => true,
-			'name' => false,
-			'content' => true,
-			'new' => true,
-		);
-		
+		$doc->subdoc->foo = 'baz';
+		$doc->array[] = 5;
+		$doc->subdocs[] = array('id' => 5);
+		$expected['name'] = false;
+		$expected['new'] = true;
+		$fields[] = 'new';
+
 		$this->assertEqual($expected, $doc->modified());
+		$doc->sync();
+
+		$expected = array_fill_keys($fields, false);
+
+		$this->assertEqual($expected, $doc->modified());
+		$doc->sync();
+
+		$doc->subdocs[1]->updated = true;
+		$expected['subdocs'] = true;
+
+		$this->assertEqual($expected, $doc->modified());
+		$doc->sync();
+
+		$expected = array_fill_keys($fields, false);
+
+		$doc->array[1] = array(
+			'foo' => 'bar'
+		);
+		$expected['array'] = true;
+
+		$this->assertEqual($expected, $doc->modified());
+		$doc->sync();
 	}
 
 	public function testNestedKeyGetSet() {


### PR DESCRIPTION
I found that the text for `$entity->modified()` from pull #423 wasn't testing for sub-documents, arrays, or document arrays.  I updated the test and made several modifications to fix the failures I found.

I'm nervous that we're still missing test cases.  Fixing modified() to not just assume every field is modified is pretty dangerous because if this goes to master with a bug, then people running on master will have incorrect data in their databases.
