### PR TITLE
Add {:bold} style, show all docblock in help, typo

### DIFF
--- a/console/Command.php
+++ b/console/Command.php
@@ -247,7 +247,7 @@ class Command extends \lithium\core\Object {
 	 *
 	 * {{{
 	 * -------
-	 * Lihtium
+	 * Lithium
 	 * -------
 	 * }}}
 	 *

--- a/console/Response.php
+++ b/console/Response.php
@@ -124,7 +124,8 @@ class Response extends \lithium\core\Object {
 			'option'  => "\033[0;35m",
 			'command' => "\033[0;35m",
 			'error'   => "\033[0;31m",
-			'success' => "\033[0;32m"
+			'success' => "\033[0;32m",
+			'bold'    => "\033[1m",
 		);
 		if ($styles === false) {
 			return array_combine(array_keys($defaults), array_pad(array(), count($defaults), null));

--- a/console/command/Help.php
+++ b/console/command/Help.php
@@ -163,7 +163,7 @@ class Help extends \lithium\console\Command {
 			$comment = Docblock::comment($method['docComment']);
 
 			$name = $method['name'];
-			$description = $comment['description'];
+			$description = trim($comment['description'] . PHP_EOL . $comment['text']);
 			$args = $method['args'];
 			$return = null;
 


### PR DESCRIPTION
With this patch, there are two new "features":
1. Added a {:bold} style, this will only work if the font has a bold variant, or if you terminal shows "bright" colors for bold.
2. The help for commands will now show all of the docblock, this is great for allowing larger descriptions of commands. e.g.

``` php
<?php
/**
 * mycommand | {:option}--arg1 [--arg2]{:end}
 *
 * {:blue}(i){:end} If {:option}--arg2{:end} is specified, it will do blah blah
 */
public function mycommand() { }
```

Will output:

```
USAGE
    li3 command mycommand
DESCRIPTION
    Some command `li3 command <subcommand>`
OPTIONS
    mycommand
        Do something | --arg1 [--arg2]
        (i) If --arg2 is specified do blah blah
```
