### PR TITLE
From Controller, look for view in own library

### DIFF
--- a/action/Controller.php
+++ b/action/Controller.php
@@ -10,6 +10,7 @@ namespace lithium\action;
 
 use lithium\util\Inflector;
 use lithium\action\DispatchException;
+use lithium\core\Libraries;
 
 /**
  * The `Controller` class is the fundamental building block of your application's request/response
@@ -243,8 +244,10 @@ class Controller extends \lithium\core\Object {
 			'location'   => false,
 			'data'       => null,
 			'head'       => false,
-			'controller' => Inflector::underscore($name)
+			'controller' => Inflector::underscore($name),
+			'library'    => Libraries::get($class)
 		);
+
 		$options += $this->_render + $defaults;
 
 		if ($key && $media::type($key)) {

--- a/tests/cases/action/ControllerTest.php
+++ b/tests/cases/action/ControllerTest.php
@@ -372,6 +372,22 @@ class ControllerTest extends \lithium\test\Unit {
 		$this->expectException("Action `foo` not found.");
 		$postsController(new Request(), array('action' => 'foo'));
 	}
+
+	/**
+	 * Tests that the library of the controller is automatically added to the default rendering
+	 * options.
+	 */
+	public function testLibraryScoping() {
+		$request = new Request();
+		$request->params['controller'] = 'lithium\tests\mocks\action\MockPostsController';
+
+		$controller = new MockPostsController(compact('request') + array('classes' => array(
+			'media' => 'lithium\tests\mocks\action\MockMediaClass'
+		)));
+
+		$controller->render();
+		$this->assertEqual('lithium', $controller->response->options['library']);
+	}
 }
 
 ?>


### PR DESCRIPTION
To this point, li3 defaults to app/views. With this change, li3 looks by
default in libraries/foo/views/, where foo is the library containing the
Controller.

Redo of #639 to point to dev
