### PR TITLE
Fix wrong embedded code for Media docs examples

### DIFF
--- a/net/http/Media.php
+++ b/net/http/Media.php
@@ -113,9 +113,9 @@ class Media extends \lithium\core\StaticObject {
 	 * Examples:
 	 * {{{ embed:lithium\tests\cases\net\http\MediaTest::testMediaTypes(1-2) }}}
 	 *
-	 * {{{ embed:lithium\tests\cases\net\http\MediaTest::testMediaTypes(19-20) }}}
+	 * {{{ embed:lithium\tests\cases\net\http\MediaTest::testMediaTypes(19-23) }}}
 	 *
-	 * {{{ embed:lithium\tests\cases\net\http\MediaTest::testMediaTypes(40-41) }}}
+	 * {{{ embed:lithium\tests\cases\net\http\MediaTest::testMediaTypes(43-44) }}}
 	 *
 	 * Alternatively, can be used to detect the type name of a registered content type:
 	 * {{{


### PR DESCRIPTION
Embedded examples were broken.
![](http://c1352201.r1.cf3.rackcdn.com/1342888926.jpg)
