### PR TITLE
Fixed the Command::nl() docblock. Method doesn't print to the output,

### DIFF
--- a/console/Command.php
+++ b/console/Command.php
@@ -331,10 +331,10 @@ class Command extends \lithium\core\Object {
 	}
 
 	/**
-	 * Add newlines ("\n") to the output stream.
+	 * Add newlines ("\n") a given number of times and return them in a single string.
 	 *
-	 * @param integer $number The number of new lines to print.
-	 * @return integer
+	 * @param integer $number The number of new lines to fill into a string.
+	 * @return string
 	 */
 	public function nl($number = 1) {
 		return str_repeat("\n", $number);


### PR DESCRIPTION
it builds a string and returns it.
