### PR TITLE
Expression support for SQL compatible datasources and value casting

### DIFF
--- a/data/source/Database.php
+++ b/data/source/Database.php
@@ -190,24 +190,23 @@ abstract class Database extends \lithium\data\Source {
 			}
 			return $value;
 		}
+
+		if (is_object($value)) {
+			return $value->value;
+		}
+
 		if ($value === null) {
 			return 'NULL';
 		}
+
 		switch ($type = isset($schema['type']) ? $schema['type'] : $this->_introspectType($value)) {
 			case 'boolean':
-				return $this->_toNativeBoolean($value);
 			case 'float':
-				return floatval($value);
 			case 'integer':
-				return intval($value);
-			case 'timestamp':
-				if ($value === 'CURRENT_TIMESTAMP') {
-					return 'NULL';
-				} else if (is_numeric($value)) {
-					return date('Y-m-d H:i:s', $value);
-				} else {
-					return strtotime($value);
-				}
+				return $this->_cast($type, $value);
+				break;
+			default:
+				return $this->connection->quote($this->_cast($type, $value));
 		}
 	}
 
@@ -940,6 +939,37 @@ abstract class Database extends \lithium\data\Source {
 
 	public function cast($entity, array $data, array $options = array()) {
 		return $data;
+	}
+
+	/**
+	 * Cast a value according to a column type.
+	 *
+	 * @param string $type Name of the column type
+	 * @param string $value Value to cast
+	 *
+	 * @return mixed Casted value
+	 *
+	 */
+	protected function _cast($type, $value) {
+		if (is_object($value) || $value === null) {
+			return $value;
+		}
+		if ($type == 'boolean') {
+			return $this->_toNativeBoolean($value);
+		} elseif (isset($this->_columns[$type])) {
+			$column = $this->_columns[$type];
+			if (isset($column['formatter'])) {
+				switch ($column['formatter']) {
+					case 'date':
+						return $column['formatter']($column['format'], strtotime($value));
+					break;
+					default:
+						return $column['formatter']($value);
+					break;
+				}
+			}
+		}
+		return $value;
 	}
 
 	protected function _createFields($data, $schema, $context) {

--- a/data/source/database/Expr.php
+++ b/data/source/database/Expr.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2012, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\data\source\database;
+
+class Expr {
+
+    public $value;
+
+	public function __construct($value) {
+		$this->value = $value;
+	}
+}
+?>

--- a/tests/cases/data/source/DatabaseTest.php
+++ b/tests/cases/data/source/DatabaseTest.php
@@ -11,6 +11,7 @@ namespace lithium\tests\cases\data\source;
 use lithium\data\model\Query;
 use lithium\data\entity\Record;
 use lithium\data\collection\RecordSet;
+use lithium\data\source\database\Expr;
 use lithium\tests\mocks\data\model\MockDatabase;
 use lithium\tests\mocks\data\model\MockDatabasePost;
 use lithium\tests\mocks\data\model\MockDatabaseComment;
@@ -94,14 +95,29 @@ class DatabaseTest extends \lithium\test\Unit {
 		$result = $this->db->value('1', array('type' => 'string'));
 		$this->assertIdentical("'1'", $result);
 
-		$result = $this->db->value('CURRENT_TIMESTAMP', array('type' => 'timestamp'));
-		$this->assertIdentical('NULL', $result);
+		$result = $this->db->value(new Expr('CURRENT_TIMESTAMP'), array('type' => 'timestamp'));
+		$this->assertIdentical('CURRENT_TIMESTAMP', $result);
 
-		$result = $this->db->value('1234567', array('type' => 'timestamp'));
-		$this->assertIdentical(date('Y-m-d H:i:s', 1234567), $result);
+		$result = $this->db->value(new Expr('REGEXP "^fo$"'));
+		$this->assertIdentical('REGEXP "^fo$"', $result);
+
+		$result = $this->db->value('Hello World', array('type' => 'timestamp'));
+		$this->assertIdentical("'1970-01-01 01:00:00'", $result);
+
+		$result = $this->db->value('2012-05-25 22:44:00', array('type' => 'timestamp'));
+		$this->assertIdentical("'2012-05-25 22:44:00'", $result);
+
+		$result = $this->db->value('2012-05-25', array('type' => 'date'));
+		$this->assertIdentical("'2012-05-25'", $result);
 
 		$result = $this->db->value('now', array('type' => 'timestamp'));
-		$this->assertIdentical(time(), $result);
+		$this->assertPattern("/^'\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}'/", $result);
+
+		$result = $this->db->value('now', array('type' => 'date'));
+		$this->assertPattern("/^'\d{4}-\d{2}-\d{2}'/", $result);
+
+		$result = $this->db->value('now', array('type' => 'time'));
+		$this->assertPattern("/^'\d{2}:\d{2}:\d{2}'/", $result);
 	}
 
 	public function testValueByIntrospect() {
@@ -571,7 +587,9 @@ class DatabaseTest extends \lithium\test\Unit {
 				'or' => array(
 					'id' => 'value1',
 					'title' => 'value2',
-					'and' => array('author_id' => '1', 'created' => '2'),
+					'and' => array(
+						'author_id' => '1', 
+						'created' => '2012-05-25 23:41:00'),
 					array('title' => 'value2'),
 					array('title' => null)
 				),
@@ -581,7 +599,7 @@ class DatabaseTest extends \lithium\test\Unit {
 		));
 		$sql = "SELECT * FROM {mock_database_posts} AS {MockDatabasePost} WHERE ";
 		$sql .= "({MockDatabasePost}.{id} = 0 OR {MockDatabasePost}.{title} = 'value2' OR ";
-		$sql .= "({MockDatabasePost}.{author_id} = 1 AND {MockDatabasePost}.{created} = '2') OR ";
+		$sql .= "({MockDatabasePost}.{author_id} = 1 AND {MockDatabasePost}.{created} = '2012-05-25 23:41:00') OR ";
 		$sql .= "({MockDatabasePost}.{title} = 'value2') OR ({MockDatabasePost}.{title} IS NULL)) AND ";
 		$sql .= "{MockDatabasePost}.{id} = 3 AND {MockDatabasePost}.{author_id} = 0;";
 		$this->assertEqual($sql, $this->db->renderCommand($query));
@@ -603,7 +621,9 @@ class DatabaseTest extends \lithium\test\Unit {
 				'or' => array(
 					'id' => 'value1',
 					'title' => 'value2',
-					'and' => array('author_id' => '1', 'created' => '2'),
+					'and' => array(
+						'author_id' => '1', 
+						'created' => '2012-05-25 23:41:00'),
 					array('title' => 'value2'),
 					array('title' => null)
 				),
@@ -613,7 +633,7 @@ class DatabaseTest extends \lithium\test\Unit {
 		));
 		$sql = "SELECT * FROM {mock_database_posts} AS {MockDatabasePost} HAVING ";
 		$sql .= "({MockDatabasePost}.{id} = 0 OR {MockDatabasePost}.{title} = 'value2' OR ";
-		$sql .= "({MockDatabasePost}.{author_id} = 1 AND {MockDatabasePost}.{created} = '2') OR ";
+		$sql .= "({MockDatabasePost}.{author_id} = 1 AND {MockDatabasePost}.{created} = '2012-05-25 23:41:00') OR ";
 		$sql .= "({MockDatabasePost}.{title} = 'value2') OR ({MockDatabasePost}.{title} IS NULL)) AND ";
 		$sql .= "{MockDatabasePost}.{id} = 3 AND {MockDatabasePost}.{author_id} = 0;";
 		$this->assertEqual($sql, $this->db->renderCommand($query));

--- a/tests/mocks/data/model/MockDatabase.php
+++ b/tests/mocks/data/model/MockDatabase.php
@@ -12,9 +12,41 @@ use lithium\tests\mocks\data\model\mock_database\MockResult;
 
 class MockDatabase extends \lithium\data\source\Database {
 
+	/**
+	 * Mock column type definitions.
+	 *
+	 * @var array
+	 */
+	protected $_columns = array(
+		'primary_key' => array('name' => 'NOT NULL AUTO_INCREMENT'),
+		'string' => array('name' => 'varchar', 'length' => 255),
+		'text' => array('name' => 'text'),
+		'integer' => array('name' => 'int', 'length' => 11, 'formatter' => 'intval'),
+		'float' => array('name' => 'float', 'formatter' => 'floatval'),
+		'datetime' => array('name' => 'datetime', 'format' => 'Y-m-d H:i:s', 'formatter' => 'date'),
+		'timestamp' => array(
+			'name' => 'timestamp', 'format' => 'Y-m-d H:i:s', 'formatter' => 'date'
+		),
+		'time' => array('name' => 'time', 'format' => 'H:i:s', 'formatter' => 'date'),
+		'date' => array('name' => 'date', 'format' => 'Y-m-d', 'formatter' => 'date'),
+		'binary' => array('name' => 'blob'),
+		'boolean' => array('name' => 'tinyint', 'length' => 1)
+	);
+
 	public $sql = null;
 
+	public $connection = null;
+
 	protected $_quotes = array('{', '}');
+
+	public function __construct(array $config = array()) {
+		parent::__construct($config);
+		$this->connection = $this;
+	}
+
+	public function quote($value) {
+		return "'{$value}'";
+	}
 
 	public function connect() {
 		return true;


### PR DESCRIPTION
I don't see any other way to support all SQL expressions. Not very elegant but does the job. Sugestions are welcome. Close #28 and #402.
