### PR TITLE
Removing `Entity::_relationships` and refactoring `Entity::__isset` & `Entity::__unset` : WARNING BC BREAK.

### DIFF
--- a/data/Entity.php
+++ b/data/Entity.php
@@ -43,14 +43,6 @@ class Entity extends \lithium\core\Object {
 	protected $_data = array();
 
 	/**
-	 * An array containing all related records and recordsets, keyed by relationship name, as
-	 * defined in the bound model class.
-	 *
-	 * @var array
-	 */
-	protected $_relationships = array();
-
-	/**
 	 * If this record is chained off of another, contains the origin object.
 	 *
 	 * @var object
@@ -111,7 +103,7 @@ class Entity extends \lithium\core\Object {
 	 */
 	protected $_autoConfig = array(
 		'classes' => 'merge', 'parent', 'schema', 'data',
-		'model', 'exists', 'pathKey', 'relationships'
+		'model', 'exists', 'pathKey'
 	);
 
 	/**
@@ -126,7 +118,7 @@ class Entity extends \lithium\core\Object {
 	 * @return object Record object.
 	 */
 	public function __construct(array $config = array()) {
-		$defaults = array('model' => null, 'data' => array(), 'relationships' => array());
+		$defaults = array('model' => null, 'data' => array());
 		parent::__construct($config + $defaults);
 	}
 
@@ -173,7 +165,22 @@ class Entity extends \lithium\core\Object {
 	 * @return mixed Result.
 	 */
 	public function __isset($name) {
-		return isset($this->_updated[$name]) || isset($this->_relationships[$name]);
+		return isset($this->_updated[$name]);
+	}
+
+	/**
+	 * PHP magic method used when unset() is called on an `Entity` instance.
+	 * {{{
+	 * $doc = Post::find($id);
+	 * unset($doc->fieldName);
+	 * $doc->save();
+	 * }}}
+	 *
+	 * @param string $name The name of the field to unset.
+	 * @return void
+	 */
+	public function __unset($name) {
+		unset($this->_updated[$name]);
 	}
 
 	/**
@@ -414,8 +421,6 @@ class Entity extends \lithium\core\Object {
 		switch ($format) {
 			case 'array':
 				$data = $this->_updated;
-				$rel = array_map(function($obj) { return $obj->data(); }, $this->_relationships);
-				$data = $rel + $data;
 				$result = Collection::toArray($data, $options);
 			break;
 			case 'string':

--- a/data/collection/RecordSet.php
+++ b/data/collection/RecordSet.php
@@ -318,12 +318,12 @@ class RecordSet extends \lithium\data\Collection {
 					$data = $conn->item($relModel, $data, $options);
 				}
 				$opts = array('class' => 'set');
-				$relationships[$field] = $conn->item($relModel, $rel, $options + $opts);
+				$main[$field] = $conn->item($relModel, $rel, $options + $opts);
 				continue;
 			}
-			$relationships[$field] = $conn->item($relModel, $rel, $options);
+			$main[$field] = $conn->item($relModel, $rel, $options);
 		}
-		return $conn->item($primary, $main, $options + compact('relationships'));
+		return $conn->item($primary, $main, $options);
 	}
 
 	protected function _columnMap() {

--- a/data/entity/Document.php
+++ b/data/entity/Document.php
@@ -110,7 +110,7 @@ class Document extends \lithium\data\Entity implements \Iterator, \ArrayAccess {
 			return $this->_getNested($name);
 		}
 
-		if (isset($this->_embedded[$name]) && !isset($this->_relationships[$name])) {
+		if (isset($this->_embedded[$name])) {
 			throw new RuntimeException("Not implemented.");
 		}
 		$result = parent::__get($name);
@@ -246,33 +246,6 @@ class Document extends \lithium\data\Entity implements \Iterator, \ArrayAccess {
 		if (is_object($current)) {
 			$current->set(array(end($path) => $value));
 		}
-	}
-
-	/**
-	 * PHP magic method used to check the presence of a field as document properties, i.e.
-	 * `$document->_id`.
-	 *
-	 * @param $name The field name, as specified with an object property.
-	 * @return boolean True if the field specified in `$name` exists, false otherwise.
-	 */
-	public function __isset($name) {
-		return isset($this->_updated[$name]);
-	}
-
-	/**
-	 * PHP magic method used when unset() is called on a `Document` instance.
-	 * Use case for this would be when you wish to edit a document and remove a field, ie.:
-	 * {{{
-	 * $doc = Post::find($id);
-	 * unset($doc->fieldName);
-	 * $doc->save();
-	 * }}}
-	 *
-	 * @param string $name The name of the field to remove.
-	 * @return void
-	 */
-	public function __unset($name) {
-		unset($this->_updated[$name]);
 	}
 
 	/**

--- a/tests/cases/data/EntityTest.php
+++ b/tests/cases/data/EntityTest.php
@@ -40,21 +40,31 @@ class EntityTest extends \lithium\test\Unit {
 		$entity = new Entity(array(
 			'model' => 'Foo',
 			'exists' => true,
-			'data' => array('test_field' => 'foo'),
-			'relationships' => array('test_relationship' => array('test_me' => 'bar'))
+			'data' => array('test_field' => 'foo')
 		));
 
 		$this->assertEqual('foo', $entity->test_field);
-		$this->assertEqual(array('test_me' => 'bar'), $entity->test_relationship);
 
 		$this->assertTrue(isset($entity->test_field));
-		$this->assertTrue(isset($entity->test_relationship));
 
 		$this->assertFalse(empty($entity->test_field));
-		$this->assertFalse(empty($entity->test_relationship));
 
 		$this->assertTrue(empty($entity->test_invisible_field));
-		$this->assertTrue(empty($entity->test_invisible_relationship));
+	}
+
+	public function testPropertyUnset() {
+		$entity = new Entity(array(
+			'model' => 'Foo',
+			'exists' => true,
+			'data' => array('test_field' => 'foo')
+		));
+
+		$this->assertEqual('foo', $entity->test_field);
+		unset($entity->test_field);
+
+		$this->assertFalse(isset($entity->test_field));
+
+		$this->assertTrue(empty($entity->test_field));
 	}
 
 	public function testIncrement() {


### PR DESCRIPTION
Separating `Entity::_relationships` & `Entity::_updated` has imo not a good thing since they are both datas and currently such separation only work on the loading step. Indeed if I use the following syntax :

<pre>
$entity->mydata = $somedata // the datas goes into _updated even if it's a relation
</pre>


So I think it's preferable to remove this feature for the moment and rethink of it when it'll be really necessary.

Secondarily close #571
