### PR TITLE
Added remove support for Document entity.

### DIFF
--- a/data/source/mongo_db/Exporter.php
+++ b/data/source/mongo_db/Exporter.php
@@ -196,7 +196,7 @@ class Exporter extends \lithium\core\StaticObject {
 		$result = array();
 
 		foreach ($left as $key => $value) {
-			if (!isset($right[$key]) || $left[$key] !== $right[$key]) {
+			if (!array_key_exists($key, $right) || $left[$key] !== $right[$key]) {
 				$result[$key] = $value;
 			}
 		}

--- a/tests/cases/data/entity/DocumentTest.php
+++ b/tests/cases/data/entity/DocumentTest.php
@@ -563,6 +563,61 @@ class DocumentTest extends \lithium\test\Unit {
 		unset($doc->none);
 	}
 
+	public function testUnsetNested() {
+		$data = array(
+			'a' => 1,
+			'b' => array(
+					'ba' => 21,
+					'bb' => 22
+			),
+			'c' => array(
+					'ca' => 31,
+					'cb' => array(
+							'cba' => 321,
+							'cbb' => 322
+					)
+			),
+			'd' => array(
+					'da' => 41
+			)
+		);
+		$model = $this->_model;
+
+		$doc = new Document(compact('model', 'data'));
+		$expected = $data;
+		$result = $doc->data();
+		$this->assertEqual($expected, $result);
+
+		unset($doc->c->cb->cba);
+		unset($expected['c']['cb']['cba']);
+		$result = $doc->data();
+		$this->assertEqual($expected, $result);
+
+		unset($doc->b->bb);
+		unset($expected['b']['bb']);
+		$result = $doc->data();
+		$this->assertEqual($expected, $result);
+
+		unset($doc->a);
+		unset($expected['a']);
+		$result = $doc->data();
+		$this->assertEqual($expected, $result);
+
+		unset($doc->d);
+		unset($expected['d']);
+		$result = $doc->data();
+		$this->assertEqual($expected, $result);
+
+		$exportedRoot = $doc->export();
+		$this->assertEqual(array('a' => true, 'd' => true), $exportedRoot['remove']);
+
+		$exportedB = $doc->b->export();
+		$this->assertEqual(array('bb' => true), $exportedB['remove']);
+
+		$exportedCCB = $doc->c->cb->export();
+		$this->assertEqual(array('cba' => true), $exportedCCB['remove']);
+	}
+
 	public function testErrors() {
 		$doc = new Document(array('data' => array(
 			'title' => 'Post',
@@ -619,6 +674,7 @@ class DocumentTest extends \lithium\test\Unit {
 		$expected = array(
 			'data' => array('foo' => 'bar', 'baz' => 'dib'),
 			'update' => array('foo' => 'bar', 'baz' => 'dib'),
+			'remove' => array(),
 			'increment' => array(),
 			'key' => '',
 			'exists' => false


### PR DESCRIPTION
Added list of removed fields to pass ones to Exporter class and to fix Iterator implementation.
Fixed lithium\data\source\mongo_db\Exporter::_diff() method to compare arrays.
