### PR TITLE
Implementing Model::relationships()

### DIFF
--- a/data/Model.php
+++ b/data/Model.php
@@ -165,6 +165,13 @@ class Model extends \lithium\core\StaticObject {
 	protected $_relations = array();
 
 	/**
+	 * An array containing the match between fieldname and their corresponding relation name.
+	 *
+	 * @var array
+	 */
+	protected $_relationships = array();
+
+	/**
 	 * List of relation types.
 	 *
 	 * Valid relation types are:
@@ -642,6 +649,22 @@ class Model extends \lithium\core\StaticObject {
 	}
 
 	/**
+	 * Returns the relation name associated to a field name, or a list of field name associated
+	 * to their to corresponding relation name if `$fieldname` is null.
+	 *
+	 * @param string $fieldname A fieldname.
+	 * @return mixed A relation name or an array of associations.
+	 */
+	public static function relationships($fieldname = null) {
+		$self = static::_object();
+
+		if (!$fieldname) {
+			return $self->_relationships;
+		}
+		return isset($self->_relationships[$fieldname]) ? $self->_relationships[$fieldname] : null;
+	}
+
+	/**
 	 * Creates a relationship binding between this model and another.
 	 *
 	 * @see lithium\data\model\Relationship
@@ -661,6 +684,7 @@ class Model extends \lithium\core\StaticObject {
 			throw new ConfigException("Invalid relationship type `{$type}` specified.");
 		}
 		$rel = static::connection()->relationship(get_called_class(), $type, $name, $config);
+		$self->_relationships[$rel->fieldName()] = $name;
 		return $self->_relations[$name] = $rel;
 	}
 

--- a/tests/cases/data/ModelTest.php
+++ b/tests/cases/data/ModelTest.php
@@ -790,6 +790,19 @@ class ModelTest extends \lithium\test\Unit {
 		$result = MockBadConnection::meta('connection');
 		$this->assertFalse($result);
 	}
+
+	public function testRelationships() {
+		MockPost::bind('hasMany', 'MockTag');
+		$relationships = MockPost::relationships();
+		$this->assertEqual(array(
+			'mock_comments' => 'MockComment',
+			'mock_tags' => 'MockTag'
+		), $relationships);
+
+		$this->assertEqual('MockComment', MockPost::relationships('mock_comments'));
+		$this->assertEqual('MockTag', MockPost::relationships('mock_tags'));
+		$this->assertNull(MockPost::relationships('undefined'));
+	}
 }
 
 ?>


### PR DESCRIPTION
Currently relation names are "Inflectorized" in datas, i.e. if you have the following relation : "Post HasMany Comment" the comment's data are available using :

<pre>
$entity->comments
</pre> 


`comments` is the fieldname associated to the "Comment" relation but there's no way to reach the relation name without iterating over all Model's relations.

`Model::relationship()` allow here to get back to the relation name.

<pre>
    echo Model::relationship('comments') // => 'Comment'
</pre>


PS:
This will help to support the following syntax in the next futur :

<pre>
$entity->comments = array(
    array('body' => 'comment1'),
    array('body' => 'comment1')
)
</pre>
