### PR TITLE
Fixed error in 'testRemoteAddrFromHttpPcRemoteAddr()'

### DIFF
--- a/tests/cases/action/RequestTest.php
+++ b/tests/cases/action/RequestTest.php
@@ -145,7 +145,7 @@ class RequestTest extends \lithium\test\Unit {
 
 	public function testRemoteAddrFromHttpPcRemoteAddr() {
 		$request = new MockIisRequest();
-		$this->assertEqual('123.456.789.000', $request->env('REMOTE_ADDR'));
+		$this->assertEqual('123.456.789.000', $request->env('HTTP_PC_REMOTE_ADDR'));
 	}
 
 	public function testBase() {


### PR DESCRIPTION
firing the 'Request Test' generates an error:

```
Assertion 'assertEqual' failed in lithium\tests\cases\action\RequestTest::testRemoteAddrFromHttpPcRemoteAddr() on line 128
```

This error is fixed by changing line 128 from

```
$this->assertEqual('123.456.789.000', $request->env('REMOTE_ADDR'));
```

to

```
$this->assertEqual('123.456.789.000', $request->env('HTTP_PC_REMOTE_ADDR'));
```
