### PR TITLE
Fix for Set::append

### DIFF
--- a/tests/cases/util/SetTest.php
+++ b/tests/cases/util/SetTest.php
@@ -1384,6 +1384,47 @@ class SetTest extends \lithium\test\Unit {
 
 		$result = Set::append(array(), array('2'));
 		$this->assertIdentical(array('2'), $result);
+
+		$array1 = array(
+			'ModelOne' => array(
+				'id' => 1001,
+				'field_one' => 's1.0.m1.f1',
+				'field_two' => 's1.0.m1.f2'
+			),
+			'ModelTwo' => array(
+				'id' => 1002,
+				'field_one' => 's1.0.m2.f1',
+				'field_two' => 's1.0.m2.f2'
+			)
+		);
+		$array2 = array(
+			'ModelTwo' => array(
+				'field_three' => 's1.0.m2.f3'
+			)
+		);
+		$array3 = array(
+			'ModelOne' => array(
+				'field_three' => 's1.0.m1.f3'
+			)
+		);
+
+		$result = Set::append($array1, $array2, $array3);
+
+		$expected = array(
+			'ModelOne' => array(
+				'id' => 1001,
+				'field_one' => 's1.0.m1.f1',
+				'field_two' => 's1.0.m1.f2',
+				'field_three' => 's1.0.m1.f3'
+			),
+			'ModelTwo' => array(
+				'id' => 1002,
+				'field_one' => 's1.0.m2.f1',
+				'field_two' => 's1.0.m2.f2',
+				'field_three' => 's1.0.m2.f3'
+			)
+		);
+		$this->assertIdentical($expected, $result);
 	}
 
 	public function testStrictKeyCheck() {

--- a/util/Set.php
+++ b/util/Set.php
@@ -37,14 +37,20 @@ class Set {
 	 *         first.
 	 */
 	public static function append(array $array, array $array2) {
-		if (!$array && $array2) {
-			return $array2;
-		}
-		foreach ($array2 as $key => $value) {
-			if (!isset($array[$key])) {
-				$array[$key] = $value;
-			} elseif (is_array($value)) {
-				$array[$key] = static::append($array[$key], $array2[$key]);
+		$arrays = func_get_args();
+		$array = array_shift($arrays);
+		foreach ($arrays as $array2) {
+			if (! $array && $array2) {
+				$array = $array2;
+				continue;
+			}
+			foreach ($array2 as $key => $value) {
+				if (! array_key_exists($key, $array)) {
+					$array[$key] = $value;
+				}
+				elseif (is_array($value)) {
+					$array[$key] = static::append($array[$key], $array2[$key]);
+				}
 			}
 		}
 		return $array;


### PR DESCRIPTION
In Set::append replaced "isset" on "array_key_exists" and add support for variable-length argument lists
