### PR TITLE
Fixed an issue with the form helper where the value zero would not display

### DIFF
--- a/template/helper/Form.php
+++ b/template/helper/Form.php
@@ -344,9 +344,9 @@ class Form extends \lithium\template\Helper {
 	/**
 	 * Returns the entity that the `Form` helper is currently bound to.
 	 *
+	 * @see lithium\template\helper\Form::$_binding
 	 * @param string $name If specified, match this field name against the list of bindings
 	 * @param string $key If $name specified, where to store relevant $_binding key
-	 * @see lithium\template\helper\Form::$_binding
 	 * @return object Returns an object, usually an instance of `lithium\data\Entity`.
 	 */
 	public function binding($name = null) {
@@ -786,10 +786,14 @@ class Form extends \lithium\template\Helper {
 			(!isset($options['value']) || $options['value'] === null) &&
 			$name && $value = $this->binding($name)->data
 		);
-		if ($hasValue) {
+		$isZero = (isset($value) && ($value === 0 || $value === "0"));
+		if ($hasValue || $isZero) {
 			$options['value'] = $value;
 		}
-		if (isset($options['default']) && empty($options['value'])) {
+		if (isset($options['value']) && !$isZero) {
+			$isZero = ($options['value'] === 0 || $options['value'] === "0");
+		}
+		if (isset($options['default']) && empty($options['value']) && !$isZero) {
 			$options['value'] = $options['default'];
 		}
 		unset($options['default']);

--- a/tests/cases/template/helper/FormTest.php
+++ b/tests/cases/template/helper/FormTest.php
@@ -173,7 +173,9 @@ class FormTest extends \lithium\test\Unit {
 			'id' => '5',
 			'author_id' => '2',
 			'title' => 'This is a saved post',
-			'body' => 'This is the body of the saved post'
+			'body' => 'This is the body of the saved post',
+			'zeroInt' => 0,
+			'zeroString' => "0"
 		)));
 
 		$result = $this->form->create($record);
@@ -185,6 +187,18 @@ class FormTest extends \lithium\test\Unit {
 		$this->assertTags($result, array('input' => array(
 			'type' => 'text', 'name' => 'title',
 			'value' => 'This is a saved post', 'id' => 'MockFormPostTitle'
+		)));
+
+
+		$result = $this->form->text('zeroInt');
+		$this->assertTags($result, array('input' => array(
+			'type' => 'text', 'name' => 'zeroInt',
+			'value' => '0', 'id' => 'MockFormPostZeroInt'
+		)));
+		$result = $this->form->text('zeroString');
+		$this->assertTags($result, array('input' => array(
+			'type' => 'text', 'name' => 'zeroString',
+			'value' => '0', 'id' => 'MockFormPostZeroString'
 		)));
 
 		$this->assertEqual('</form>', $this->form->end());
@@ -382,12 +396,16 @@ class FormTest extends \lithium\test\Unit {
 			))
 		));
 
-		$document = new Document(array('model' => $this->_model, 'data' => array('subdocument' => array('foo' => true))));
+		$document = new Document(array('model' => $this->_model, 'data' =>
+			array('subdocument' => array('foo' => true))
+		));
 		$this->form->create($document);
 
 		$result = $this->form->checkbox('subdocument.foo');
 		$this->assertTags($result, array(
-			array('input' => array('type' => 'hidden', 'value' => '', 'name' => 'subdocument[foo]')),
+			array('input' => array(
+				'type' => 'hidden', 'value' => '', 'name' => 'subdocument[foo]')
+			),
 			array('input' => array(
 				'type' => 'checkbox', 'value' => '1', 'name' => 'subdocument[foo]',
 				'checked' => 'checked', 'id' => 'MockFormPostSubdocumentFoo'
@@ -614,7 +632,8 @@ class FormTest extends \lithium\test\Unit {
 
 	/**
 	 * When trying to determine which option of a select box should be selected, we should be
-	 * int/string agnostic because it all looks the same in HTML.
+	 * integer/string agnostic because it all looks the same in HTML.
+	 *
 	 */
 	public function testSelectTypeAgnosticism() {
 		$taglist = array(


### PR DESCRIPTION
See http://stackoverflow.com/questions/10819825/lithium-not-rendering-zero-0-in-form/10824838

I confirmed the issue.  Basically has to do with assignment of falsy values and use of `empty()`.
