### PR TITLE
Curl Option support for Curl Socket

### DIFF
--- a/net/socket/Curl.php
+++ b/net/socket/Curl.php
@@ -50,7 +50,7 @@ class Curl extends \lithium\net\Socket {
 	 * Opens a curl connection and initializes the internal resource handle.
 	 *
 	 * @param array $options update the config settings
-     *             if $options['options'] exists, will be passed to $this->set()
+	 * 			if $options['options'] exists, will be passed to $this->set()
 	 * @return mixed Returns `false` if the socket configuration does not contain the
 	 *         `'scheme'` or `'host'` settings, or if configuration fails, otherwise returns a
 	 *         resource stream.
@@ -59,12 +59,12 @@ class Curl extends \lithium\net\Socket {
 		$this->options = array();
 		parent::open($options);
 		$config = $this->_config;
-        if (empty($config['scheme']) || empty($config['host'])) {
+		if (empty($config['scheme']) || empty($config['host'])) {
 			return false;
 		}
-        if (!empty($config['options'])){
-            $this->set($config['options']);
-        }
+		if (!empty($config['options'])){
+			$this->set($config['options']);
+		}
 
 		$url = "{$config['scheme']}://{$config['host']}";
 		$this->_resource = curl_init($url);

--- a/tests/cases/net/socket/CurlTest.php
+++ b/tests/cases/net/socket/CurlTest.php
@@ -140,17 +140,17 @@ class CurlTest extends \lithium\test\Unit {
 		$this->assertEqual('Changed Dummy Value', $stream->options['DummyFlag']);
 	}
 
-    public function testSettingOfOptionsInConfig() {
-        $this->_testConfig['options'] = array('DummyFlag'=> 'Dummy Value');
-   		$stream = new Curl($this->_testConfig);
-   		$stream->open();
-   		$this->assertEqual('Dummy Value', $stream->options['DummyFlag']);
-   	}
-    public function testSettingOfOptionsInOpen() {
-   		$stream = new Curl($this->_testConfig);
-   		$stream->open(array('options'=>array('DummyFlag'=> 'Dummy Value')));
-   		$this->assertEqual('Dummy Value', $stream->options['DummyFlag']);
-   	}
+	public function testSettingOfOptionsInConfig() {
+		$this->_testConfig['options'] = array('DummyFlag'=> 'Dummy Value');
+		$stream = new Curl($this->_testConfig);
+		$stream->open();
+		$this->assertEqual('Dummy Value', $stream->options['DummyFlag']);
+	}
+	public function testSettingOfOptionsInOpen() {
+		$stream = new Curl($this->_testConfig);
+		$stream->open(array('options'=>array('DummyFlag'=> 'Dummy Value')));
+		$this->assertEqual('Dummy Value', $stream->options['DummyFlag']);
+	}
 
 
 	public function testSendPostThenGet() {


### PR DESCRIPTION
can now pass curl options in either the Socket configuration array or the array passed to open function via an 'options' key inside either array (open parameter data takes precedence if collision).

Test cases provided for both scenarios in CurlTest cases.

Downside still remaining that anything passed directly via ->set() call prior to ->open() call will get deleted.

Another way around this would be to change the call to reset option which happens in first line of open() method and put that in the close() method so reset happens when connection closes instead of when opened.  I didn't want to go there as some may be dependent on open() implementation.
