### PR TITLE
Developing on a local machine never recognized test environment based on the url.

### DIFF
--- a/core/Environment.php
+++ b/core/Environment.php
@@ -285,7 +285,7 @@ class Environment {
 					return 'test';
 				case ($request->env('PLATFORM') == 'CLI'):
 					return 'development';
-				case (preg_match('/^test\//', $request->url) && $isLocal):
+				case (preg_match('/^test/', $request->url) && $isLocal):
 					return 'test';
 				case ($isLocal):
 					return 'development';


### PR DESCRIPTION
It prevented the Lithium testing bench to run under testing envorinment
while local.
