### PR TITLE
Testing for MongoID embedded in an array being casted as string on save() 

### DIFF
--- a/tests/cases/data/source/MongoDbTest.php
+++ b/tests/cases/data/source/MongoDbTest.php
@@ -651,9 +651,9 @@ class MongoDbTest extends \lithium\test\Unit {
 	}
 
 	/**
-	 * Tests that the MongoDB adapter will not attempt to overwrite an MongoID in an
+	 * Tests that the MongoDB adapter will not attempt to overwrite a MongoID in an
 	 * embedded array during update.
-	 * Note: AssertEqual is returns false positive between MongoId and string.
+	 * Note: AssertEqual returns false positive between MongoId and string.
 	 */
 	public function testPreserveEmbeddedId() {
 		$model = $this->_model;


### PR DESCRIPTION
When updating a document that has an array with MongoIds they are being casted to string. Writing the test case it appears that asserttrue is unreliable since it will match a MongoID object to a string. So I matched it to instanceof MongoID. Currently the test is failing the latest master build.
