### PR TITLE
Lazy load model's relationships

### DIFF
--- a/tests/cases/data/ModelTest.php
+++ b/tests/cases/data/ModelTest.php
@@ -790,6 +790,16 @@ class ModelTest extends \lithium\test\Unit {
 		$result = MockBadConnection::meta('connection');
 		$this->assertFalse($result);
 	}
+
+	public function testLazyLoad() {
+		$object = MockPost::invokeMethod('_object');
+		$object->belongsTo = array('Unexisting');
+		MockPost::config();
+		MockPost::invokeMethod('_init', array('lithium\tests\mocks\data\MockPost'));
+		$exception = 'Related model class \'lithium\tests\mocks\data\Unexisting\' not found.';
+		$this->expectException($exception);
+		MockPost::relations('Unexisting');
+	}
 }
 
 ?>


### PR DESCRIPTION
Currently relations are all instanciated on Model::_init(). With `belongTo` relations, the `Relationship` class need to get the key of the `belongTo` model which lead to instanciate the relations of the relation and so on with all `belongTo` relations.

This PR, will load relations on `Model::relations()` and no more on `Model::_init()`
