### PR TITLE
Lazily initialize Model's metadata, refactor Model::_init() and Model::_classes is no more static

### DIFF
--- a/tests/mocks/data/MockPostFiltered.php
+++ b/tests/mocks/data/MockPostFiltered.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2012, Union of RAD(http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\tests\mocks\data;
+
+class MockPostFiltered extends \lithium\tests\mocks\data\MockBase {
+
+	public $hasMany = array('MockComment');
+
+	public static $connection = null;
+
+	public static $initCalled = 0;
+
+	protected $_meta = array('connection' => false, 'key' => 'id');
+
+	public function _init() {
+		parent::_init();
+
+		static::applyFilter('filteredStatic', function($self, $params, $chain) {
+		    $response = $chain->next($self, $params, $chain);
+		    return $response . ' filtered static';
+		});
+
+		static::applyFilter('filteredDynamic', function($self, $params, $chain) {
+		    $response = $chain->next($self, $params, $chain);
+		    return $response . ' filtered dynamic';
+		});
+
+		static::$initCalled++;
+	}
+
+	public function filteredDynamic($entity, $value) {
+		$params = compact('value');
+
+		return static::_filter(__METHOD__, $params, function($self, $params) {
+		    return $params['value'];
+		});
+	}
+
+	public static function filteredStatic($value) {
+		$params = compact('value');
+
+		return static::_filter(__FUNCTION__, $params, function($self, $params) {
+		    return $params['value'];
+		});
+	}
+}
+
+?>


### PR DESCRIPTION
1 - Implementing the @nateabele Model's metadatas initializations strategy using cutom closures.

Example :

```
Posts::config(array(
    'initializers' => array(
        'source' => function($self) {
            return 'custom_' . Inflector::underscore($self::meta('name'));
        },
        'name' => function($self) {
            return Inflector::singularize(basename(str_replace('\\', '/', $self)));
        }
    )
));
```

2 - Model::_classes is no more static.

3 - Since Models are in the "same time" static and dynamic, for consistency, this PR reintroduce the `_init()` method which is a standard method called just after `__construct`.
Here `_init()` is called just after the class instanciation (instead of `__construct`) and can be used for lazy initializations.`__init()` can always be used for "direct" initializations.
