### PR TITLE
Fix #530.

### DIFF
--- a/data/source/Database.php
+++ b/data/source/Database.php
@@ -350,11 +350,12 @@ abstract class Database extends \lithium\data\Source {
 					$name = $model::meta('name');
 					$key = $model::key();
 
+					$fieldname = $self->name("{$name}.{$key}");
 					$subQuery = $self->invokeMethod('_instance', array(get_class($query), array(
 						'type' => 'read',
 						'model' => $model,
-						'group' => $self->name("{$name}.{$key}"),
-						'fields' => array("{$name}.{$key}"),
+						'fields' => array((object) "DISTINCT({$fieldname})"),
+						'group' => $query->group(),
 						'joins' => $query->joins(),
 						'conditions' => $query->conditions(),
 						'limit' => $query->limit(),
@@ -365,7 +366,7 @@ abstract class Database extends \lithium\data\Source {
 
 					if ($ids->count()) {
 						$query->limit(false)->conditions(array("{$name}.{$key}" => array_map(
-							function($index) use ($key) { return $index[$key]; },
+							function($index) { return current($index); },
 							$ids->data()
 						)));
 					}

--- a/tests/cases/data/source/DatabaseTest.php
+++ b/tests/cases/data/source/DatabaseTest.php
@@ -1003,11 +1003,11 @@ class DatabaseTest extends \lithium\test\Unit {
 		$this->db->log = false;
 
 		$result = MockDatabasePost::$connection->logs[0];
-		$expected = "SELECT {MockDatabasePost}.{id} FROM {mock_database_posts} AS ";
+		$expected = "SELECT DISTINCT({MockDatabasePost}.{id}) FROM {mock_database_posts} AS ";
 		$expected .= "{MockDatabasePost} LEFT JOIN {mock_database_comments} AS ";
 		$expected .= "{MockDatabaseComment} ON {MockDatabasePost}.{id} = ";
 		$expected .= "{MockDatabaseComment}.{mock_database_post_id} WHERE ";
-		$expected .= "{MockDatabasePost}.{id} = 5 GROUP BY {MockDatabasePost}.{id} LIMIT 1;";
+		$expected .= "{MockDatabasePost}.{id} = 5 LIMIT 1;";
 		$this->assertEqual($expected, $result);
 
 		$result = MockDatabasePost::$connection->logs[1];


### PR DESCRIPTION
Change the actual `GROUP BY` strategy for recovering unique primary keys with has many relation(s). The MySQL `GROUP BY` clause is not conventional and can't be applied with the PostgreSQL adapter for recovering unique primary keys with an `ORDER BY` query using the same syntax.
