### PR TITLE
#519 - integration tests for select * usage

### DIFF
--- a/tests/integration/data/DatabaseTest.php
+++ b/tests/integration/data/DatabaseTest.php
@@ -181,6 +181,57 @@ class DatabaseTest extends \lithium\test\Integration {
 		$this->assertEqual($fields, array_keys($image->data()));
 	}
 
+	/**
+	 * Images has no schema, so li3 derives it from the database.
+	 * Images2 has a schema, but with `title` and `image` swapped in sequence
+	 *
+	 * Swapping fields in a defined schema compared too the database should
+	 * not hurt. Now it hurst (data is mapped by field sequence, not by fieldname,
+	 * and as a bonus prevents the tests hereafter from running.
+	 */
+	public function testSelectWithAndWithoutSchema() {
+		$this->_createGalleryWithImages();
+
+		$images1 = Images::first();
+		$images2 = Images2::first();
+
+		$this->assertEqual($images1->id, $images2->id);
+		$this->assertEqual($images1->gallery_id, $images2->gallery_id);
+		$this->assertEqual($images1->image, $images2->image);
+		$this->assertEqual($images1->title, $images2->title);
+	}
+
+	/**
+	 * Too many fields in a defined schema should hurt, but
+	 * in a decent way. Now it dies somewhere...
+	 */
+	public function testSchemaHasTooManyFields() {
+		$this->_createGalleryWithImages();
+
+		$images1 = Images::first();
+		$images2 = Images3::first();
+
+		$this->assertEqual($images1->id, $images2->id);
+		$this->assertEqual($images1->gallery_id, $images2->gallery_id);
+		$this->assertEqual($images1->image, $images2->image);
+		$this->assertEqual($images1->title, $images2->title);
+	}
+
+	/**
+	 * Missing fields in a defined schema does not hurt.
+	 * You will only miss the last field(s) of the table.
+	 */
+	public function testSchemaHasTooFewFields() {
+		$this->_createGalleryWithImages();
+
+		$images1 = Images::first();
+		$images2 = Images4::first();
+
+		$this->assertEqual($images1->id, $images2->id);
+		$this->assertEqual($images1->gallery_id, $images2->gallery_id);
+		$this->assertEqual($images1->image, $images2->image);
+	}
+
 	public function testOrder() {
 		$this->_createGalleryWithImages();
 		$images = Images::find('all', array(

--- a/tests/mocks/data/source/Images2.php
+++ b/tests/mocks/data/source/Images2.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2012, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\tests\mocks\data\source;
+
+class Images2 extends \lithium\data\Model {
+
+	protected $_meta = array(
+			'connection' => 'lithium_mysql_test',
+			'source' => 'images'
+	);
+
+	/**
+	 * swapping sequence for title and image
+	 */
+	protected $_schema = array(
+		'id' => array('type' => 'integer'),
+		'gallery_id' => array('type' => 'integer'),
+		'title' => array('type' => 'string', 'length' => 50),
+		'image' => array('type' => 'string', 'length' => 50),
+	);
+
+	public $belongsTo = array('Galleries');
+}
+
+?>

--- a/tests/mocks/data/source/Images3.php
+++ b/tests/mocks/data/source/Images3.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2012, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\tests\mocks\data\source;
+
+class Images3 extends \lithium\data\Model {
+
+	protected $_meta = array(
+			'connection' => 'lithium_mysql_test',
+			'source' => 'images'
+	);
+
+	/**
+	 * a table row extra
+	 */
+	protected $_schema = array(
+		'id' => array('type' => 'integer'),
+		'gallery_id' => array('type' => 'integer'),
+		'image' => array('type' => 'string', 'length' => 50),
+		'title' => array('type' => 'string', 'length' => 50),
+		'extra' => array('type' => 'string', 'length' => 50),
+	);
+
+	public $belongsTo = array('Galleries');
+}
+
+?>

--- a/tests/mocks/data/source/Images4.php
+++ b/tests/mocks/data/source/Images4.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2012, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\tests\mocks\data\source;
+
+class Images4 extends \lithium\data\Model {
+
+	protected $_meta = array(
+			'connection' => 'lithium_mysql_test',
+			'source' => 'images'
+	);
+
+	/**
+	 * a table row missing
+	 */
+	protected $_schema = array(
+		'id' => array('type' => 'integer'),
+		'gallery_id' => array('type' => 'integer'),
+		'image' => array('type' => 'string', 'length' => 50),
+	);
+
+	public $belongsTo = array('Galleries');
+}
+
+?>


### PR DESCRIPTION
Select \* can be risky - integration tests

Defined schemas that are out of sync with the database
results in various side-effects:
- wrong sequence: data is mapped to wrong field
- too many fields: li3 dies
- too little fields: ok
