### PR TITLE
allow dispatching of unknown methods to redis connection object

### DIFF
--- a/storage/cache/adapter/Redis.php
+++ b/storage/cache/adapter/Redis.php
@@ -100,6 +100,27 @@ class Redis extends \lithium\core\Object {
 	}
 
 	/**
+	 * Dispatches a not-found method to the Redis connection object.
+	 *
+	 * That way, one can easily use a custom method on that redis adapter like that:
+	 *
+	 * {{{Cache::adapter('named-of-redis-config')->methodName($argument);}}}
+	 *
+	 * If you want to know, what methods are available, have a look at the readme of phprdis.
+	 * One use-case might be to query possible keys, e.g.
+	 *
+	 * {{{Cache::adapter('redis')->keys('*');}}}
+	 *
+	 * @link https://github.com/nicolasff/phpredis GitHub: PhpRedis Extension
+	 * @param string $method Name of the method to call
+	 * @param array $params Parameter list to use when calling $method
+	 * @return mixed Returns the result of the method call
+	 */
+	public function __call($method, $params = array()) {
+		return call_user_func_array(array(&$this->connection, $method), $params);
+	}
+
+	/**
 	 * Sets expiration time for cache keys
 	 *
 	 * @param string $key The key to uniquely identify the cached item

--- a/tests/cases/storage/cache/adapter/RedisTest.php
+++ b/tests/cases/storage/cache/adapter/RedisTest.php
@@ -390,6 +390,18 @@ class RedisTest extends \lithium\test\Unit {
 		$result = $this->_redis->delete($key);
 		$this->assertTrue($result);
 	}
+
+	public function testMethodDispatch() {
+
+		$this->_redis->flushdb();
+		$this->_redis->set('some_key', 'somevalue');
+
+		$result = $this->redis->keys('*');
+		$this->assertEqual($result, array('some_key'), 'redis method dispatch failed');
+
+		$result = $this->redis->info();
+		$this->assertTrue(is_array($result), 'redis method dispatch failed');
+	}
 }
 
 ?>


### PR DESCRIPTION
Recently, i was using redis more often. The already implemented cache-adapter is just a start but it allows for easy access to the redis backend.

Some of the functions of redis are not available through the cache adapter, though. As stated in `storage\Cache` it is easy to use custom methods on cache-adapters like that:

```
Cache::adapter('named-configuration')->methodName($argument);
```

That way, it would be easily possible to use custom functions on the redis-adapter. After i created an extension, building some functionality i needed for my project i finally came to this easy, yet powerful way of extending the current redis adapter to allow for dispatching of methods on to the redis connection object.

As this is just an add-on to the existing functionality it might be useful to others. What do you think?

Another way of achieving a similar functionality (without using magic methods) would be to have a method called `command` or `exec` or what comes to your mind, that takes 2 parameters. First one would be the name of the method to call, second an array with parameters to be passed into that method. If you would prefer that way, just give me a note.

I think, as lithium makes it easy to get your fingers into these innovative technologies it should make it easy to go beyond the basic functionality and let people grow with that from what they have.

EDIT: This is pointing to 'dev' and has a unit-test, references #653 and #654 - sorry for the mess, was not sure how to squash commits after push.
