### PR TITLE
testcase for #519 - select * risky

### DIFF
--- a/tests/cases/data/source/database/adapter/MySqlTest.php
+++ b/tests/cases/data/source/database/adapter/MySqlTest.php
@@ -253,6 +253,42 @@ class MySqlTest extends \lithium\test\Unit {
 		);
 		$this->assertEqual($expected, $result);
 	}
+
+	/**
+	 * mysql_companies2.sql is almost identical to mysql_companies.sql, but the the two
+	 * fields `name` and `active` are swapped. The test is almost identical to
+	 * testRawSqlQuerying (expecting the same fields in the same sequences), emulating
+	 * that the tables are different from the known schema.
+	 */
+	public function testRawSqlSwappedColumns() {
+		$lithium = LITHIUM_LIBRARY_PATH . '/lithium';
+		$sqlFile = $lithium . '/tests/mocks/data/source/database/adapter/mysql_companies2.sql';
+		$sql = file_get_contents($sqlFile);
+		$this->db->read($sql, array('return' => 'resource'));
+
+		$this->assertTrue($this->db->create(
+				'INSERT INTO companies2 (name, active) VALUES (?, ?)',
+				array('Test', 1)
+		));
+
+		$result = $this->db->read('SELECT * From companies2 AS Company WHERE name = {:name}', array(
+				'name' => 'Test',
+				'return' => 'array'
+		));
+		$this->assertEqual(1, count($result));
+		$expected = array('id', 'name', 'active', 'created', 'modified');
+		$this->assertEqual($expected, array_keys($result[0]));
+
+		$this->assertTrue(is_numeric($result[0]['id']));
+		unset($result[0]['id']);
+
+		$expected = array('name' => 'Test', 'active' => '1', 'created' => null, 'modified' => null);
+		$this->assertIdentical($expected, $result[0]);
+
+		$this->assertTrue($this->db->delete('DELETE From companies2 WHERE name = {:name}', array(
+				'name' => 'Test'
+		)));
+	}
 }
 
 ?>

--- a/tests/mocks/data/source/database/adapter/mysql_companies2.sql
+++ b/tests/mocks/data/source/database/adapter/mysql_companies2.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS `companies2` (
+  `id` int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `active` tinyint(1),
+  `name` varchar(255),
+  `created` datetime,
+  `modified` datetime
+);


### PR DESCRIPTION
Swapped columns could be due to a defined schema in the model, but maual applying the table alterations differently.

Note, I create an extra table in the database. The original table gets deleted, but I do not see where in the file or Unit object this happens. This newly created table is thus not yet removed after the testcase is run. (I can do a drop, but would like to keep it with the other cleaning actions).
