### PR TITLE
Add virtual fields

### DIFF
--- a/data/entity/Document.php
+++ b/data/entity/Document.php
@@ -115,7 +115,9 @@ class Document extends \lithium\data\Entity implements \Iterator, \ArrayAccess {
 		}
 		$result = parent::__get($name);
 
-		if ($result !== null || array_key_exists($name, $this->_updated)) {
+		if ($result !== null || array_key_exists($name, $this->_updated) 
+			|| array_key_exists($name, $this->_virtual['get'])
+		) {
 			return $result;
 		}
 
@@ -135,14 +137,14 @@ class Document extends \lithium\data\Entity implements \Iterator, \ArrayAccess {
 		return $null;
 	}
 
-	public function export() {
+	public function export(array $options=array()) {
 		foreach ($this->_updated as $key => $val) {
 			if ($val instanceof self) {
 				$path = $this->_pathKey ? "{$this->_pathKey}." : '';
 				$this->_updated[$key]->_pathKey = "{$path}{$key}";
 			}
 		}
-		return parent::export() + array('key' => $this->_pathKey);
+		return parent::export($options) + array('key' => $this->_pathKey);
 	}
 
 	/**
@@ -243,17 +245,6 @@ class Document extends \lithium\data\Entity implements \Iterator, \ArrayAccess {
 		if (is_object($current)) {
 			$current->set(array(end($path) => $value));
 		}
-	}
-
-	/**
-	 * PHP magic method used to check the presence of a field as document properties, i.e.
-	 * `$document->_id`.
-	 *
-	 * @param $name The field name, as specified with an object property.
-	 * @return boolean True if the field specified in `$name` exists, false otherwise.
-	 */
-	public function __isset($name) {
-		return isset($this->_updated[$name]);
 	}
 
 	/**

--- a/tests/cases/data/EntityTest.php
+++ b/tests/cases/data/EntityTest.php
@@ -119,6 +119,54 @@ class EntityTest extends \lithium\test\Unit {
 		$entity->set($data);
 		$this->assertEqual(array('foo' => true, 'baz' => true), $entity->modified());
 	}
+	
+	public function testVirtual() {
+		$model = 'lithium\tests\mocks\data\MockModelVirtual';
+		$entity = new Entity(array('model' => $model, 'data' => array('foo' => true)));
+		$this->assertTrue($entity->validates());
+		
+		$this->assertEqual(true, $entity->foo);
+		$this->assertTrue(isset($entity->foo));
+		$this->assertFalse(isset($entity->bar));
+		
+		$this->assertFalse(isset($entity->fielda));
+		$entity->fielda = 'a';
+		$this->assertTrue(isset($entity->fielda));
+		$this->assertTrue(isset($entity->bar));
+		$this->assertEqual('a', $entity->fielda);
+		$this->assertEqual('a', $entity->bar);
+		$entity->bar = null;
+		
+		$this->assertFalse(isset($entity->fieldb));
+		$entity->fieldb = 'b';
+		$this->assertTrue(isset($entity->fieldb));
+		$this->assertFalse(isset($entity->bar));
+		$this->assertEqual('b', $entity->fieldb);
+		$this->assertEqual(null, $entity->bar);
+		$entity->bar = null;
+		
+		$this->assertFalse(isset($entity->field_c));
+		$entity->bar = 'c';
+		$this->assertTrue(isset($entity->field_c));
+		$this->assertTrue(isset($entity->bar));
+		$this->assertEqual('c', $entity->field_c);
+		$this->assertEqual('c', $entity->bar);
+
+		$export = $entity->export();
+		$expected = array('exists', 'data', 'update', 'increment');
+		$this->assertEqual($expected, array_keys($export));
+		$expected = array('foo' => true, 'bar' => 'c', 'fieldb' => 'b');
+		$this->assertEqual($expected, $export['update']);
+		
+		$export = $entity->export(array('virtual' => true));
+		$expected = array('exists', 'data', 'update', 'increment', 'virtual');
+		$this->assertEqual($expected, array_keys($export));
+		$expected = array('fielda' => 'c', 'fieldb' => 'c', 'field_c' => 'c');
+		$this->assertEqual($expected, $export['virtual']);
+
+		$this->expectException('No model bound or unhandled method call `setfield_c`.');
+		$this->assertTrue($entity->field_c = 'd');
+	}
 }
 
 ?>

--- a/tests/mocks/data/MockModelVirtual.php
+++ b/tests/mocks/data/MockModelVirtual.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2012, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\tests\mocks\data;
+
+use lithium\tests\mocks\data\source\database\adapter\MockAdapter;
+
+class MockModelVirtual extends \lithium\data\Model {
+
+	protected $_meta = array(
+		'connection' => false
+	);
+	
+	public static $_properties = array(
+		'fielda' => 'FieldA',
+		'fieldb' => array('FieldB', 'get' => 'getFieldZ', 'set' => false),
+		'field_c' => array('get' => 'myTest')
+	);
+	
+	public function getFieldA($entity) {
+		return $entity->bar;
+	}
+	
+	public function setFieldA($entity, $value) {
+		$entity->bar = $value;
+	}
+	
+	public function issetFieldA($entity) {
+		return isset($entity->bar);
+	}
+	
+	public function issetFieldB($entity) {
+		return $entity->bar;
+	}
+	
+	public function getFieldZ($entity) {
+		return $entity->bar;
+	}
+	
+	public function myTest($entity) {
+		return $entity->bar;
+	}
+	
+	public function issetfield_c($entity) {
+		return isset($entity->bar);
+	}
+	
+	// must be missing public function setfield_c
+}
+
+?>


### PR DESCRIPTION
Summary:

Virtual fields in using methods in the Model, that are almost like the current behaviour to implement methods for an Entity. 

Virtual fields are defined in the model like `_schema` (although that is done for SQL db's by the datasource),  eg:

``` php
protected $_properties = array(
    'extra_field_1' => 'ExtraField`, 
    // expects model to have methods getExtraField, setExtraField, issetExtraField

    'extra_field_2' => array('get' => 'DoSomethingFancy', 'set' => false) 
    // expects model to have methods DoSomethingFancy and issetextra_field_2
    // set is done like for normal fields: data is added to _updated
)
```

that would save a lot of checks and makes the behaviour more explicit.

Outstanding:
- set behaviour in data\entity\Document - need some help with that
- squash commits (when everything is ready)
