### PR TITLE
Allow for invalid "HTTP/1.1 <code>" responses

### DIFF
--- a/net/http/Response.php
+++ b/net/http/Response.php
@@ -198,13 +198,19 @@ class Response extends \lithium\net\http\Message {
 		if (array_filter($headers) == array()) {
 			return trim($body);
 		}
-		preg_match('/HTTP\/(\d+\.\d+)\s+(\d+)\s+(.*)/i', array_shift($headers), $match);
+		preg_match('/HTTP\/(\d+\.\d+)\s+(\d+)(?:\s+(.*))?/i', array_shift($headers), $match);
 		$this->headers($headers);
 
 		if (!$match) {
 			return trim($body);
 		}
-		list($line, $this->version, $code, $message) = $match;
+		list($line, $this->version, $code) = $match;
+		if (isset($this->_statuses[$code])) {
+			$message = $this->_statuses[$code];
+		}
+		if (isset($match[3])) {
+			$message = $match[3];
+		}
 		$this->status = compact('code', 'message') + $this->status;
 		$this->protocol = "HTTP/{$this->version}";
 		return $body;

--- a/tests/cases/net/http/ResponseTest.php
+++ b/tests/cases/net/http/ResponseTest.php
@@ -106,7 +106,7 @@ class ResponseTest extends \lithium\test\Unit {
 
 	public function testParseMessage() {
 		$message = join("\r\n", array(
-			'HTTP/1.1 200 OK',
+			'HTTP/1.1 404 Not Found',
 			'Header: Value',
 			'Connection: close',
 			'Content-Type: application/json;charset=iso-8859-1',
@@ -118,6 +118,9 @@ class ResponseTest extends \lithium\test\Unit {
 		$this->assertEqual($message, (string) $response);
 		$this->assertEqual('application/json', $response->type);
 		$this->assertEqual('ISO-8859-1', $response->encoding);
+		$this->assertEqual('404', $response->status['code']);
+		$this->assertEqual('Not Found', $response->status['message']);
+		$this->assertEqual('HTTP/1.1 404 Not Found', $response->status());
 
 		$body = 'Not a Message';
 		$expected = join("\r\n", array('HTTP/1.1 200 OK', '', '', 'Not a Message'));
@@ -305,6 +308,38 @@ class ResponseTest extends \lithium\test\Unit {
 			'opaque' => 'dd7bcee161192cb8fba765eb595eba87'
 		);
 		$result = array_filter($response->digest());
+		$this->assertEqual($expected, $result);
+	}
+
+	public function testMalformedStatus() {
+		$expected = "HTTP/1.1 304 Not Modified";
+
+		$message = join("\r\n", array(
+			'HTTP/1.1 304',
+			'Header: Value',
+			'Connection: close',
+			'Content-Type: application/json;charset=iso-8859-1',
+			'',
+			'Test!'
+		));
+
+		$response = new Response(compact('message'));
+		$result = $response->status();
+		$this->assertEqual($expected, $result);
+
+		$expected = "HTTP/1.1 500 Internal Server Error";
+
+		$message = join("\r\n", array(
+			'HTTP/1.1 500',
+			'Header: Value',
+			'Connection: close',
+			'Content-Type: application/json;charset=iso-8859-1',
+			'',
+			'Test!'
+		));
+
+		$response = new Response(compact('message'));
+		$result = $response->status();
 		$this->assertEqual($expected, $result);
 	}
 }


### PR DESCRIPTION
Some web services return a poorly formed status line, of just `HTTP/1.x <code>`, rather than the correct `HTTP/1.x <code> <reason>`. This small change allows lithium to handle this scenario by looking up the code in the status array and should not hamper the original behavior in any way.
