### PR TITLE
Minor Security fix for `Form::button()`

### DIFF
--- a/template/helper/Form.php
+++ b/template/helper/Form.php
@@ -37,7 +37,7 @@ class Form extends \lithium\template\Helper {
 	 * @var array
 	 */
 	protected $_strings = array(
-		'button'         => '<button{:options}>{:name}</button>',
+		'button'         => '<button{:options}>{:title}</button>',
 		'checkbox'       => '<input type="checkbox" name="{:name}"{:options} />',
 		'checkbox-multi' => '<input type="checkbox" name="{:name}[]"{:options} />',
 		'checkbox-multi-group' => '{:raw}',
@@ -490,6 +490,21 @@ class Form extends \lithium\template\Helper {
 			$result[] = $this->field($field, compact('label') + $options);
 		}
 		return join("\n", $result);
+	}
+
+	/**
+	 * Generates an HTML button `<button></button>`.
+	 *
+	 * @param string $title The title of the button.
+	 * @param array $options Any options passed are converted to HTML attributes within the
+	 *              `<button></button>` tag.
+	 * @return string Returns a `<button></button>` tag with the given title and HTML attributes.
+	 */
+	public function button($title = null, array $options = array()) {
+		$defaults = array('escape' => true);
+		list($scope, $options) = $this->_options($defaults, $options);
+		list($title, $options, $template) = $this->_defaults(__METHOD__, $title, $options);
+		return $this->_render(__METHOD__, 'button', compact('type', 'title', 'options', 'value'), $scope);
 	}
 
 	/**

--- a/tests/cases/template/helper/FormTest.php
+++ b/tests/cases/template/helper/FormTest.php
@@ -1241,9 +1241,16 @@ class FormTest extends \lithium\test\Unit {
 	 * Tests that magic method support can be used to automatically generate a `<button />` tag
 	 * based on the default string template.
 	 */
-	public function testAutoMagicButton() {
+	public function testButton() {
 		$result = $this->form->button('Foo!', array('id' => 'bar'));
 		$this->assertTags($result, array('button' => array('id' => 'bar'), 'Foo!', '/button'));
+
+		$result = $this->form->button('Continue >', array('type' => 'submit'));
+		$this->assertTags($result, array(
+			'button' => array('type' => 'submit', 'id' => 'Continue'),
+			'Continue &gt;',
+			'/button'
+		));
 	}
 
 	/**


### PR DESCRIPTION
Change the string template of the button element for making it's content escaped by default using `$title` instead of `$name`.
