### PR TITLE
Request->_url gives wrong url for request_uri like controller/test:1

### DIFF
--- a/tests/cases/action/RequestTest.php
+++ b/tests/cases/action/RequestTest.php
@@ -177,6 +177,23 @@ class RequestTest extends \lithium\test\Unit {
 		$this->assertEqual('pages/test_app', $request->url);
 	}
 
+	public function testRequestWithColon() {
+		unset($_GET['url']);
+		$request = new Request(array('env' => array(
+			'PHP_SELF' => '/test_app/app/webroot/index.php',
+			'REQUEST_URI' => '/test_app/pages/test_app/test:a'
+		)));
+		$this->assertEqual('/test_app', $request->env('base'));
+		$this->assertEqual('pages/test_app/test:a', $request->url);
+
+		$request = new Request(array('env' => array(
+			'PHP_SELF' => '/test_app/app/webroot/index.php',
+			'REQUEST_URI' => '/test_app/pages/test_app/test:1'
+		)));
+		$this->assertEqual('/test_app', $request->env('base'));
+		$this->assertEqual('pages/test_app/test:1', $request->url);
+	}
+
 	public function testRequestWithoutUrlQueryParamAndNoApp() {
 		unset($_GET['url']);
 		$request = new Request(array('env' => array(


### PR DESCRIPTION
Testcase

`'REQUEST_URI' => '/test_app/pages/test_app/test:a'` should return `'pages/test_app/test:a'` [ok]

`'REQUEST_URI' => '/test_app/pages/test_app/test:1'` should return `'pages/test_app/test:1'` [fail: returns '/']
