### PR TITLE
Allows MongoIds and MongoDates in arrays of subobjects.

### DIFF
--- a/tests/cases/util/CollectionTest.php
+++ b/tests/cases/util/CollectionTest.php
@@ -275,6 +275,33 @@ class CollectionTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 	}
 
+	public function testCollectionHandlers() {
+		$obj = new StdClass();
+		$obj->a = "b";
+		$handlers = array(
+			'stdClass' => function($v) { return (array) $v; }
+		);
+		$data = array(
+			'test' => new Collection(array('data' => compact('obj'))),
+			'obj' => $obj
+		);
+
+		$collection = new Collection(compact('data'));
+		$expected = array(
+			'test' => array(
+				'obj' => array('a' => 'b')
+			),
+			'obj' => array('a' => 'b')
+		);
+		$this->assertIdentical($expected, $collection->to('array', compact('handlers')));
+
+		$handlers = array(
+			'stdClass' => function($v) { return $v; }
+		);
+		$expected = array('test' => compact('obj')) + compact('obj');
+		$this->assertIdentical($expected, $collection->to('array', compact('handlers')));
+	}
+
 	/**
 	 * Tests that the Collection::sort method works appropriately.
 	 *

--- a/util/Collection.php
+++ b/util/Collection.php
@@ -556,7 +556,7 @@ class Collection extends \lithium\core\Object implements \ArrayAccess, \Iterator
 					$result[$key] = $options['handlers'][$class]($item);
 				break;
 				case (method_exists($item, 'to')):
-					$result[$key] = $item->to('array');
+					$result[$key] = $item->to('array', $options);
 				break;
 				case ($vars = get_object_vars($item)):
 					$result[$key] = static::toArray($vars, $options);


### PR DESCRIPTION
Also adds null value capabilities via schema 'null' => true regardless of the field type.

Potential fix for #623.
