### PR TITLE
WARNING: backwards-incompatible change to Model::config()

### DIFF
--- a/data/Model.php
+++ b/data/Model.php
@@ -289,21 +289,45 @@ class Model extends \lithium\core\StaticObject {
 	protected static $_instanceMethods = array();
 
 	/**
-	 * Configures the model for use.
+	 * Holds an array of values that should be processed on `Model::config()`. Each value should
+	 * have a matching protected property (prefixed with `_`) defined in the class. If the
+	 * property is an array, the property name should be the key and the value should be `'merge'`.
 	 *
-	 * This method will set the `Model::$_meta` class attributes.
-	 *
-	 * @param array $options Meta-information for this model, such as the connection.
+	 * @see lithium\data\Model::config()
+	 * @var array
 	 */
-	public static function config(array $options = array()) {
+	protected static $_autoConfig = array('meta', 'finders', 'query', 'schema', 'classes');
+
+	/**
+	 * Configures the model for use. This method will set the `Model::$_schema`, `Model::$_meta`,
+	 * `Model::$_finders` class attributes, as well as obtain a handle to the configured
+	 * persistent storage connection.
+	 *
+	 * @param array $config Possible options are:
+	 *        - `meta`: Meta-information for this model, such as the connection.
+	 *        - `finders`: Custom finders for this model.
+	 *        - `query`: Default query parameters.
+	 *        - `schema`: A `Schema` instance for this model.
+	 *        - `classes`: Classes used by this model.
+	 */
+	public static function config(array $config = array()) {
 		if (($class = get_called_class()) === __CLASS__) {
 			return;
 		}
-		
+
 		if (!isset(static::$_instances[$class])) {
 			static::$_instances[$class] = new $class();
 		}
-		static::$_instances[$class]->_meta = $options + static::$_instances[$class]->_meta;
+		$self = static::$_instances[$class];
+
+		foreach (static::$_autoConfig as $key) {
+			if (isset($config[$key])) {
+				$_key = "_{$key}";
+				$val = $config[$key];
+				$self->$_key = is_array($val) ? $val + $self->$_key : $val;
+			}
+		}
+
 		static::$_initialized[$class] = false;
 	}
 
@@ -325,6 +349,7 @@ class Model extends \lithium\core\StaticObject {
 		static::$_initialized[$class] = true;
 
 		$query   = array();
+		$finders = array();
 		$meta    = array();
 		$schema  = array();
 		$source  = array();
@@ -333,9 +358,10 @@ class Model extends \lithium\core\StaticObject {
 		foreach (static::_parents() as $parent) {
 			$parentConfig = get_class_vars($parent);
 
-			foreach (array('meta', 'schema', 'classes', 'query') as $key) {
+			foreach (static::$_autoConfig as $key) {
 				if (isset($parentConfig["_{$key}"])) {
-					${$key} += $parentConfig["_{$key}"];
+					$val = $parentConfig["_{$key}"];
+					${$key} = is_array($val) ? ${$key} + $val : $val;
 				}
 			}
 			if ($parent == __CLASS__) {
@@ -356,6 +382,10 @@ class Model extends \lithium\core\StaticObject {
 		$local = compact('class', 'name') + $self->_meta;
 		$self->_meta = ($local + $source['meta'] + $meta);
 		$self->_meta['initialized'] = false;
+
+		if (is_object($schema)) {
+			$schema = $schema->fields();
+		}
 		$self->schema()->append($schema + $source['schema']);
 
 		$self->_finders += $source['finders'] + $self->_findFilters();
@@ -481,6 +511,30 @@ class Model extends \lithium\core\StaticObject {
 			return isset($self->_finders[$name]) ? $self->_finders[$name] : null;
 		}
 		$self->_finders[$name] = $finder;
+	}
+
+	/**
+	 * Gets or sets the default query for the model.
+	 *
+	 * @param array $query.  Possible options are:
+	 *        - `'conditions'`: The conditional query elements, e.g.
+	 *          `'conditions' => array('published' => true)`
+	 *        - `'fields'`: The fields that should be retrieved. When set to `null`, defaults to
+	 *          all fields.
+	 *        - `'order'`: The order in which the data will be returned, e.g. `'order' => 'ASC'`.
+	 *        - `'limit'`: The maximum number of records to return.
+	 *        - `'page'`: For pagination of data.
+	 *        - `'with'`: An array of relationship names to be included in the query.
+	 *
+	 * @return mixed Returns the query definition if querying, or `null` if setting.
+	 */
+	public static function query($query = null) {
+		$self = static::_object();
+
+		if (!$query) {
+			return $self->_query;
+		}
+		$self->_query += $query;
 	}
 
 	/**
@@ -1133,6 +1187,14 @@ class Model extends \lithium\core\StaticObject {
 				return $self::connection()->calculation('count', $query, $options);
 			}
 		);
+	}
+
+	/**
+	 * Reseting the model
+	 */
+	public static function reset() {
+		$class = get_called_class();
+		unset(static::$_instances[$class]);
 	}
 }
 

--- a/tests/cases/data/CollectionTest.php
+++ b/tests/cases/data/CollectionTest.php
@@ -47,7 +47,7 @@ class CollectionTest extends \lithium\test\Unit {
 	 */
 	public function testAccessorMethods() {
 		$model = $this->_model;
-		$model::config(array('connection' => false, 'key' => 'id'));
+		$model::config(array('meta' => array('connection' => false, 'key' => 'id')));
 		$collection = new DocumentSet(compact('model'));
 		$this->assertEqual($model, $collection->model());
 		$this->assertEqual(compact('model'), $collection->meta());

--- a/tests/cases/data/ModelTest.php
+++ b/tests/cases/data/ModelTest.php
@@ -11,6 +11,7 @@ namespace lithium\tests\cases\data;
 use stdClass;
 use lithium\data\Model;
 use lithium\data\Entity;
+use lithium\data\Schema;
 use lithium\data\model\Query;
 use lithium\data\entity\Record;
 use lithium\tests\mocks\data\MockTag;
@@ -25,29 +26,49 @@ class ModelTest extends \lithium\test\Unit {
 
 	protected $_database = 'lithium\tests\mocks\data\MockSource';
 
-	protected $_altSchema = array(
-		'id' => array('type' => 'integer'),
-		'author_id' => array('type' => 'integer'),
-		'title' => array('type' => 'string'),
-		'body' => array('type' => 'text')
-	);
+	protected $_altSchema = null;
 
 	public function setUp() {
 		$database = $this->_database;
 
-		MockPost::resetSchema(true);
-		MockPost::config();
-		MockTag::config();
-		MockComment::config();
+		$class = 'lithium\tests\mocks\data\MockPost';
+		$connection = new $database();
+		MockPost::$connection = $connection;
+		MockTag::$connection = $connection;
+		MockComment::$connection = $connection;
+		MockCreator::$connection = $connection;
 
-		MockPost::$connection = new $database();
-		MockTag::$connection = new $database();
-		MockComment::$connection = new $database();
+		$config = MockPost::$connection->configureClass($class);
+		MockPost::config(array('meta' => array('connection' => true) + $config['meta']));
+		MockTag::config(array('meta' => array('connection' => true)));
+		MockComment::config(array('meta' => array('connection' => true)));
+		MockCreator::config(array('meta' => array('connection' => true)));
+		MockPostForValidates::config(array('meta' => array('locked' => true)));
+
+		$this->_altSchema = new Schema(array(
+			'fields' => array(
+				'id' => array('type' => 'integer'),
+				'author_id' => array('type' => 'integer'),
+				'title' => array('type' => 'string'),
+				'body' => array('type' => 'text')
+		)));
+	}
+
+	public function tearDown() {
+		MockPost::$connection = null;
+		MockTag::$connection = null;
+		MockComment::$connection = null;
+		MockCreator::$connection = null;
+		MockPost::reset();
+		MockTag::reset();
+		MockComment::reset();
+		MockPostForValidates::reset();
+		MockCreator::reset();
 	}
 
 	public function testOverrideMeta() {
+		MockTag::reset();
 		$meta = MockTag::meta(array('id' => 'key'));
-
 		$this->assertFalse($meta['connection']);
 		$this->assertEqual('mock_tags', $meta['source']);
 		$this->assertEqual('key', $meta['id']);
@@ -57,24 +78,62 @@ class ModelTest extends \lithium\test\Unit {
 		$expected = MockPost::instances();
 		MockPost::config();
 		$this->assertEqual($expected, MockPost::instances());
-
 		Model::config();
 		$this->assertEqual($expected, MockPost::instances());
 
 		$this->assertEqual('mock_posts', MockPost::meta('source'));
 
-		MockPost::config(array('source' => 'post'));
+		MockPost::config(array('meta' => array('source' => 'post')));
 		$this->assertEqual('post', MockPost::meta('source'));
 
-		MockPost::config(array('source' => false));
+		MockPost::config(array('meta' => array('source' => false)));
 		$this->assertIdentical(false, MockPost::meta('source'));
 
-		MockPost::config(array('source' => null));
+		MockPost::config(array('meta' => array('source' => null)));
 		$this->assertIdentical('mock_posts', MockPost::meta('source'));
 
 		MockPost::config();
 		$this->assertEqual('mock_posts', MockPost::meta('source'));
+		$this->assertTrue(MockPost::meta('connection'));
+
+		MockPost::config(array('meta' => array('source' => 'toreset')));
+		MockPost::reset();
+		$this->assertEqual('mock_posts', MockPost::meta('source'));
 		$this->assertFalse(MockPost::meta('connection'));
+
+		MockPost::config(array('query' => array('with' => array('MockComment'), 'limit' => 10)));
+		$expected =  array(
+			'with' => array('MockComment'),
+			'limit' => 10,
+			'conditions' => null,
+			'fields' => null,
+			'order' => null,
+			'page' => null
+		);
+		$this->assertEqual($expected, MockPost::query());
+
+		$finder = array(
+			'fields' => array('title', 'body')
+		);
+		MockPost::finder('myFinder', $finder);
+		$result = MockPost::find('myFinder');
+		$expected = $finder + array(
+			'order' => null,
+			'limit' => 10,
+			'conditions' => null,
+			'page' => null,
+			'with' => array('MockComment'),
+			'type' => 'read',
+			'model' => 'lithium\tests\mocks\data\MockPost'
+		);
+		$this->assertEqual($expected, $result['options']);
+
+		$finder = array(
+			'fields' => array('id', 'title')
+		);
+		MockPost::reset();
+		$result = MockPost::finder('myFinder');
+		$this->assertNull($result);
 	}
 
 	public function testInstanceMethods() {
@@ -110,8 +169,8 @@ class ModelTest extends \lithium\test\Unit {
 			'initialized' => true,
 			'locked'      => true
 		);
-		MockPost::resetSchema(true);
-		MockPost::config(array('connection' => true) + $config['meta']);
+
+		MockPost::config(array('meta' => array('connection' => true) + $config['meta']));
 		$this->assertEqual($expected, MockPost::meta());
 
 		$class = 'lithium\tests\mocks\data\MockComment';
@@ -126,8 +185,8 @@ class ModelTest extends \lithium\test\Unit {
 			'locked'      => true
 		);
 		unset($config['meta']['key']);
-		MockComment::resetSchema(true);
-		MockComment::config(array('connection' => true) + $config['meta']);
+
+		MockComment::config(array('meta' => array('connection' => true) + $config['meta']));
 		$this->assertEqual($expected, MockComment::meta());
 
 		$expected += array('foo' => 'bar');
@@ -140,9 +199,10 @@ class ModelTest extends \lithium\test\Unit {
 	public function testSchemaLoading() {
 		$result = MockPost::schema();
 		$this->assertTrue($result);
-
-		MockPost::resetSchema(true);
 		$this->assertEqual($result->fields(), MockPost::schema()->fields());
+
+		MockPost::config(array('schema' => $this->_altSchema));
+		$this->assertEqual($this->_altSchema->fields(), MockPost::schema()->fields());
 	}
 
 	public function testFieldIntrospection() {
@@ -159,9 +219,9 @@ class ModelTest extends \lithium\test\Unit {
 	 * @return void
 	 */
 	public function testRelationshipIntrospection() {
-		MockPost::config(array('connection' => true));
-		MockComment::config(array('connection' => true));
-		MockTag::config(array('connection' => true));
+		MockPost::config(array('meta' => array('connection' => true)));
+		MockComment::config(array('meta' => array('connection' => true)));
+		MockTag::config(array('meta' => array('connection' => true)));
 
 		$result = array_keys(MockPost::relations());
 		$expected = array('MockComment');
@@ -214,9 +274,9 @@ class ModelTest extends \lithium\test\Unit {
 		$expected = array('MockPost.id' => 'MockComment.mock_post_id');
 		$this->assertEqual($expected, MockPost::relations('MockComment')->constraints());
 
-		MockPost::config(array('connection' => false));
-		MockComment::config(array('connection' => false));
-		MockTag::config(array('connection' => false));
+		MockPost::config(array('meta' => array('connection' => false)));
+		MockComment::config(array('meta' => array('connection' => false)));
+		MockTag::config(array('meta' => array('connection' => false)));
 	}
 
 	public function testSimpleRecordCreation() {
@@ -503,8 +563,6 @@ class ModelTest extends \lithium\test\Unit {
 	}
 
 	public function testDefaultValuesFromSchema() {
-		MockCreator::$connection = MockPost::$connection;
-		MockCreator::resetSchema(true);
 		$creator = MockCreator::create();
 
 		$expected = array(
@@ -543,13 +601,14 @@ class ModelTest extends \lithium\test\Unit {
 	}
 
 	public function testModelWithNoBackend() {
+		MockPost::reset();
 		$this->assertFalse(MockPost::meta('connection'));
-		MockPost::config(array('connection' => true));
+		MockPost::config(array('meta' => array('connection' => true)));
 		$this->assertTrue(MockPost::meta('connection'));
 		$schema = MockPost::schema();
 
-		MockPost::overrideSchema($this->_altSchema);
-		$this->assertEqual($this->_altSchema, MockPost::schema()->fields());
+		MockPost::config(array('schema' => $this->_altSchema));
+		$this->assertEqual($this->_altSchema->fields(), MockPost::schema()->fields());
 
 		$post = MockPost::create(array('title' => 'New post'));
 		$this->assertTrue($post instanceof Entity);
@@ -557,9 +616,8 @@ class ModelTest extends \lithium\test\Unit {
 	}
 
 	public function testSave() {
-		$schema = MockPost::schema();
-		MockPost::overrideSchema($this->_altSchema);
-		MockPost::resetSchema();
+		MockPost::config(array('schema' => $this->_altSchema));
+		MockPost::config(array('schema' => new Schema()));
 		$data = array('title' => 'New post', 'author_id' => 13, 'foo' => 'bar');
 		$record = MockPost::create($data);
 		$result = $record->save();
@@ -567,8 +625,8 @@ class ModelTest extends \lithium\test\Unit {
 		$this->assertEqual('create', $result['query']->type());
 		$this->assertEqual($data, $result['query']->data());
 		$this->assertEqual('lithium\tests\mocks\data\MockPost', $result['query']->model());
-		MockPost::overrideSchema($this->_altSchema);
 
+		MockPost::config(array('schema' => $this->_altSchema));
 		$record->tags = array("baz", "qux");
 		$otherData = array('body' => 'foobar');
 		$result = $record->save($otherData);
@@ -577,13 +635,11 @@ class ModelTest extends \lithium\test\Unit {
 
 		$expected = array('title' => 'New post', 'author_id' => 13, 'body' => 'foobar');
 		$this->assertNotEqual($data, $result['query']->data());
-
-		MockPost::overrideSchema($schema->fields());
 	}
 
 	public function testSaveWithNoCallbacks() {
-		$schema = MockPost::schema();
-		MockPost::overrideSchema($this->_altSchema);
+		MockPost::config(array('schema' => $this->_altSchema));
+
 		$data = array('title' => 'New post', 'author_id' => 13);
 		$record = MockPost::create($data);
 		$result = $record->save(null, array('callbacks' => false));
@@ -591,7 +647,6 @@ class ModelTest extends \lithium\test\Unit {
 		$this->assertEqual('create', $result['query']->type());
 		$this->assertEqual($data, $result['query']->data());
 		$this->assertEqual('lithium\tests\mocks\data\MockPost', $result['query']->model());
-		MockPost::overrideSchema($schema->fields());
 	}
 
 	public function testSaveWithFailedValidation() {
@@ -677,7 +732,7 @@ class ModelTest extends \lithium\test\Unit {
 	}
 
 	public function testFindFirst() {
-		MockTag::config(array('key' => 'id'));
+		MockTag::config(array('meta' => array('key' => 'id')));
 		$tag = MockTag::find('first', array('conditions' => array('id' => 2)));
 		$tag2 = MockTag::find(2);
 		$tag3 = MockTag::first(2);
@@ -711,7 +766,6 @@ class ModelTest extends \lithium\test\Unit {
 	}
 
 	public function testSettingNestedObjectDefaults() {
-		$original = MockPost::schema()->fields();
 		$schema = MockPost::schema()->append(array(
 			'nested.value' => array('type' => 'string', 'default' => 'foo')
 		));
@@ -719,8 +773,6 @@ class ModelTest extends \lithium\test\Unit {
 
 		$data = array('nested' => array('value' => 'bar'));
 		$this->assertEqual('bar', MockPost::create($data)->nested['value']);
-
-		MockPost::overrideSchema($original);
 	}
 
 	/**
@@ -734,7 +786,7 @@ class ModelTest extends \lithium\test\Unit {
 	}
 
 	public function testLiveConfiguration() {
-		MockBadConnection::config(array('connection' => false));
+		MockBadConnection::config(array('meta' => array('connection' => false)));
 		$result = MockBadConnection::meta('connection');
 		$this->assertFalse($result);
 	}

--- a/tests/cases/data/collection/DocumentSetTest.php
+++ b/tests/cases/data/collection/DocumentSetTest.php
@@ -42,8 +42,8 @@ class DocumentSetTest extends \lithium\test\Unit {
 		Connections::add('mongo', array('type' => 'MongoDb', 'autoConnect' => false));
 		Connections::add('couch', array('type' => 'http', 'adapter' => 'CouchDb'));
 
-		MockDocumentPost::config(array('connection' => 'mongo'));
-		MockDocumentMultipleKey::config(array('connection' => 'couch'));
+		MockDocumentPost::config(array('meta' => array('connection' => 'mongo')));
+		MockDocumentMultipleKey::config(array('meta' => array('connection' => 'couch')));
 	}
 
 	public function tearDown() {

--- a/tests/cases/data/entity/DocumentTest.php
+++ b/tests/cases/data/entity/DocumentTest.php
@@ -104,7 +104,7 @@ class DocumentTest extends \lithium\test\Unit {
 			'name' => true,
 			'content' => true,
 		);
-		
+
 		$this->assertEqual($expected, $doc->modified());
 		$doc->sync();
 
@@ -120,7 +120,7 @@ class DocumentTest extends \lithium\test\Unit {
 			'content' => true,
 			'new' => true,
 		);
-		
+
 		$this->assertEqual($expected, $doc->modified());
 	}
 
@@ -320,7 +320,7 @@ class DocumentTest extends \lithium\test\Unit {
 
 	public function testUpdateWithMultipleKeys() {
 		$model = 'lithium\tests\mocks\data\model\MockDocumentMultipleKey';
-		$model::config(array('key' => array('id', 'rev'), 'foo' => true));
+		$model::config(array('meta' => array('key' => array('id', 'rev'), 'foo' => true)));
 		$doc = new Document(compact('model'));
 
 		$result = $model::meta('key');

--- a/tests/cases/data/entity/RecordTest.php
+++ b/tests/cases/data/entity/RecordTest.php
@@ -9,6 +9,7 @@
 namespace lithium\tests\cases\data\entity;
 
 use lithium\data\entity\Record;
+use lithium\data\Schema;
 
 class RecordTest extends \lithium\test\Unit {
 
@@ -20,8 +21,14 @@ class RecordTest extends \lithium\test\Unit {
 		$database = $this->_database;
 		$model = $this->_model;
 
-		$model::overrideSchema(array('id' => 'int', 'title' => 'string', 'body' => 'text'));
-		$model::config(array('connection' => false, 'key' => 'id', 'locked' => true));
+		$schema = new Schema(array(
+			'fields' => array(
+				'id' => 'int', 'title' => 'string', 'body' => 'text'
+		)));
+		$model::config(array(
+			'meta' => array('connection' => false, 'key' => 'id', 'locked' => true),
+			'schema' => $schema
+		));
 		$model::$connection = new $database();
 		$this->record = new Record(compact('model'));
 	}

--- a/tests/cases/data/model/QueryTest.php
+++ b/tests/cases/data/model/QueryTest.php
@@ -35,9 +35,6 @@ class QueryTest extends \lithium\test\Unit {
 
 	public function setUp() {
 		$this->db = new MockDatabase();
-		MockQueryPost::config();
-		MockQueryComment::config();
-
 		MockQueryPost::$connection = $this->db;
 		MockQueryComment::$connection = $this->db;
 	}

--- a/tests/cases/data/source/HttpTest.php
+++ b/tests/cases/data/source/HttpTest.php
@@ -133,7 +133,7 @@ class HttpTest extends \lithium\test\Unit {
 
 	public function testCreateWithModel() {
 		$model = $this->_model;
-		$model::config(array('key' => 'id'));
+		$model::config(array('meta' => array('key' => 'id')));
 		$http = new Http($this->_testConfig);
 		$query = new Query(compact('model') + array('data' => array('title' => 'Test Title')));
 		$result = $http->create($query);

--- a/tests/cases/data/source/mongo_db/ExporterTest.php
+++ b/tests/cases/data/source/mongo_db/ExporterTest.php
@@ -137,7 +137,7 @@ class ExporterTest extends \lithium\test\Unit {
 	public function testUpdateWithSubObjects() {
 		$model = $this->_model;
 		$exists = true;
-		$model::config(array('key' => '_id'));
+		$model::config(array('meta' => array('key' => '_id')));
 		$schema = new Schema(array('fields' => array(
 			'forceArray' => array('type' => 'string', 'array' => true),
 			'array' => array('type' => 'string', 'array' => true),

--- a/tests/cases/template/helper/FormTest.php
+++ b/tests/cases/template/helper/FormTest.php
@@ -164,9 +164,9 @@ class FormTest extends \lithium\test\Unit {
 
 	public function testFormDataBinding() {
 		try {
-			MockFormPost::config(array('connection' => false));
+			MockFormPost::config(array('meta' => array('connection' => false)));
 		} catch (Exception $e) {
-			MockFormPost::config(array('connection' => false));
+			MockFormPost::config(array('meta' => array('connection' => false)));
 		}
 
 		$record = new Record(array('model' => $this->_model, 'data' => array(

--- a/tests/integration/data/CrudTest.php
+++ b/tests/integration/data/CrudTest.php
@@ -50,7 +50,6 @@ class CrudTest extends \lithium\test\Integration {
 		);
 		$this->skipIf(!$isAvailable, "No {$connection} connection available.");
 
-		Companies::config();
 		$this->_key = Companies::key();
 		$this->_database = $config['database'];
 		$this->_connection = Connections::get($connection);

--- a/tests/integration/data/DocumentTest.php
+++ b/tests/integration/data/DocumentTest.php
@@ -45,7 +45,6 @@ class DocumentTest extends \lithium\test\Integration {
 		);
 		$this->skipIf(!$isAvailable, "No {$connection} connection available.");
 
-		Companies::config();
 		$this->_key = Companies::key();
 		$this->_database = $config['database'];
 		$this->_connection = Connections::get($connection);

--- a/tests/integration/data/SourceTest.php
+++ b/tests/integration/data/SourceTest.php
@@ -54,8 +54,6 @@ class SourceTest extends \lithium\test\Integration {
 		);
 		$this->skipIf(!$isAvailable, "No {$connection} connection available.");
 
-		Companies::config();
-		Employees::config();
 		$this->_key = Companies::key();
 		$this->_database = $config['database'];
 		$this->_connection = Connections::get($connection);

--- a/tests/mocks/data/MockBase.php
+++ b/tests/mocks/data/MockBase.php
@@ -17,13 +17,6 @@ class MockBase extends \lithium\data\Model {
 
 	public static $connection = null;
 
-	public static function resetSchema($array = false) {
-		if ($array) {
-			return static::_object()->_schema = array();
-		}
-		static::_object()->_schema = new Schema();
-	}
-
 	public static function &connection() {
 		if (!static::$connection) {
 			$connection = new MockDatabase();

--- a/tests/mocks/data/MockPost.php
+++ b/tests/mocks/data/MockPost.php
@@ -18,10 +18,6 @@ class MockPost extends \lithium\tests\mocks\data\MockBase {
 
 	protected $_meta = array('connection' => false, 'key' => 'id');
 
-	public static function overrideSchema(array $fields = array()) {
-		static::_object()->_schema = new Schema(compact('fields'));
-	}
-
 	public static function instances() {
 		return array_keys(static::$_instances);
 	}

--- a/tests/mocks/data/MockSource.php
+++ b/tests/mocks/data/MockSource.php
@@ -124,7 +124,8 @@ class MockSource extends \lithium\data\Source {
 	}
 
 	public function describe($entity, $schema = array(), array $meta = array()) {
-		$fields = $this->{'_' . Inflector::camelize($entity, false)};
+		$source = '_' . Inflector::camelize($entity, false);
+		$fields = isset($this->$source) ? $this->$source : array();
 		return $this->_instance('schema', compact('fields'));
 	}
 

--- a/tests/mocks/data/source/MockMongoPost.php
+++ b/tests/mocks/data/source/MockMongoPost.php
@@ -17,13 +17,6 @@ class MockMongoPost extends \lithium\tests\mocks\data\MockBase {
 
 	public static $connection;
 
-	public static function resetSchema($array = false) {
-		if ($array) {
-			return static::_object()->_schema = array();
-		}
-		static::_object()->_schema = new Schema();
-	}
-
 	public static function schema($field = null) {
 		$result = parent::schema($field);
 


### PR DESCRIPTION
- `Model::config()` will now follow the convention. The parameter name is an array and it makes change to the instance state (see #500).
- Removing the mock functions `resetSchema()` `overrideSchema()` in favor of core functions.
- Introduce `Model::query()` a getter/setter for the default query
- Introduce `Model::reset()` to enhance isolation tests see #470
