### PR TITLE
Fix for Renderer::_render() with no set $request property.

### DIFF
--- a/template/view/Renderer.php
+++ b/template/view/Renderer.php
@@ -486,8 +486,10 @@ abstract class Renderer extends \lithium\core\Object {
 	 * @return string Returns a the rendered template content as a string.
 	 */
 	protected function _render($type, $template, array $data = array(), array $options = array()) {
-		$library = $this->_request->library;
-		$options += compact('library');
+		if ($this->_request) {
+			$library = $this->_request->library;
+			$options += compact('library');
+		}
 		return $this->_view->render($type, $data + $this->_data, compact('template') + $options);
 	}
 }


### PR DESCRIPTION
Quick fix in the renderer class for instances when $_request is null.  I encountered this when attaching my own error handler method which was not attached to Dispatch::run() as the example error handler is, and thus the request object was not available.

My error template called $this->_render() to include a template element and this raised an ErrorException "Trying to get property of non-object in [...]/Projects/Lithium/dev/li3_core/libraries/lithium/template/view/Renderer.php on line 490";
