### PR TITLE
Refactor Schema Casting close #567 : WARNING BC BREAK

### DIFF
--- a/data/Schema.php
+++ b/data/Schema.php
@@ -117,7 +117,7 @@ class Schema extends \lithium\core\Object implements \ArrayAccess {
 		return isset($this->_types[$type]) ? $this->_types[$type] : $type;
 	}
 
-	public function cast($object, $data, array $options = array()) {
+	public function cast($object, $key, $data, array $options = array()) {
 		return $data;
 	}
 

--- a/data/collection/DocumentSet.php
+++ b/data/collection/DocumentSet.php
@@ -22,17 +22,7 @@ class DocumentSet extends \lithium\data\Collection {
 
 	protected function _init() {
 		parent::_init();
-		$pathKey = $this->_pathKey;
-		$model = $this->_model;
-
-		if (($model = $this->_model) && ($schema = $this->schema())) {
-			$exists = $this->_exists;
-			$pathKey = $this->_pathKey;
-			$this->_data = $schema->cast($this, $this->_data, compact('exists', 'pathKey'));
-			foreach ($this->_data as &$data) {
-				$data = $schema->cast($this, $data, compact('pathKey', 'model'));
-			}
-		}
+		$this->set($this->_data);
 		$this->_original = $this->_data;
 	}
 
@@ -100,12 +90,11 @@ class DocumentSet extends \lithium\data\Collection {
 		if ($schema = $this->schema()) {
 			$model = $this->_model;
 			$pathKey = $this->_pathKey;
-			$options =  compact('model', 'pathKey') + $options;
-			$result = $schema->cast($this, array($offset => $data), $options);
-			$data = reset($result);
+			$options =  compact('model', 'pathKey' ) + $options;
+			$data = $schema->cast($this, $offset, $data, $options);
 		}
 		($offset === null) ? $this->_data[] = $data : $this->_data[$offset] = $data;
-		if (is_object($data)) {
+		if (method_exists($data, 'assignTo')) {
 			$data->assignTo($this);
 		}
 		return $data;

--- a/data/entity/Document.php
+++ b/data/entity/Document.php
@@ -291,29 +291,27 @@ class Document extends \lithium\data\Entity implements \Iterator, \ArrayAccess {
 		$defaults = array('init' => false);
 		$options += $defaults;
 
+		$cast = ($schema = $this->schema());
+
 		foreach ($data as $key => $val) {
+			unset($this->_increment[$key]);
 			if (strpos($key, '.')) {
 				$this->_setNested($key, $val);
-				unset($data[$key]);
+				continue;
 			}
-			unset($this->_increment[$key]);
-		}
-
-		if ($data && ($schema = $this->schema())) {
-			$pathKey = $this->_pathKey;
-			$model = $this->_model;
-			$data = $schema->cast($this, $data, compact('pathKey', 'model'));
-		}
-
-		foreach ($data as $key => $value) {
-			if ($value instanceof self) {
-				$value->_exists = $options['init'] && $this->_exists;
-				$value->_pathKey = ($this->_pathKey ? "{$this->_pathKey}." : '') . $key;
-				$value->_model = $value->_model ?: $this->_model;
-				$value->_schema = $value->_schema ?: $this->_schema;
+			if ($cast) {
+				$pathKey = $this->_pathKey;
+				$model = $this->_model;
+				$val = $schema->cast($this, $key, $val, compact('pathKey', 'model'));
 			}
+			if ($val instanceof self) {
+				$val->_exists = $options['init'] && $this->_exists;
+				$val->_pathKey = ($this->_pathKey ? "{$this->_pathKey}." : '') . $key;
+				$val->_model = $val->_model ?: $this->_model;
+				$val->_schema = $val->_schema ?: $this->_schema;
+			}
+			$this->_updated[$key] = $val;
 		}
-		$this->_updated = $data + $this->_updated;
 	}
 
 	/**

--- a/data/source/MongoDb.php
+++ b/data/source/MongoDb.php
@@ -666,8 +666,8 @@ class MongoDb extends \lithium\data\Source {
 		$ops = $this->_operators;
 		$castOpts = array('first' => true, 'database' => $this, 'wrap' => false);
 
-		$cast = function($value) use (&$schema, &$castOpts) {
-			return $schema ? $schema->cast(null, $value, $castOpts) : $value;
+		$cast = function($key, $value) use (&$schema, &$castOpts) {
+			return $schema ? $schema->cast(null, $key, $value, $castOpts) : $value;
 		};
 
 		foreach ($conditions as $key => $value) {
@@ -688,15 +688,13 @@ class MongoDb extends \lithium\data\Source {
 				continue;
 			}
 			if (!is_array($value)) {
-				$value = $cast(array($key => $value));
-				$conditions[$key] = reset($value);
+				$conditions[$key] = $cast($key, $value);
 				continue;
 			}
 			$current = key($value);
 
 			if (!isset($ops[$current]) && $current[0] !== '$') {
-				$value = $cast(array($key => $value));
-				$conditions[$key] = array('$in' => reset($value));
+				$conditions[$key] = array('$in' => $cast($key, $value));
 				continue;
 			}
 			$conditions[$key] = $this->_operators($key, $value, $schema);
@@ -717,14 +715,13 @@ class MongoDb extends \lithium\data\Source {
 		$castOpts = compact('schema');
 		$castOpts += array('first' => true, 'database' => $this, 'wrap' => false);
 
-		$cast = function($value) use (&$schema, &$castOpts) {
-			return $schema ? $schema->cast(null, $value, $castOpts) : $value;
+		$cast = function($key, $value) use (&$schema, &$castOpts) {
+			return $schema ? $schema->cast(null, $key, $value, $castOpts) : $value;
 		};
 
 		foreach ($operators as $key => $value) {
 			if (!isset($this->_operators[$key])) {
-				$value = $cast(array($field => $value));
-				$operators[$key] = reset($value);
+				$operators[$key] = $cast($field, $value);
 				continue;
 			}
 			$operator = $this->_operators[$key];
@@ -736,8 +733,7 @@ class MongoDb extends \lithium\data\Source {
 				return $operator($key, $value, $schema);
 			}
 			unset($operators[$key]);
-			$value = $cast(array($field => $value));
-			$operators[$operator] = reset($value);
+			$operators[$operator] = $cast($field, $value);
 		}
 		return $operators;
 	}

--- a/tests/cases/data/entity/DocumentTest.php
+++ b/tests/cases/data/entity/DocumentTest.php
@@ -146,6 +146,10 @@ class DocumentTest extends \lithium\test\Unit {
 
 		$doc->forceArray = false;
 		$result = $doc->export();
+		$this->assertIdentical(array(false), $result['update']['forceArray']->data());
+
+		$doc->forceArray = array();
+		$result = $doc->export();
 		$this->assertIdentical(array(), $result['update']['forceArray']->data());
 	}
 
@@ -657,7 +661,7 @@ class DocumentTest extends \lithium\test\Unit {
 		$modified = $doc->export();
 		$this->assertTrue($modified['exists']);
 		$this->assertEqual(array('foo' => 'bar', 'baz' => 'dib'), $modified['data']);
-		$this->assertEqual(array('nested', 'foo', 'baz'), array_keys($modified['update']));
+		$this->assertEqual(array('foo', 'baz', 'nested'), array_keys($modified['update']));
 		$this->assertNull($modified['key']);
 
 		$nested = $modified['update']['nested']->export();
@@ -675,7 +679,7 @@ class DocumentTest extends \lithium\test\Unit {
 
 		$expected = array('more' => 'cowbell') + $modified['data'];
 		$this->assertEqual($expected, $modified['update']);
-		$this->assertEqual(array('nested', 'foo', 'baz'), array_keys($modified['data']));
+		$this->assertEqual(array('foo', 'baz', 'nested'), array_keys($modified['data']));
 		$this->assertEqual('bar', $modified['data']['foo']);
 		$this->assertEqual('dib', $modified['data']['baz']);
 		$this->assertTrue($modified['exists']);

--- a/tests/cases/data/source/MongoDbTest.php
+++ b/tests/cases/data/source/MongoDbTest.php
@@ -740,7 +740,7 @@ class MongoDbTest extends \lithium\test\Unit {
 
 		$query = new Query(array('type' => 'update') + compact('entity'));
 		$result = $query->export($this->db);
-		$expected = array('updated', '_id', 'created', 'list');
+		$expected = array('_id', 'created', 'list', 'updated');
 		$this->assertEqual($expected, array_keys($result['data']['update']));
 		$this->assertTrue($result['data']['update']['updated'] instanceof MongoDate);
 	}

--- a/tests/cases/data/source/mongo_db/ExporterTest.php
+++ b/tests/cases/data/source/mongo_db/ExporterTest.php
@@ -298,7 +298,7 @@ class ExporterTest extends \lithium\test\Unit {
 	public function testNestedObjectCasting() {
 		$model = $this->_model;
 		$data = array('notifications' => array('foo' => '', 'bar' => '1', 'baz' => 0, 'dib' => 42));
-		$result = $model::schema()->cast(null, $data, compact('model'));
+		$result = $model::schema()->cast(null, null, $data, compact('model'));
 
 		$this->assertIdentical(false, $result['notifications']->foo);
 		$this->assertIdentical(true, $result['notifications']->bar);
@@ -331,38 +331,37 @@ class ExporterTest extends \lithium\test\Unit {
 		$handlers = $this->_handlers;
 		$options = compact('model', 'handlers');
 		$schema = new Schema(array('fields' => $this->_schema));
-		$result = $schema->cast(null, $data, $options);
+		$result = $schema->cast(null, null, $data, $options);
+		$this->assertEqual(array_keys($data), array_keys($result->data()));
+		$this->assertTrue($result->_id instanceof MongoId);
+		$this->assertEqual('4c8f86167675abfabd970300', (string) $result->_id);
 
-		$this->assertEqual(array_keys($data), array_keys($result));
-		$this->assertTrue($result['_id'] instanceof MongoId);
-		$this->assertEqual('4c8f86167675abfabd970300', (string) $result['_id']);
-
-		$this->assertTrue($result['comments'] instanceof DocumentSet);
+		$this->assertTrue($result->comments instanceof DocumentSet);
 		$this->assertEqual(3, count($result['comments']));
 
-		$this->assertTrue($result['comments'][0] instanceof MongoId);
-		$this->assertTrue($result['comments'][1] instanceof MongoId);
-		$this->assertTrue($result['comments'][2] instanceof MongoId);
-		$this->assertEqual('4c8f86167675abfabdbe0300', (string) $result['comments'][0]);
-		$this->assertEqual('4c8f86167675abfabdbf0300', (string) $result['comments'][1]);
-		$this->assertEqual('4c8f86167675abfabdc00300', (string) $result['comments'][2]);
+		$this->assertTrue($result->comments[0] instanceof MongoId);
+		$this->assertTrue($result->comments[1] instanceof MongoId);
+		$this->assertTrue($result->comments[2] instanceof MongoId);
+		$this->assertEqual('4c8f86167675abfabdbe0300', (string) $result->comments[0]);
+		$this->assertEqual('4c8f86167675abfabdbf0300', (string) $result->comments[1]);
+		$this->assertEqual('4c8f86167675abfabdc00300', (string) $result->comments[2]);
 
-		$this->assertEqual($data['comments'], $result['comments']->data());
-		$this->assertEqual(array('test'), $result['tags']->data());
-		$this->assertEqual(array('4c8f86167675abfabdb00300'), $result['authors']->data());
-		$this->assertTrue($result['authors'][0] instanceof MongoId);
+		$this->assertEqual($data['comments'], $result->comments->data());
+		$this->assertEqual(array('test'), $result->tags->data());
+		$this->assertEqual(array('4c8f86167675abfabdb00300'), $result->authors->data());
+		$this->assertTrue($result->authors[0] instanceof MongoId);
 
-		$this->assertTrue($result['modified'] instanceof MongoDate);
-		$this->assertTrue($result['created'] instanceof MongoDate);
-		$this->assertTrue($result['created']->sec > 0);
+		$this->assertTrue($result->modified instanceof MongoDate);
+		$this->assertTrue($result->created instanceof MongoDate);
+		$this->assertTrue($result->created->sec > 0);
 
-		$this->assertTrue($result['empty_array'] instanceof DocumentSet);
+		$this->assertTrue($result->empty_array instanceof DocumentSet);
 
-		$this->assertEqual($time, $result['modified']->sec);
-		$this->assertEqual($time, $result['created']->sec);
+		$this->assertEqual($time, $result->modified->sec);
+		$this->assertEqual($time, $result->created->sec);
 
-		$this->assertIdentical(45, $result['rank_count']);
-		$this->assertIdentical(3.45688, $result['rank']);
+		$this->assertIdentical(45, $result->rank_count);
+		$this->assertIdentical(3.45688, $result->rank);
 	}
 
 	/**
@@ -388,24 +387,24 @@ class ExporterTest extends \lithium\test\Unit {
 		$handlers = $this->_handlers;
 		$options = compact('model', 'handlers');
 		$schema = new Schema(array('fields' => $this->_schema));
-		$result = $schema->cast(null, $data, $options);
+		$result = $schema->cast(null, null, $data, $options);
 
-		$this->assertEqual(array_keys($data), array_keys($result));
-		$this->assertTrue($result['_id'] instanceof MongoId);
-		$this->assertEqual('4c8f86167675abfabd970300', (string) $result['_id']);
+		$this->assertEqual(array_keys($data), array_keys($result->data()));
+		$this->assertTrue($result->_id instanceof MongoId);
+		$this->assertEqual('4c8f86167675abfabd970300', (string) $result->_id);
 
-		$this->assertTrue($result['accounts'] instanceof DocumentSet);
-		$this->assertEqual(2, count($result['accounts']));
+		$this->assertTrue($result->accounts instanceof DocumentSet);
+		$this->assertEqual(2, count($result->accounts));
 
-		$this->assertTrue($result['accounts'][0]['_id'] instanceof MongoId);
-		$this->assertEqual('4fb6e2dd3e91581fe6e75736', (string) $result['accounts'][0]['_id']);
-		$this->assertTrue($result['accounts'][1]['_id'] instanceof MongoId);
-		$this->assertEqual('4fb6e2df3e91581fe6e75737', (string) $result['accounts'][1]['_id']);
+		$this->assertTrue($result->accounts[0]['_id'] instanceof MongoId);
+		$this->assertEqual('4fb6e2dd3e91581fe6e75736', (string) $result->accounts[0]['_id']);
+		$this->assertTrue($result->accounts[1]['_id'] instanceof MongoId);
+		$this->assertEqual('4fb6e2df3e91581fe6e75737', (string) $result->accounts[1]['_id']);
 
-		$this->assertTrue($result['accounts'][0]['created'] instanceof MongoDate);
-		$this->assertTrue($result['accounts'][0]['created']->sec > 0);
-		$this->assertTrue($result['accounts'][1]['created'] instanceof MongoDate);
-		$this->assertTrue($result['accounts'][1]['created']->sec > 0);
+		$this->assertTrue($result->accounts[0]['created'] instanceof MongoDate);
+		$this->assertTrue($result->accounts[0]['created']->sec > 0);
+		$this->assertTrue($result->accounts[1]['created'] instanceof MongoDate);
+		$this->assertTrue($result->accounts[1]['created']->sec > 0);
 	}
 
 	public function testWithArraySchema() {

--- a/tests/cases/data/source/mongo_db/SchemaTest.php
+++ b/tests/cases/data/source/mongo_db/SchemaTest.php
@@ -30,13 +30,13 @@ class SchemaTest extends \lithium\test\Unit {
 			'users' => array('type' => 'id', 'array' => true)
 		)));
 
-		$result = $schema->cast(null, array('users' => new MongoId()), array(
+		$result = $schema->cast(null, null, array('users' => new MongoId()), array(
 			'database' => $this->db
 		));
 
-		$this->assertEqual(array('users'), array_keys($result));
-		$this->assertEqual(1, count($result['users']));
-		$this->assertTrue($result['users'][0] instanceof MongoId);
+		$this->assertEqual(array('users'), array_keys($result->data()));
+		$this->assertEqual(1, count($result->users));
+		$this->assertTrue($result->users[0] instanceof MongoId);
 	}
 
 	public function testCastingEmptyValues() {
@@ -44,7 +44,7 @@ class SchemaTest extends \lithium\test\Unit {
 			'_id' => array('type' => 'id'),
 			'foo' => array('type' => 'string', 'array' => true)
 		)));
-		$result = $schema->cast(null, null, array('database' => $this->db));
+		$result = $schema->cast(null, null, null, array('database' => $this->db));
 	}
 }
 


### PR DESCRIPTION
the `DocumentSchema::cast()` 's signature has changed to :

<pre>
public function cast($object, $key, $data, array $options = array())
</pre>


If `wrap` is set to true, the `DocumentSchema->cast()` will returns a `Document` or a `DocumentSet` (according to `$data`) instead of returning an array with wrapped fields inside.
