### PR TITLE
Allow for namespace prefixes in CLI commands

### DIFF
--- a/core/Libraries.php
+++ b/core/Libraries.php
@@ -843,7 +843,7 @@ class Libraries {
 			}
 
 			foreach (static::_searchPaths($paths, $library, $params) as $tpl) {
-				$params['library'] = $library;
+                $params['library'] = rtrim($config['prefix'], '\\');
 				$class = str_replace('\\*', '', String::insert($tpl, $params));
 
 				if (file_exists($file = Libraries::path($class, $options))) {


### PR DESCRIPTION
This resolves an issue I had where when using a prefix on the default app, li3 saw the command (and listed it in the help) but couldn't call it.

The replicate, create a command at:

`extensions/command/Foo.php` that looks like:

``` php
<?php
namespace foo\bar\baz;

class Foo extends extends \lithium\console\Command {
    public function run() {
        echo "hello world";
    }
}
?>
```

Then add to `bootstrap/libraries.php`:

``` php
<?php
Libraries::add('qux', array(
    'prefix' => 'foo\bar\baz\\',
    'default' => true,
));
?>
```

If you then call `li3` it will list the `foo` command, but when you try to run it with `li3 foo` it will return: `Command 'Foo' not found.`
