### PR TITLE
Fixing an issue where strategies were applied to incorrect session configurations

### DIFF
--- a/storage/Session.php
+++ b/storage/Session.php
@@ -147,16 +147,17 @@ class Session extends \lithium\core\Adaptable {
 			}
 		}
 		$result = false;
-		$settings = static::_config($name);
 
-		if ($options['strategies']) {
-			$options += array('key' => $key, 'class' => __CLASS__);
-			$value = static::applyStrategies(__FUNCTION__, $name, $value, $options);
-		}
-		$params = compact('key', 'value', 'options');
+		$original = $value;
 
 		foreach ($methods as $name => $method) {
+			$settings = static::_config($name);
 			$filters = $settings['filters'];
+			if ($options['strategies']) {
+				$options += array('key' => $key, 'class' => __CLASS__);
+				$value = static::applyStrategies(__FUNCTION__, $name, $original, $options);
+			}
+			$params = compact('key', 'value', 'options');
 			$result = static::_filter(__FUNCTION__, $params, $method, $filters) || $result;
 		}
 		return $result;
@@ -192,15 +193,15 @@ class Session extends \lithium\core\Adaptable {
 		}
 		$result = false;
 		$options += array('key' => $key, 'class' => __CLASS__);
-
-		if ($options['strategies']) {
-			$options += array('key' => $key, 'class' => __CLASS__);
-			$key = static::applyStrategies(__FUNCTION__, $name, $key, $options);
-		}
-		$params = compact('key', 'options');
+		$original = $key;
 
 		foreach ($methods as $name => $method) {
 			$settings = static::_config($name);
+			if ($options['strategies']) {
+				$options += array('key' => $key, 'class' => __CLASS__);
+				$key = static::applyStrategies(__FUNCTION__, $name, $original, $options);
+			}
+			$params = compact('key', 'options');
 			$filters = $settings['filters'];
 			$result = static::_filter(__FUNCTION__, $params, $method, $filters) || $result;
 		}

--- a/tests/cases/storage/SessionTest.php
+++ b/tests/cases/storage/SessionTest.php
@@ -246,6 +246,31 @@ class SessionTest extends \lithium\test\Unit {
 		$this->assertFalse(Session::check('test', array('strategies' => false)));
 	}
 
+	public function testMultipleStrategies() {
+		Session::config(array(
+			'primary' => array(
+				'adapter' => new Memory(),
+				'filters' => array(),
+				'strategies' => array()
+			),
+			'secondary' => array(
+				'adapter' => new Memory(),
+				'filters' => array(),
+				'strategies' => array('lithium\storage\cache\strategy\Json')
+			)
+		));
+
+		Session::write('test', array('foo' => 'bar'));
+		$result = Session::read('test');
+		$this->assertEqual(array('foo' => 'bar'), $result);
+
+		$result = Session::read('test', array('name' => 'primary', 'strategies' => false));
+		$this->assertEqual(array('foo' => 'bar'), $result);
+
+		$result = Session::read('test', array('name' => 'secondary', 'strategies' => false));
+		$this->assertEqual('{"foo":"bar"}', $result);
+	}
+
 	public function testEncryptedStrategy() {
 		$this->skipIf(!MockEncrypt::enabled(), 'The Mcrypt extension is not installed or enabled.');
 


### PR DESCRIPTION
Also added 'configuration' to the filter params so the filters know which session configuration it is processing.

Basically here's what I was trying to do:

Have a default session that I use for normal things.  But then have a long lived cookie session adapter that uses an encrypted data strategy.

I found that my default session was getting encrypted too and causing all types of trouble.

This patch fixes that bug (with a test case).  I also added `'configuration'` to the filter params because without it, my filter had no idea which configuration was being filtered.

I'm using filters to get the methods to only write to my default configuration unless I specifically name a configuration in the options.  By default, Lithium writes, clears, deletes, and checks all session adapters (but only reads from the first named session adapter).
