### PR TITLE
Fix Command options parsing for underscored or dashed args

### DIFF
--- a/console/Router.php
+++ b/console/Router.php
@@ -34,7 +34,8 @@ class Router extends \lithium\core\Object {
 					$params[$match['key']] = true;
 					continue;
 				}
-				if (preg_match('/^--(?P<key>[a-z0-9-]+)(?:=(?P<val>.+))?$/i', $arg, $match)) {
+				if (preg_match('/^--(?P<key>[a-z0-9_\-]+)(?:=(?P<val>.+))?$/i', $arg, $match)) {
+					$match['key'] = str_replace('-', '_', $match['key']);
 					$params[$match['key']] = !isset($match['val']) ? true : $match['val'];
 					continue;
 				}

--- a/tests/cases/console/RouterTest.php
+++ b/tests/cases/console/RouterTest.php
@@ -71,6 +71,28 @@ class RouterTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 	}
 
+	public function testParseUnderscoredOrDashedOption() {
+		$expected = array(
+			'command' => 'test', 'action' => 'run', 'args' => array(),
+			'foo_bar' => 'something'
+		);
+		$result = Router::parse(new Request(array(
+			'args' => array(
+				'test', 'run',
+				'--foo_bar=something'
+			)
+		)));
+		$this->assertEqual($expected, $result);
+
+		$result = Router::parse(new Request(array(
+			'args' => array(
+				'test', 'run',
+				'--foo-bar=something'
+			)
+		)));
+		$this->assertEqual($expected, $result);
+	}
+
 	public function testParseShortOption() {
 		$expected = array(
 			'command' => 'test', 'action' => 'action', 'args' => array(),


### PR DESCRIPTION
Li3 command line options wasn't parsed correctly in case of an underscored option like `--foo_bar=something`.
Dashed options are converted to an underscored form. `--foo-bar` will be available at `$this->foo_bar`
