### PR TITLE
reverse order of setting body and type on request in _request()

### DIFF
--- a/net/http/Service.php
+++ b/net/http/Service.php
@@ -216,8 +216,8 @@ class Service extends \lithium\core\Object {
 		$request->method = $method = strtoupper($method);
 
 		$hasBody = in_array($method, array('POST', 'PUT'));
+    	$hasBody ? $request->type($options['type']) : null;
 		$hasBody ? $request->body($data) : $request->query = $data;
-		$hasBody ? $request->type($options['type']) : null;
 		return $request;
 	}
 }


### PR DESCRIPTION
having the body set before the type meant the body was encoded as html no matter what the type actually is.
