### PR TITLE
Provide low verbose to li3 test for skipped tests

### DIFF
--- a/console/command/Test.php
+++ b/console/command/Test.php
@@ -52,21 +52,13 @@ class Test extends \lithium\console\Command {
 	public $format = 'txt';
 
 	/**
-	 * Enable verbose output especially for the `txt` format.
+	 * Enable verbose output especially for the `txt` format. Options are `high` 
+	 * (default if none given) for full details and `skipped` for only information
+	 * on the skipped tests.
 	 *
-	 * @var boolean
+	 * @var string
 	 */
 	public $verbose = false;
-
-	/**
-	 * Enable output displaying skipped tests in the `txt` format.
-	 *
-	 * This can be seen as a little verbose mode. The `verbose` shows
-	 * the skipped tests by default.
-	 *
-	 * @var boolean
-	 */
-	public $showskipped = false;
 	
 	/**
 	 * Enable plain mode to prevent any headers or similar decoration being output.
@@ -83,6 +75,16 @@ class Test extends \lithium\console\Command {
 	 * @var array
 	 */
 	protected $_handlers = array();
+	
+	public function verboseLevel() {
+		if ($this->verbose === false) {
+			return false;
+		}
+		if ($this->verbose === 'skipped') {
+				return 'skipped';
+		}
+		return 'high';
+	}
 
 	/**
 	 * Initializes the output handlers.
@@ -120,7 +122,7 @@ class Test extends \lithium\console\Command {
 					}
 				};
 
-				if ($command->verbose) {
+				if ($command->verboseLevel() == 'high') {
 					$reporter = function($result) use ($command, $colorize) {
 						$command->out(sprintf(
 							'[%s] on line %4s in %s::%s()',
@@ -161,7 +163,7 @@ class Test extends \lithium\console\Command {
 					$command->out($report->render('result', $stats));
 					$command->out($report->render('errors', $stats));
 
-					if ($command->verbose || $command->showskipped) {
+					if ($command->verboseLevel()) {
 						$command->out($report->render('skips', $stats));
 					}
 

--- a/console/command/Test.php
+++ b/console/command/Test.php
@@ -59,6 +59,16 @@ class Test extends \lithium\console\Command {
 	public $verbose = false;
 
 	/**
+	 * Enable output displaying skipped tests in the `txt` format.
+	 *
+	 * This can be seen as a little verbose mode. The `verbose` shows
+	 * the skipped tests by default.
+	 *
+	 * @var boolean
+	 */
+	public $showskipped = false;
+	
+	/**
 	 * Enable plain mode to prevent any headers or similar decoration being output.
 	 * Good for command calls embedded into other scripts.
 	 *
@@ -151,7 +161,7 @@ class Test extends \lithium\console\Command {
 					$command->out($report->render('result', $stats));
 					$command->out($report->render('errors', $stats));
 
-					if ($command->verbose) {
+					if ($command->verbose || $command->showskipped) {
 						$command->out($report->render('skips', $stats));
 					}
 

--- a/tests/cases/console/command/HelpTest.php
+++ b/tests/cases/console/command/HelpTest.php
@@ -54,7 +54,7 @@ class HelpTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$expected  = 'li3 test [--filters=<string>]';
-		$expected .= ' [--format=<string>] [--verbose] [--plain] [<path>]';
+		$expected .= ' [--format=<string>] [--verbose] [--showskipped] [--plain] [<path>]';
 		$expected = preg_quote($expected);
 		$result = $command->response->output;
 		$this->assertPattern("/{$expected}/", $result);

--- a/tests/cases/console/command/HelpTest.php
+++ b/tests/cases/console/command/HelpTest.php
@@ -54,7 +54,7 @@ class HelpTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$expected  = 'li3 test [--filters=<string>]';
-		$expected .= ' [--format=<string>] [--verbose] [--showskipped] [--plain] [<path>]';
+		$expected .= ' [--format=<string>] [--verbose=<string>] [--plain] [<path>]';
 		$expected = preg_quote($expected);
 		$result = $command->response->output;
 		$this->assertPattern("/{$expected}/", $result);


### PR DESCRIPTION
li3 test now only shows that tests have been skipped, and only with verbose you can identify them. But verbose is very verbose. With this flag, test shows the normal test output followed by the skipped tests.
