### PR TITLE
library controllers use library views

### DIFF
--- a/action/Controller.php
+++ b/action/Controller.php
@@ -231,6 +231,7 @@ class Controller extends \lithium\core\Object {
 	public function render(array $options = array()) {
 		$media = $this->_classes['media'];
 		$class = get_class($this);
+		$library = preg_replace('/\\\\.*/', '', $class);
 		$name = preg_replace('/Controller$/', '', substr($class, strrpos($class, '\\') + 1));
 		$key = key($options);
 
@@ -243,8 +244,10 @@ class Controller extends \lithium\core\Object {
 			'location'   => false,
 			'data'       => null,
 			'head'       => false,
-			'controller' => Inflector::underscore($name)
+			'controller' => Inflector::underscore($name),
+			'library'    => $library
 		);
+
 		$options += $this->_render + $defaults;
 
 		if ($key && $media::type($key)) {


### PR DESCRIPTION
To this point, li3 defaults to app/views. With this change, li3 looks by
default in libraries/foo/views/, where foo is the library containing the
Controller (and app if it is, in fact, an app/ controller). It seems to me this ought to be default, so that distributed libraries can contain their own views, without necessitating explicit specification of those views in the controllers.

Not sure if this will impact out-of-the-box functionality, e.g. included mini-sites, tests, docs, etc. It might cause problems for backwards-compatibility for existing projects built on li3.

Also I grant that the preg_replace() is kludgy. If there is a more elegant way to look up current library, I will modify.
