### PR TITLE
Fix for Set::append

### DIFF
--- a/tests/cases/util/SetTest.php
+++ b/tests/cases/util/SetTest.php
@@ -1387,14 +1387,10 @@ class SetTest extends \lithium\test\Unit {
 
 		$array1 = array(
 			'ModelOne' => array(
-				'id' => 1001,
-				'field_one' => 's1.0.m1.f1',
-				'field_two' => 's1.0.m1.f2'
+				'id' => 1001, 'field_one' => 's1.0.m1.f1', 'field_two' => 's1.0.m1.f2'
 			),
 			'ModelTwo' => array(
-				'id' => 1002,
-				'field_one' => 's1.0.m2.f1',
-				'field_two' => 's1.0.m2.f2'
+				'id' => 1002, 'field_one' => 's1.0.m2.f1', 'field_two' => 's1.0.m2.f2'
 			)
 		);
 		$array2 = array(
@@ -1412,16 +1408,10 @@ class SetTest extends \lithium\test\Unit {
 
 		$expected = array(
 			'ModelOne' => array(
-				'id' => 1001,
-				'field_one' => 's1.0.m1.f1',
-				'field_two' => 's1.0.m1.f2',
-				'field_three' => 's1.0.m1.f3'
+				'id' => 1001, 'field_one' => 's1.0.m1.f1', 'field_two' => 's1.0.m1.f2', 'field_three' => 's1.0.m1.f3'
 			),
 			'ModelTwo' => array(
-				'id' => 1002,
-				'field_one' => 's1.0.m2.f1',
-				'field_two' => 's1.0.m2.f2',
-				'field_three' => 's1.0.m2.f3'
+				'id' => 1002, 'field_one' => 's1.0.m2.f1', 'field_two' => 's1.0.m2.f2', 'field_three' => 's1.0.m2.f3'
 			)
 		);
 		$this->assertIdentical($expected, $result);

--- a/util/Set.php
+++ b/util/Set.php
@@ -40,15 +40,14 @@ class Set {
 		$arrays = func_get_args();
 		$array = array_shift($arrays);
 		foreach ($arrays as $array2) {
-			if (! $array && $array2) {
+			if (!$array && $array2) {
 				$array = $array2;
 				continue;
 			}
 			foreach ($array2 as $key => $value) {
-				if (! array_key_exists($key, $array)) {
+				if (!array_key_exists($key, $array)) {
 					$array[$key] = $value;
-				}
-				elseif (is_array($value)) {
+				} elseif (is_array($value)) {
 					$array[$key] = static::append($array[$key], $array2[$key]);
 				}
 			}


### PR DESCRIPTION
In Set::append replaced "isset" by "array_key_exists" and add support for variable-length argument lists
