### PR TITLE
Updated docs for Model::$_schema.

### DIFF
--- a/data/Model.php
+++ b/data/Model.php
@@ -244,6 +244,19 @@ class Model extends \lithium\core\StaticObject {
 	 * a collection, along with a `'data'` key, which contains the schema for that collection, in
 	 * the format specified above.
 	 *
+	 * When defining `'$_schema'` where the data source is MongoDB, the types map to database types as follows:
+	 *
+	 * {{{
+	 *	id      => MongoId
+	 *	date    => MongoDate
+	 *	regex   => MongoRegex
+	 *	integer => integer
+	 *	float   => float
+	 *	boolean => boolean
+	 *	code    => MongoCode
+	 *	binary  => MongoBinData
+	 * }}}
+	 *
 	 * @see lithium\data\source\MongoDb::$_schema
 	 * @var array
 	 */


### PR DESCRIPTION
Added a list of types and what underlying database types they map to when using MongoDB as data source.
