### PR TITLE
Make it so that li3 shell script still works in directories that have spaces in the names.

### DIFF
--- a/console/li3
+++ b/console/li3
@@ -5,5 +5,5 @@
 # @copyright     Copyright 2012, Union of RAD (http://union-of-rad.org)
 # @license       http://opensource.org/licenses/bsd-license.php The BSD License
 #
-SELF=$0; test -L $0 && SELF=$(readlink -n $0)
-php -f $(dirname $SELF)/lithium.php -- "$@"
+SELF=$0; test -L "$0" && SELF=$(readlink -n $0)
+php -f "$(dirname "$SELF")"/lithium.php -- "$@"


### PR DESCRIPTION
console/li3 doesn't currently work on directories that have spaces in the names.  This commit makes it so it still works when there's a space in the directory name.
