### PR TITLE
allow dispatching of unknown methods to redis connection object

### DIFF
--- a/storage/cache/adapter/Redis.php
+++ b/storage/cache/adapter/Redis.php
@@ -117,22 +117,7 @@ class Redis extends \lithium\core\Object {
 	 * @return mixed Returns the result of the method call
 	 */
 	public function __call($method, $params = array()) {
-		switch (count($params)) {
-			case 0:
-				return $this->connection->{$method}();
-			case 1:
-				return $this->connection->{$method}($params[0]);
-			case 2:
-				return $this->connection->{$method}($params[0], $params[1]);
-			case 3:
-				return $this->connection->{$method}($params[0], $params[1], $params[2]);
-			case 4:
-				return $this->connection->{$method}($params[0], $params[1], $params[2], $params[3]);
-			case 5:
-				return $this->connection->{$method}($params[0], $params[1], $params[2], $params[3], $params[4]);
-			default:
-				return call_user_func_array(array(&$this->connection, $method), $params);
-		}
+		return call_user_func_array(array(&$this->connection, $method), $params);
 	}
 
 	/**


### PR DESCRIPTION
Recently, i was using redis more often. The already implemented cache-adapter is just a start but it allows for easy access to the redis backend.

Some of the functions of redis are not available through the cache adapter, though. As stated in `storage\Cache` it is easy to use custom methods on cache-adapters like that:

```
Cache::adapter('named-configuration')->methodName($argument);
```

That way, it would be easily possible to use custom functions on the redis-adapter. After i created an extension, building some functionality i needed for my project i finally came to this easy, yet powerful way of extending the current redis adapter to allow for dispatching of methods on to the redis connection object.

As this is just an add-on to the existing functionality it might be useful to others. What do you think?

Another way of achieving a similar functionality (without using magic methods) would be to have a method called `command` or `exec` or what comes to your mind, that takes 2 parameters. First one would be the name of the method to call, second an array with parameters to be passed into that method. If you would prefer that way, just give me a note.

I think, as lithium makes it easy to get your fingers into these innovative technologies it should make it easy to go beyond the basic functionality and let people grow with that from what they have.
