### PR TITLE
Route: support request method in route matching and fix _match/_meta in compile

### DIFF
--- a/net/http/Route.php
+++ b/net/http/Route.php
@@ -273,8 +273,7 @@ class Route extends \lithium\core\Object {
 			}
 		}
 
-        // check http method
-        if (isset($this->_meta['http:method']) && $options['http:method'] != $this->_meta['http:method'] ) {
+        if (isset($this->_meta['http:method']) && $options['http:method'] != $this->_meta['http:method']) {
             return false;
         }
         unset($options['http:method']);

--- a/tests/cases/net/http/RouteTest.php
+++ b/tests/cases/net/http/RouteTest.php
@@ -542,8 +542,7 @@ class RouteTest extends \lithium\test\Unit {
 		$this->assertEqual('/', $url);
 	}
 
-
-    /**
+	/**
      * Test route matching for routes with specified request method (http:method)
      */
     public function testMatchWithRequestMethod() {
@@ -615,8 +614,6 @@ class RouteTest extends \lithium\test\Unit {
 
 
     }
-
-
 
 	/**
 	 * Tests that routes with optional trailing elements have unnecessary slashes trimmed.


### PR DESCRIPTION
Two things in this pull request
## Added request method to route matching ( match() ) 

route matching works as follows:
- routes defined without a request method match for all request methods
- routes with request method GET
  
  Router::connect( '/get', array("http:method" => "GET", 'controller' => 'mycontroller', 'action'=> 'do_get'));
  
  //both match for route definition (GET is used as default)
  Router::match(array('controller' => 'mycontroller', 'action' => 'do_get', 'http:method' => 'GET')) 
  Router::match(array('controller' => 'mycontroller', 'action' => 'do_get )) 
- routes with other request methods, e.g. POST
  
  Router::connect( '/post, array("http:method" => "POST", 'controller' => 'mycontroller', 'action'=> 'do_post'));
  
  // matches route definition
  Router::match(array('controller' => 'mycontroller', 'action' => 'do_post', 'http:method' => 'POST'))
  // does not match
  Router::match(array('controller' => 'mycontroller', 'action' => 'do_post'))

I could imagine some people find it nice not to pass http:method for POST etc. but I think this way of matching is more consistent with route definition. Also i actually needed it in one case where I wanted two URLS for get and post pointing to one action.

It clearly can break existing applications that do make use of http:method in the route definition and do not pass it to match().
## Fixed different behavior of for _match/_meta depending of the presence of parameters in route templates. 

In cases the route template contained parameters _meta (i.e. options with ':' were handled differently than if no parameters we used (  Route->compile() )

Also created tests for routes with specified request method.

First change clearly can break existing applications that do make use of http:method in the route definition and do not pass it to match(). It should be discussed . Second change (_meta) should be applied anyways as it seems to be a bug.
