### PR TITLE
Making sure the default namespace used in Library::extract() is valid

### DIFF
--- a/console/command/Library.php
+++ b/console/command/Library.php
@@ -13,6 +13,7 @@ use Exception;
 use RuntimeException;
 use lithium\core\Libraries;
 use lithium\util\String;
+use lithium\util\Inflector;
 
 /**
  * The Library command is used to archive and extract Phar::GZ archives. Requires zlib extension.
@@ -237,7 +238,7 @@ class Library extends \lithium\console\Command {
 				$this->out(basename($to) . " created in " . dirname($to) . " from {$from}");
 
 				if (empty($this->namespace)) {
-					$this->namespace = basename($to);
+					$this->namespace = Inflector::underscore(basename($to));
 				}
 
 				$replacements = $this->_findReplacements($to);


### PR DESCRIPTION
By default, the `extract` command will use the target directory name as the namespace. If the target directory name contains spaces or invalid characters, the extracted app will result in parsing errors. This patch uses Inflector::underscore() to make sure the resulting namespace is valid.
