### PR TITLE
Fix for issue #448.  li3 help now converts commands to CamelCase

### DIFF
--- a/console/command/Help.php
+++ b/console/command/Help.php
@@ -27,7 +27,7 @@ class Help extends \lithium\console\Command {
 	 * @return void
 	 */
 	public function run($command = null) {
-	    $message = 'Lithium console started in the ' . Environment::get() . ' environment.';
+		$message = 'Lithium console started in the ' . Environment::get() . ' environment.';
 		$message .= ' Use the --env=environment key to alter this.';
 		$this->out($message);
 
@@ -37,7 +37,7 @@ class Help extends \lithium\console\Command {
 		}
 
 		if (!preg_match('/\\\\/', $command)) {
-			$command = ucwords($command);
+			$command = Inflector::camelize($command);
 		}
 
 		if (!$class = Libraries::locate('command', $command)) {

--- a/tests/cases/console/command/HelpTest.php
+++ b/tests/cases/console/command/HelpTest.php
@@ -67,6 +67,20 @@ class HelpTest extends \lithium\test\Unit {
 		$expected = preg_quote($expected);
 		$result = $command->response->output;
 		$this->assertPattern("/{$expected}/", $result);
+
+		$expected = "Command `TestWithDashes` not found";
+		$expected = preg_quote($expected);
+		$result = $command->run('test-with-dashes');
+		$this->assertFalse($result);
+		$result = $command->response->error;
+		$this->assertPattern("/{$expected}/", $result);
+
+		$expected = "Command `TestWithUnderscores` not found";
+		$expected = preg_quote($expected);
+		$result = $command->run('test_with_underscores');
+		$this->assertFalse($result);
+		$result = $command->response->error;
+		$this->assertPattern("/{$expected}/", $result);
 	}
 
 	public function testApiClass() {


### PR DESCRIPTION
Note - this expects people to not name their command classes with underscores.
