### PR TITLE
Update `composer.json` with the correct package type for Lithium libraries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,6 @@
 	],
 	"require": {
 		"php": ">=5.3.6",
-		"composer/installers": "*"
+		"composer/installers": "dev-master"
 	}
 }


### PR DESCRIPTION
Installing Lithium with Composer will install it to `libraries/UnionOfRAD/lithium`.

Composer knows `lithium-library` type and make use of a custom installer to install the library to `libraries/{$name}` (without `$vendor`)
See: https://github.com/composer/installers

**Note:** I'm getting `requires composer/installers * -> no matching package found.` but this seems to be a composer related issue.
Requiring `"composer/installers": "dev-master"` in your app composer file is a workaround.

UPDATE: Composer installers aren't yet flagged as stable, requiring them need to explicitly ask for a dev version.
Explanation got from IRC ![](http://c1352201.r1.cf3.rackcdn.com/1344459206.jpg)
