### PR TITLE
Implements Collection::reduce

### DIFF
--- a/data/Collection.php
+++ b/data/Collection.php
@@ -257,6 +257,22 @@ abstract class Collection extends \lithium\util\Collection {
 	}
 
 	/**
+	 * Reduce, or fold, a collection down to a single value
+	 *
+	 * Overridden to load any data that has not yet been loaded.
+	 *
+	 * @param callback $filter The filter to apply.
+	 * @param mixed $initial Initial value
+	 * @return mixed A single reduced value
+	 */
+	public function reduce($filter, $initial = false) {
+		if (!$this->closed()) {
+			while ($this->next()) {}
+		}
+		return parent::reduce($filter);
+	}
+
+	/**
 	 * Sorts the objects in the collection, useful in situations where
 	 * you are already using the underlying datastore to sort results.
 	 *

--- a/data/collection/RecordSet.php
+++ b/data/collection/RecordSet.php
@@ -273,6 +273,20 @@ class RecordSet extends \lithium\data\Collection {
 	}
 
 	/**
+	 * Reduce, or fold, a collection down to a single value
+	 *
+	 * Overriden to load any data that has not yet been loaded.
+	 *
+	 * @param callback $filter The filter to apply.
+	 * @param mixed $initial Initial value
+	 * @return mixed A single reduced value
+	 */
+	public function reduce($filter, $initial = false) {
+		$this->offsetGet(null);
+		return parent::reduce($filter, $initial);
+	}
+
+	/**
 	 * Applies a callback to a copy of all data in the collection
 	 * and returns the result.
 	 *

--- a/tests/cases/data/CollectionTest.php
+++ b/tests/cases/data/CollectionTest.php
@@ -150,6 +150,23 @@ class CollectionTest extends \lithium\test\Unit {
 	}
 
 	/**
+	 * Tests `Collection::reduce`.
+	 */
+	public function testReduce() {
+		$collection = new DocumentSet();
+		$collection->set(array(
+			'title' => 'Lorem Ipsum',
+			'key'   => 'value',
+			'foo'   => 'bar'
+		));
+		$result = $collection->reduce(function($memo, $value) {
+			return trim($memo . ' ' . $value);
+		}, '');
+		$expected = 'Lorem Ipsum value bar';
+		$this->assertEqual($expected, $result);
+	}
+
+	/**
 	 * Tests `Collection::data`.
 	 */
 	public function testData() {

--- a/tests/cases/data/collection/RecordSetTest.php
+++ b/tests/cases/data/collection/RecordSetTest.php
@@ -443,6 +443,15 @@ class RecordSetTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result->get('_data'));
 	}
 
+	public function testReduce() {
+		$filter = function($memo, $rec) {
+			return $memo + $rec->id;
+		};
+		$expected = 10;
+		$result = $this->_recordSet->reduce($filter, 0);
+		$this->assertEqual($expected, $result);
+	}
+
 	public function testRecordSet() {
 		$expected = array(
 			'post1' => array(

--- a/tests/cases/util/CollectionTest.php
+++ b/tests/cases/util/CollectionTest.php
@@ -152,6 +152,15 @@ class CollectionTest extends \lithium\test\Unit {
 		$this->assertEqual(array(2, 3, 4, 5, 6), $result);
 	}
 
+	public function testCollectionReduceFilter() {
+		$collection = new Collection(array('data' => array(1, 2, 3)));
+		$filter = function($memo, $item) { return $memo + $item; };
+		$result = $collection->reduce($filter, 0);
+
+		$this->assertEqual(6, $collection->reduce($filter, 0));
+		$this->assertEqual(7, $collection->reduce($filter, 1));
+	}
+
 	/**
 	 * Tests the `ArrayAccess` interface implementation for manipulating values by direct offsets.
 	 *

--- a/util/Collection.php
+++ b/util/Collection.php
@@ -354,6 +354,17 @@ class Collection extends \lithium\core\Object implements \ArrayAccess, \Iterator
 	}
 
 	/**
+	 * Reduce, or fold, a collection down to a single value
+	 *
+	 * @param callback $filter The filter to apply.
+	 * @param mixed $initial Initial value
+	 * @return mixed A single reduced value
+	 */
+	public function reduce($filter, $initial = false) {
+		return array_reduce($this->_data, $filter, $initial);
+	}
+
+	/**
 	 * Sorts the objects in the collection.
 	 *
 	 * @param callable $sorter The sorter for the data, can either be a sort function like


### PR DESCRIPTION
The duo `map` and `each` just lacked `reduce` to make it easier for functional programming style in Lithium.
The need for stuff like this should not be uncommon:

``` php
$profit = Invoices::all()->reduce(function($memo, $model) {
    return $memo + $model->sum;
}, 0);
```
