### PR TITLE
allow auth adapters to return a single value instead of arrays

### DIFF
--- a/security/Auth.php
+++ b/security/Auth.php
@@ -150,16 +150,11 @@ class Auth extends \lithium\core\Adaptable {
 			}
 
 			if (($credentials) && $data = $self::adapter($name)->check($credentials, $options)) {
-				if ($options['persist']) {
-					foreach ($data as $key => $value) {
-						if (!in_array($key, $options['persist'])) {
-							unset($data[$key]);
-						}
-					}
-				} else {
+				if ($options['persist'] && is_array($data)) {
+					$data = array_intersect_key($data, array_fill_keys($options['persist'], true));
+				} elseif (is_array($data)) {
 					unset($data['password']);
 				}
-
 				return ($options['writeSession']) ? $self::set($name, $data) : $data;
 			}
 			return false;

--- a/tests/cases/security/AuthTest.php
+++ b/tests/cases/security/AuthTest.php
@@ -125,6 +125,28 @@ class AuthTest extends \lithium\test\Unit {
 		$result = Auth::check('test', $user, array('success' => true, 'checkSession' => false));
 		$this->assertEqual($expected, $result);
 		$this->assertEqual($expected, Session::read('test'));
+
+		Auth::reset();
+
+		Auth::config(array(
+			'test' => array(
+				'adapter' => $this->_classes['mockAuthAdapter'],
+			)
+		));
+
+		$user = array(
+			'id' => '123',
+			'username' => 'foobar',
+			'password' => 'not!important',
+			'email' => 'foo@bar.com',
+			'insuranceNumer' => 1234567
+		);
+
+		$expected = 123;
+
+		$result = Auth::check('test', $user, array('keyOnly' => true, 'checkSession' => false));
+		$this->assertEqual($expected, $result);
+		$this->assertEqual($expected, Session::read('test'));
 	}
 }
 

--- a/tests/mocks/security/auth/adapter/MockAuthAdapter.php
+++ b/tests/mocks/security/auth/adapter/MockAuthAdapter.php
@@ -11,7 +11,13 @@ namespace lithium\tests\mocks\security\auth\adapter;
 class MockAuthAdapter extends \lithium\core\Object {
 
 	public function check($credentials, array $options = array()) {
-		return isset($options['success']) ? $credentials : false;
+		switch (true) {
+			case isset($options['success']):
+				return $credentials;
+			case isset($options['keyOnly']):
+				return $credentials['id'];
+		}
+		return false;
 	}
 
 	public function set($data, array $options = array()) {


### PR DESCRIPTION
Change behavior of auth adapters so, that they can return scalar values.

Currently, auth adapters must return arrays, because of a hard-coded unset on `$data['password']`.

This PR changed the behavior so, that an auth adapter can return a scalar value without being presented with a

```
Fatal error: Cannot unset string offsets in /libraries/lithium/security/Auth.php on line 160
```

An updated unit-test is included.

follow up to #651
