### PR TITLE
Implementing new features for queries Warning BC BREAK

### DIFF
--- a/data/Source.php
+++ b/data/Source.php
@@ -279,6 +279,14 @@ abstract class Source extends \lithium\core\Object {
 		unset($options['class']);
 		return $this->_instance($class, compact('model', 'data') + $options);
 	}
+
+	/**
+	 * Applying a strategy to a `lithium\data\model\Query` object
+	 *
+	 * @param array $options The option array
+	 * @param object $context A query object to configure
+	 */
+	public function finalizeQuery($options, $context) {}
 }
 
 ?>

--- a/data/collection/RecordSet.php
+++ b/data/collection/RecordSet.php
@@ -8,6 +8,8 @@
 
 namespace lithium\data\collection;
 
+use lithium\util\Set;
+
 class RecordSet extends \lithium\data\Collection {
 
 	/**
@@ -17,6 +19,29 @@ class RecordSet extends \lithium\data\Collection {
 	 * @var array
 	 */
 	protected $_columns = array();
+
+	/**
+	 * A recursive array of relation dependencies where key are relations
+	 * and value are arrays with their relation dependencies
+	 *
+	 * @var array
+	 */
+	protected $_dependencies = array();
+
+	/**
+	 * Precompute index of the main model primary key(s) which allow to find
+	 * values directly is result data without the column name matching process
+	 *
+	 * @var array
+	 */
+	protected $_keyIndex = array();
+
+	/**
+	 * Precompute the main model name
+	 *
+	 * @var array
+	 */
+	protected $_name = null;
 
 	/**
 	 * Initializes the record set and uses the database connection to get the column list contained
@@ -31,6 +56,11 @@ class RecordSet extends \lithium\data\Collection {
 		parent::_init();
 		if ($this->_result) {
 			$this->_columns = $this->_columnMap();
+			if ($this->_query) {
+				$this->_dependencies = Set::expand(Set::normalize(array_keys($this->_columns)));
+				$this->_name = $this->_query->name();
+				$this->_keyIndex = $this->_keyIndex($this->_name);
+			}
 		}
 	}
 
@@ -67,95 +97,146 @@ class RecordSet extends \lithium\data\Collection {
 		return $key !== null ? $this->_data[$key] = $data : $this->_data[] = $data;
 	}
 
+	/**
+	 * Convert a PDO `Result` array to a nested `Record` object
+	 *
+	 * @param array $data 2 dimensional PDO `Result` array
+	 * @return object Returns a `Record` object
+	 */
 	protected function _mapRecord($data) {
-		$options = array('exists' => true);
-		$relationships = array();
 		$primary = $this->_model;
 		$conn = $primary::connection();
+		$main = $record = array();
+		$i = 0;
 
-		if (!$this->_query) {
-			return $conn->item($primary, $data, $options + compact('relationships'));
+		foreach ($this->_keyIndex as $key => $value) {
+			$main[$key] = $data[$key];
 		}
-
-		$dataMap = array();
-		$relMap = $this->_query->relationships();
-		$main = null;
 
 		do {
 			$offset = 0;
-
+			if ($i != 0) {
+				$keys = array();
+				foreach ($this->_keyIndex as $key => $value) {
+					$keys[$key] = $data[$key];
+				}
+				if ($main != $keys) {
+					$this->_result->prev();
+					break;
+				}
+			}
 			foreach ($this->_columns as $name => $fields) {
 				$fieldCount = count($fields);
-				$record = array_combine($fields, array_slice($data, $offset, $fieldCount));
+				$record[$i][$name] = array_combine($fields, array_slice($data, $offset, $fieldCount));
 				$offset += $fieldCount;
-
-				if ($name === 0) {
-					if ($main && $main != $record) {
-						$this->_result->prev();
-						break 2;
-					}
-					$main = $record;
-					continue;
-				}
-
-				if ($relMap[$name]['type'] != 'hasMany') {
-					$dataMap[$name] = $record;
-					continue;
-				}
-
-				if (array_filter($record)) {
-					$dataMap[$name][] = $record;
-				}
 			}
+			$i++;
 		} while ($data = $this->_result->next());
 
-		foreach (array_filter(array_keys($this->_columns)) as $name) {
-			if (!array_key_exists($name, $dataMap)) {
-				$dataMap[$name] = array();
-			}
-		}
+		$relMap = $this->_query->relationships();
+		return $this->_hydrateRecord($this->_dependencies[$this->_name], $primary, $record, 0, $i, $this->_name, $relMap, $conn);
+	}
 
-		foreach ($dataMap as $name => $rel) {
-			$field = $relMap[$name]['fieldName'];
-			$relModel = $relMap[$name]['model'];
+	/**
+	 * Hydrate a 2 dimensional PDO `Result` array
+	 *
+	 * @param array $relations The cascading with relation
+	 * @param string $primary Model classname
+	 * @param array $record Loaded Records
+	 * @param integer $min
+	 * @param integer $max
+	 * @param string $name Alias name
+	 * @param array $relMap The query relationships array
+	 * @param object $conn The connection object
+	 * @return object Returns a `Record` object
+	 */
+	protected function _hydrateRecord($relations, $primary, $record, $min, $max, $name, &$relMap, $conn) {
+		$options = array('exists' => true);
 
-			if ($relMap[$name]['type'] == 'hasMany') {
-				foreach ($rel as &$data) {
-					$data = $conn->item($relModel, $data, $options);
+		$count = count($record);
+		if (!empty($relations)) {
+			foreach ($relations as $relation => $subrelations) {
+				$relName = $name . '.' . $relation;
+				$field = $relMap[$relName]['fieldName'];
+				$relModel = $relMap[$relName]['model'];
+				$relPk = $relModel::key();
+				$index = is_array($relPk) ? false: true;
+
+				if ($relMap[$relName]['type'] === 'hasMany') {
+					$main = null;
+					$i = $min;
+					$j = $i + 1;
+					$main = $relModel::key($record[$i][$relName]);
+					$rel = array();
+					while ($j < $max) {
+						$keys = $relModel::key($record[$j][$relName]);
+						if ($main != $keys) {
+							$rel[] = $this->_hydrateRecord($subrelations, $relModel, $record, $i, $j, $relName, $relMap, $conn);
+							$main = $keys;
+							$i = $j;
+						}
+						$j++;
+					}
+					if (array_filter($record[$i][$relName])) {
+						$rel[] = $this->_hydrateRecord($subrelations, $relModel, $record, $i, $j, $relName, $relMap, $conn);
+					}
+					$opts = array('class' => 'set') + $options;
+					$record[$min][$name][$field] = $conn->item($primary, $rel, $opts);
+				} else {
+					$record[$min][$name][$field] = $this->_hydrateRecord($subrelations, $relModel, $record, $min, $max, $relName, $relMap, $conn);
 				}
-				$opts = array('class' => 'set');
-				$relationships[$field] = $conn->item($relModel, $rel, $options + $opts);
-				continue;
 			}
-			$relationships[$field] = $conn->item($relModel, $rel, $options);
 		}
-		return $conn->item($primary, $main, $options + compact('relationships'));
+		return $conn->item($primary, $record[$min][$name], $options);
 	}
 
 	protected function _columnMap() {
 		if ($this->_query && $map = $this->_query->map()) {
-			if (isset($map[$this->_query->alias()])) {
-				$map = array($map[$this->_query->alias()]) + $map;
-				unset($map[$this->_query->alias()]);
-			} else {
-				$map = array(array_shift($map)) + $map;
-			}
 			return $map;
 		}
 		if (!($model = $this->_model)) {
 			return array();
 		}
 		if (!is_object($this->_query) || !$this->_query->join()) {
-			$map = $model::connection()->schema($this->_query, $this->_result, $this);
-			return array_values($map);
+			$map = $model::connection()->schema($this->_query);
+			return $map;
 		}
-
 		$model = $this->_model;
-		$map = $model::connection()->schema($this->_query, $this->_result, $this);
-		$map = array($map[$this->_query->alias()]) + $map;
-		unset($map[$this->_query->alias()]);
+		$map = $model::connection()->schema($this->_query);
 
 		return $map;
+	}
+
+	/**
+	 * Result object contain SQL result which are generally a 2 dimentionnal array
+	 * where line are records and columns are fields.
+	 * This function extract from the Result object the index of primary key(s).
+	 *
+	 * @param string $name The name of the relation to retreive the index of
+	 *               corresponding primary key(s).
+	 * @return array An array where key are index and value are primary key fieldname
+	 */
+	protected function _keyIndex($name) {
+		if (!($model = $this->_model) || !isset($this->_columns[$name])) {
+			return array();
+		}
+		$index = 0;
+		foreach ($this->_columns as $key => $value) {
+			if ($key == $name) {
+				$flip = array_flip($value);
+				$keys = $model::meta('key');
+				if (!is_array($keys)) {
+					$keys = array($keys);
+				}
+				$keys = array_flip($keys);
+				$keys = array_intersect_key($flip, $keys);
+				foreach ($keys as &$value) {
+					$value += $index;
+				}
+				return array_flip($keys);
+			}
+			$index += count($value);
+		}
 	}
 }
 

--- a/data/model/Query.php
+++ b/data/model/Query.php
@@ -8,9 +8,9 @@
 
 namespace lithium\data\model;
 
+use lithium\util\Set;
 use lithium\data\Source;
 use lithium\core\ConfigException;
-use lithium\data\model\QueryException;
 
 /**
  * The `Query` class acts as a container for all information necessary to perform a particular
@@ -79,6 +79,25 @@ class Query extends \lithium\core\Object {
 	);
 
 	/**
+	 * Count the number of identical models in a query for building
+	 * unique aliases
+	 *
+	 * @see lithium\data\model\Query::alias()
+	 *
+	 * @var array
+	 */
+	protected $_alias = array();
+
+	/**
+	 * Map the generated aliases to relation dependencies
+	 *
+	 * @see lithium\data\model\Query::alias()
+	 *
+	 * @var array
+	 */
+	protected $_aliases = array();
+
+	/**
 	 * Auto configuration properties.
 	 *
 	 * @var array
@@ -86,38 +105,81 @@ class Query extends \lithium\core\Object {
 	protected $_autoConfig = array('type', 'map');
 
 	/**
-	 * Class constructor, which initializes the default values this object supports. Even though
-	 * only a specific list of configuration parameters is available by default, the `Query` object
-	 * uses the `__call()` method to implement automatic getters and setters for any arbitrary piece
-	 * of data.
+	 * Importing methods
 	 *
-	 * This means that any information may be passed into the constructor may be used by the backend
-	 * data source executing the query (or ignored, if support is not implemented). This is useful
-	 * if, for example, you wish to extend a core data source and implement custom fucntionality.
-	 * @param array $config
+	 * @var array
+	 */
+	protected $_importMethods = array(
+		'model', 'entity', 'fields', 'conditions', 'having', 'group', 'order',
+		'limit', 'offset', 'page', 'data', 'calculate', 'schema', 'comment'
+	);
+
+	/**
+	 * Boolean indicate if the query is built or not
+	 *
+	 * @var string
+	 */
+	protected $_built = false;
+
+	/**
+	 * Class constructor, which initializes the default values this object supports.
+	 * Even though only a specific list of configuration parameters is available
+	 * by default, the `Query` object uses the `__call()` method to implement
+	 * automatic getters and setters for any arbitrary piece of data.
+	 *
+	 * This means that any information may be passed into the constructor may be
+	 * used by the backend data source executing the query (or ignored, if support
+	 * is not implemented). This is useful if, for example, you wish to extend a
+	 * core data source and implement custom fucntionality.
+	 *
+	 * @param array $config Config options:
+	 *        - `'type'` _string_: The type of the query (`read`, `insert`, `update`, `delete`).
+	 *        - `'entity'` _object_: The base entity to query on. If set `'model'` is optionnal.
+	 *        - `'model'` _string_: The base model to query on.
+	 *        - `'source'` _string_: The name of the table/collection. Unnecessary
+	 *          if `model` is set.
+	 *        - `'alias'` _string_: Alias for the source. Unnecessary if `model` is set.
+	 *        - `'schema'` _object_: A schema model. Unnecessary if `model` is set.
+	 *        - `'fields'` _array_: The fields to retreive.
+	 *        - `'conditions'` _array_: The conditions of the queries
+	 *        - `'having'` _array_: The having conditions of the queries
+	 *        - `'group'` _string_: The group by parameter.
+	 *        - `'order'` _string_: The order by parameter.
+	 *        - `'limit'` _string_: The limit parameter.
+	 *        - `'offset'` _string_: The offset of the `limit` options.
+	 *        - `'page'` _string_: Convenience parameter for setting the `offset`:
+	 *          `offset` = `page` * `limit`.
+	 *        - `'with'` _array_: Contain dependencies. Works only if `model` is set.
+	 *        - `'joins'` _array_: Contain manual join dependencies.
+	 *        - `'data'` _array_: Datas for update queries.
+	 *        - `'whitelist'` _array_: Allowed fields for updating queries.
+	 *        - `'calculate'` _string_: Alias name of the count.
+	 *        - `'comment'` _string_: Comment for the query.
+	 *        - `'map'` _object_: Unnecessary if `model` is set.
+	 *        - `'relationships'` _array_: Unnecessary if `model` is set.
 	 */
 	public function __construct(array $config = array()) {
 		$defaults = array(
-			'calculate'  => null,
-			'schema'     => null,
+			'model' => null,
+			'entity' => null,
+			'source' => null,
+			'alias' => null,
+			'fields' => array(),
 			'conditions' => array(),
-			'having'     => array(),
-			'fields'     => array(),
-			'data'       => array(),
-			'model'      => null,
-			'alias'      => null,
-			'source'     => null,
-			'order'      => null,
-			'offset'     => null,
-			'name'       => null,
-			'limit'      => null,
-			'page'       => null,
-			'group'      => null,
-			'comment'    => null,
-			'joins'      => array(),
-			'with'       => array(),
-			'map'        => array(),
-			'whitelist'  => array(),
+			'having' => array(),
+			'group' => null,
+			'order' => null,
+			'limit' => null,
+			'offset' => null,
+			'page' => null,
+			'with' => array(),
+			'joins' => array(),
+			'data' => array(),
+			'whitelist' => array(),
+			'calculate' => null,
+			'schema' => null,
+			'comment' => null,
+			'map' => array(),
 			'relationships' => array()
 		);
 		parent::__construct($config + $defaults);
@@ -127,9 +189,11 @@ class Query extends \lithium\core\Object {
 		parent::_init();
 		unset($this->_config['type']);
 
-		foreach ($this->_config as $key => $val) {
-			if (method_exists($this, $key) && $val !== null) {
-				$this->_config[$key] = is_array($this->_config[$key]) ? array() : null;
+		$keys = array_keys($this->_config);
+		foreach ($this->_importMethods as $key) {
+			$val = $this->_config[$key];
+			if ($val !== null) {
+				$this->_config[$key] = is_array($val) ? array() : null;
 				$this->{$key}($val);
 			}
 		}
@@ -139,16 +203,21 @@ class Query extends \lithium\core\Object {
 		if ($this->_config['with']) {
 			$this->_associate($this->_config['with']);
 		}
-		$joins = $this->_config['joins'];
-		$this->_config['joins'] = array();
 
-		foreach ($joins as $i => $join) {
-			$this->join($i, $join);
-		}
 		if ($this->_entity && !$this->_config['model']) {
 			$this->model($this->_entity->model());
 		}
-		unset($this->_config['entity'], $this->_config['init'], $this->_config['with']);
+
+		$this->alias($this->_config['alias']);
+
+		if ($this->_config['with']) {
+			if (!$model = $this->model()) {
+				throw new ConfigException("The `'with'` option needs a valid binded model.");
+			}
+			$this->_config['with'] = Set::normalize($this->_config['with']);
+		}
+
+		unset($this->_config['entity'], $this->_config['init']);
 	}
 
 	/**
@@ -202,8 +271,7 @@ class Query extends \lithium\core\Object {
 		}
 		$this->_config['model'] = $model;
 		$this->_config['source'] = $this->_config['source'] ?: $model::meta('source');
-		$this->_config['alias'] = $this->_config['alias'] ?: $model::meta('name');
-		$this->_config['name'] = $this->_config['name'] ?: $this->_config['alias'];
+		$this->_config['name'] = $model::meta('name');
 		return $this;
 	}
 
@@ -407,71 +475,131 @@ class Query extends \lithium\core\Object {
 	}
 
 	/**
-	 * Set and get the join queries
+	 * Set and get the relationships.
+	 *
+	 * @param string $relpath A dotted path.
+	 * @param array $config the config array to set.
+	 * @return mixed The relationships array or a relationship array if `$relpath` is set. Returns
+	 *         `null` if a join doesn't exist.
+	 */
+	public function relationships($relpath = null, $config = null) {
+		if ($config) {
+			if (!$relpath) {
+				throw new ConfigException("The relation dotted path is empty.");
+			}
+			$this->_config['relationships'][$relpath] = $config;
+			return $this;
+		}
+		if (!$relpath) {
+			return $this->_config['relationships'];
+		}
+		if (isset($this->_config['relationships'][$relpath])) {
+			return $this->_config['relationships'][$relpath];
+		}
+	}
+
+	/**
+	 * Set and get the joins
 	 *
 	 * @param string $name Optional name of join. Unless two parameters are passed, this parameter
 	 *               is regonized as `$join`.
 	 * @param object|string $join A single query object or an array of query objects
-	 * @return array of query objects
+	 * @return mixed The joins array or a join array if `$name` is set. Returns `null` if a join
+	 *         doesn't exist.
 	 */
-	public function join($name = null, $join = null) {
-		if (is_scalar($name) && !$join && isset($this->_config['joins'][$name])) {
-			return $this->_config['joins'][$name];
-		}
-		if ($name && !$join) {
+	public function joins($name = null, $join = null) {
+		if (is_array($name)) {
 			$join = $name;
 			$name = null;
 		}
 		if ($join) {
-			$join = is_array($join) ? $this->_instance(get_class($this), $join) : $join;
-			$name ? $this->_config['joins'][$name] = $join : $this->_config['joins'][] = $join;
+			if (!$name) {
+				$this->_config['joins'][] = $join;
+			} else {
+				$this->_config['joins'][$name] = $join;
+			}
 			return $this;
 		}
-		return $this->_config['joins'];
+		if (!$name) {
+			return $this->_config['joins'];
+		}
+		if (isset($this->_config['joins'][$name])) {
+			return $this->_config['joins'][$name];
+		}
 	}
 
 	/**
 	 * Convert the query's properties to the data sources' syntax and return it as an array.
 	 *
-	 * @param object $dataSource Instance of the data source (`lithium\data\Source`) to use for
-	 *               conversion.
+	 * @param object $source Instance of the data source (`lithium\data\Source`) to use for
+	 *        conversion.
 	 * @param array $options Options to use when exporting the data.
 	 * @return array Returns an array containing a data source-specific representation of a query.
 	 */
-	public function export(Source $dataSource, array $options = array()) {
+	public function export(Source $source, array $options = array()) {
 		$defaults = array('keys' => array());
 		$options += $defaults;
 
 		$keys = $options['keys'] ?: array_keys($this->_config);
-		$methods = $dataSource->methods();
+
 		$results = array('type' => $this->_type);
 
-		$apply = array_intersect($keys, $methods);
+		$apply = array_intersect($keys, $source->methods());
 		$copy = array_diff($keys, $apply);
 
-		foreach ($apply as $item) {
-			$results[$item] = $dataSource->{$item}($this->{$item}(), $this);
+		if (in_array('with', $keys)) {
+			$this->_finalizeQuery($source);
 		}
+
+		foreach ($apply as $item) {
+			$results[$item] = $source->{$item}($this->{$item}(), $this);
+		}
+
 		foreach ($copy as $item) {
 			if (in_array($item, $keys)) {
 				$results[$item] = $this->_config[$item];
 			}
 		}
+
 		if (in_array('data', $keys)) {
 			$results['data'] = $this->_exportData();
 		}
+
 		if (isset($results['source'])) {
-			$results['source'] = $dataSource->name($results['source']);
+			$results['source'] = $source->name($results['source']);
 		}
+
 		if (!isset($results['fields'])) {
 			return $results;
 		}
+
 		$created = array('fields', 'values');
 
 		if (is_array($results['fields']) && array_keys($results['fields']) == $created) {
 			$results = $results['fields'] + $results;
 		}
 		return $results;
+	}
+
+	/**
+	 * Helper method used by `export()` which delegate the query generation to the datasource.
+	 *
+	 * @param object $source Instance of the data source (`lithium\data\Source`) to use for
+	 *        conversion.
+	 */
+	protected function _finalizeQuery(Source $source) {
+		if ($this->_built) {
+			return;
+		}
+		$this->_built = true;
+		if (!$this->_config['with']) {
+			return;
+		}
+		$options = array();
+		if (isset($this->_config['mode'])) {
+			$options = array('mode' => $this->_config['mode']);
+		}
+		$source->finalizeQuery($options, $this);
 	}
 
 	/**
@@ -482,7 +610,6 @@ class Query extends \lithium\core\Object {
 	 */
 	protected function _exportData() {
 		$data = $this->_entity ? $this->_entity->export() : $this->_data;
-
 		if (!$list = $this->_config['whitelist']) {
 			return $data;
 		}
@@ -491,6 +618,7 @@ class Query extends \lithium\core\Object {
 		if (!$this->_entity) {
 			return array_intersect_key($data, $list);
 		}
+
 		foreach ($data as $type => $values) {
 			if (!is_array($values)) {
 				continue;
@@ -515,15 +643,57 @@ class Query extends \lithium\core\Object {
 		}
 	}
 
-	public function alias($alias = null) {
+	/**
+	 * Get or Set a unique alias for the query or a query's relation if `$relpath` is set.
+	 *
+	 * @param mixed $name The name of the alias to set, `true` to get a setted the alias or
+	 *        `null` for generating a unique alias automagically if the alias doesn't exists.
+	 * @param string $relpath A dotted relation name or `null` to identify the query's model.
+	 * @return string A unique alias name or `null` if `$name` is `true` and no alias founded.
+	 */
+	public function alias($name = true, $relpath = null) {
+		if (!$relpath) {
+			if ($name === true || (!$name && $this->_config['alias'])) {
+				return $this->_config['alias'];
+			}
+			if (!$name && !$this->_config['alias'] && ($model = $this->_config['model'])) {
+				$name = $model::meta('name');
+			}
+			$this->_config['alias'] = $name;
+			$this->_alias[$name] = 1;
+			$this->_aliases[$name] = $name;
+			return $this->_config['alias'];
+		}
+		$alias = array_search($relpath, $this->_aliases);
+		if (!$name) {
+			$paths = explode('.', $relpath);
+			$name = end($paths);
+		} elseif ($name === true) {
+			return $alias ?: null;
+		}
 		if ($alias) {
-			$this->_config['alias'] = $alias;
-			return $this;
+			return $alias;
 		}
-		if (!$this->_config['alias'] && ($model = $this->_config['model'])) {
-			$this->_config['alias'] = $model::meta('name');
+		if (isset($this->_alias[$name])) {
+			$this->_alias[$name]++;
+			$name .= '__' . $this->_alias[$name];
+		} else {
+			$this->_alias[$name] = 1;
 		}
-		return $this->_config['alias'];
+		$this->_aliases[$name] = $relpath;
+		return $name;
+	}
+
+	/**
+	 * Return the generated aliases
+	 *
+	 * @param object $source Instance of the data source (`lithium\data\Source`) to use for
+	 *        conversion.
+	 * @return array Map between alias and their corresponding dotted relation
+	 */
+	public function aliases(Source $source) {
+		$this->_finalizeQuery($source);
+		return $this->_aliases;
 	}
 
 	/**
@@ -566,37 +736,27 @@ class Query extends \lithium\core\Object {
 		return $val ? array($key => $val) : array();
 	}
 
-	protected function _associate($related) {
+	/**
+	 * Get/set sub queries for the query.
+	 * The getter must be called after an export since the sub queries are built
+	 * during the export according the export's `mode` option and the query `with` option.
+	 *
+	 * @see lithium\data\model\Query::export()
+	 *
+	 * @param string $relpath a dotted relation path
+	 * @param string $query a query instance
+	 * @return mixed
+	 */
+
+	public function childs($relpath = null, $query = null) {
 		if (!$model = $this->model()) {
-			return;
+			throw new ConfigException("No binded model.");
 		}
-
-		foreach ((array) $related as $name => $config) {
-			if (is_int($name)) {
-				$name = $config;
-			}
-			if (!$relationship = $model::relations($name)) {
-				throw new QueryException("Model relationship `{$name}` not found.");
-			}
-			list($name, $query) = $this->_fromRelationship($relationship);
-			$this->join($name, $query);
+		if ($query) {
+			$this->_childs[$relpath] = $query;
+			return $this;
 		}
-	}
-
-	protected function _fromRelationship($rel) {
-		$model = $rel->to();
-		$name = $rel->name();
-		$type = $rel->type();
-		$fieldName = $rel->fieldName();
-		$this->_config['relationships'][$name] = compact('type', 'model', 'fieldName');
-
-		$constraint = $rel->constraints();
-		$class = get_class($this);
-
-		return array($name, $this->_instance($class, compact('constraint', 'model') + array(
-			'type' => 'LEFT',
-			'alias' => $rel->name()
-		)));
+		return $this->_childs;
 	}
 }
 

--- a/data/model/Relationship.php
+++ b/data/model/Relationship.php
@@ -53,44 +53,44 @@ class Relationship extends \lithium\core\Object {
 	 * Constructs an object that represents a relationship between two model classes.
 	 *
 	 * @param array $config The relationship's configuration, which defines how the two models in
-	 *              question are bound. The available options are:
+	 *        question are bound. The available options are:
 	 *
-	 *             - `'name'` _string_: The name of the relationship in the context of the
-	 *               originating model. For example, a `Posts` model might define a relationship to
-	 *               a `Users` model like so:
+	 *        - `'name'` _string_: The name of the relationship in the context of the
+	 *          originating model. For example, a `Posts` model might define a relationship to
+	 *          a `Users` model like so:
 	 * {{{ public $hasMany = array('Author' => array('to' => 'Users')); }}}
 	 * In this case, the relationship is bound to the `Users` model, but `'Author'` would be the
 	 * relationship name. This is the name with which the relationship is referenced in the
 	 * originating model.
-	 *             - `'key'` _mixed_: An array of fields that define the relationship, where the
-	 *               keys are fields in the originating model, and the values are fields in the
-	 *               target model. If the relationship is not deined by keys, this array should be
-	 *               empty.
-	 *             - `'type'` _string_: The type of relationship. Should be one of `'belongsTo'`,
-	 *               `'hasOne'` or `'hasMany'`.
-	 *             - `'from'` _string_: The fully namespaced class name of the model where this
-	 *                relationship originates.
-	 *             - `'to'` _string_: The fully namespaced class name of the model that this
-	 *               relationship targets.
-	 *             - `'link'` _string_: A constant specifying how the object bound to the
-	 *               originating model is linked to the object bound to the target model. For
-	 *               relational databases, the only valid value is `LINK_KEY`, which means a foreign
-	 *               key in one object matches another key (usually the primary key) in the other.
-	 *               For document-oriented and other non-relational databases, different types of
-	 *               linking, including key lists, database reference objects (such as MongoDB's
-	 *               `MongoDBRef`), or even embedding.
-	 *             - `'fields'` _mixed_: An array of the subset of fields that should be selected
-	 *               from the related object(s) by default. If set to `true` (the default), all
-	 *               fields are selected.
-	 *             - `'fieldName'` _string_: The name of the field used when accessing the related
-	 *               data in a result set. For example, in the case of `Posts hasMany Comments`, the
-	 *               field name defaults to `'comments'`, so comment data is accessed (assuming
-	 *               `$post = Posts::first()`) as `$post->comments`.
-	 *             - `'constraint'` _mixed_: A string or array containing additional constraints
-	 *               on the relationship query. If a string, can contain a literal SQL fragment or
-	 *               other database-native value. If an array, maps fields from the related object
-	 *               either to fields elsewhere, or to arbitrary expressions. In either case, _the
-	 *               values specified here will be literally interpreted by the database_.
+	 *        - `'key'` _mixed_: An array of fields that define the relationship, where the
+	 *          keys are fields in the originating model, and the values are fields in the
+	 *          target model. If the relationship is not deined by keys, this array should be
+	 *          empty.
+	 *        - `'type'` _string_: The type of relationship. Should be one of `'belongsTo'`,
+	 *          `'hasOne'` or `'hasMany'`.
+	 *        - `'from'` _string_: The fully namespaced class name of the model where this
+	 *          relationship originates.
+	 *        - `'to'` _string_: The fully namespaced class name of the model that this
+	 *          relationship targets.
+	 *        - `'link'` _string_: A constant specifying how the object bound to the
+	 *          originating model is linked to the object bound to the target model. For
+	 *          relational databases, the only valid value is `LINK_KEY`, which means a foreign
+	 *          key in one object matches another key (usually the primary key) in the other.
+	 *          For document-oriented and other non-relational databases, different types of
+	 *          linking, including key lists, database reference objects (such as MongoDB's
+	 *          `MongoDBRef`), or even embedding.
+	 *        - `'fields'` _mixed_: An array of the subset of fields that should be selected
+	 *          from the related object(s) by default. If set to `true` (the default), all
+	 *          fields are selected.
+	 *        - `'fieldName'` _string_: The name of the field used when accessing the related
+	 *          data in a result set. For example, in the case of `Posts hasMany Comments`, the
+	 *          field name defaults to `'comments'`, so comment data is accessed (assuming
+	 *          `$post = Posts::first()`) as `$post->comments`.
+	 *        - `'constraints'` _mixed_: A string or array containing additional constraints
+	 *          on the relationship query. If a string, can contain a literal SQL fragment or
+	 *          other database-native value. If an array, maps fields from the related object
+	 *          either to fields elsewhere, or to arbitrary expressions. In either case, _the
+	 *          values specified here will be literally interpreted by the database_.
 	 */
 	public function __construct(array $config = array()) {
 		$defaults = array(
@@ -102,7 +102,7 @@ class Relationship extends \lithium\core\Object {
 			'link' => static::LINK_KEY,
 			'fields' => true,
 			'fieldName' => null,
-			'constraint' => array()
+			'constraints' => array()
 		);
 		parent::__construct($config + $defaults);
 	}
@@ -129,18 +129,6 @@ class Relationship extends \lithium\core\Object {
 			return $this->_config;
 		}
 		return isset($this->_config[$key]) ? $this->_config[$key] : null;
-	}
-
-	public function constraints() {
-		$constraints = array();
-		$config  = $this->_config;
-		$relFrom = $config['from']::meta('name');
-		$relTo   = $config['name'];
-
-		foreach ($this->_config['key'] as $from => $to) {
-			$constraints["{$relFrom}.{$from}"] = "{$relTo}.{$to}";
-		}
-		return $constraints + (array) $this->_config['constraint'];
 	}
 
 	public function __call($name, $args = array()) {

--- a/data/source/database/adapter/MySql.php
+++ b/data/source/database/adapter/MySql.php
@@ -21,14 +21,6 @@ use PDOException;
  */
 class MySql extends \lithium\data\source\Database {
 
-	protected $_classes = array(
-		'entity' => 'lithium\data\entity\Record',
-		'set'    => 'lithium\data\collection\RecordSet',
-		'relationship' => 'lithium\data\model\Relationship',
-		'result' => 'lithium\data\source\database\adapter\pdo\Result',
-		'schema' => 'lithium\data\Schema'
-	);
-
 	/**
 	 * MySQL column type definitions.
 	 *

--- a/data/source/database/adapter/PostgreSql.php
+++ b/data/source/database/adapter/PostgreSql.php
@@ -22,19 +22,6 @@ use PDOException;
 class PostgreSql extends \lithium\data\source\Database {
 
 	/**
-	 * @var PDO
-	 */
-	public $connection;
-
-	protected $_classes = array(
-		'entity' => 'lithium\data\entity\Record',
-		'set' => 'lithium\data\collection\RecordSet',
-		'relationship' => 'lithium\data\model\Relationship',
-		'result' => 'lithium\data\source\database\adapter\pdo\Result',
-		'schema' => 'lithium\data\Schema'
-	);
-
-	/**
 	 * PostgreSQL column type definitions.
 	 *
 	 * @var array

--- a/data/source/database/adapter/Sqlite3.php
+++ b/data/source/database/adapter/Sqlite3.php
@@ -19,14 +19,6 @@ use lithium\core\ConfigException;
  */
 class Sqlite3 extends \lithium\data\source\Database {
 
-	protected $_classes = array(
-		'entity' => 'lithium\data\entity\Record',
-		'set' => 'lithium\data\collection\RecordSet',
-		'relationship' => 'lithium\data\model\Relationship',
-		'result' => 'lithium\data\source\database\adapter\pdo\Result',
-		'schema' => 'lithium\data\Schema'
-	);
-
 	/**
 	 * Pair of opening and closing quote characters used for quoting identifiers in queries.
 	 *

--- a/tests/cases/data/ModelTest.php
+++ b/tests/cases/data/ModelTest.php
@@ -251,13 +251,10 @@ class ModelTest extends \lithium\test\Unit {
 			'link' => 'key',
 			'fields' => true,
 			'fieldName' => 'mock_post',
-			'constraint' => array(),
+			'constraints' => array(),
 			'init' => true
 		);
 		$this->assertEqual($expected, MockComment::relations('MockPost')->data());
-
-		$expected = array('MockComment.mock_post_id' => 'MockPost.id');
-		$this->assertEqual($expected, MockComment::relations('MockPost')->constraints());
 
 		$expected = array(
 			'name' => 'MockComment',
@@ -268,13 +265,10 @@ class ModelTest extends \lithium\test\Unit {
 			'key' => array('id' => 'mock_post_id'),
 			'link' => 'key',
 			'fieldName' => 'mock_comments',
-			'constraint' => array(),
+			'constraints' => array(),
 			'init' => true
 		);
 		$this->assertEqual($expected, MockPost::relations('MockComment')->data());
-
-		$expected = array('MockPost.id' => 'MockComment.mock_post_id');
-		$this->assertEqual($expected, MockPost::relations('MockComment')->constraints());
 
 		MockPost::config(array('meta' => array('connection' => false)));
 		MockComment::config(array('meta' => array('connection' => false)));
@@ -730,7 +724,7 @@ class ModelTest extends \lithium\test\Unit {
 		$this->assertEqual(array('published' => false), $query->conditions());
 
 		$keys = array_keys(array_filter($query->export(MockPost::$connection)));
-		$this->assertEqual(array('type', 'name', 'conditions', 'model', 'alias', 'source'), $keys);
+		$this->assertEqual(array('type', 'name', 'conditions', 'model', 'source', 'alias'), $keys);
 	}
 
 	public function testFindFirst() {

--- a/tests/cases/data/SourceTest.php
+++ b/tests/cases/data/SourceTest.php
@@ -19,8 +19,9 @@ class SourceTest extends \lithium\test\Unit {
 		$expected = array(
 			'connect', 'disconnect', 'sources', 'describe', 'create', 'read', 'update', 'delete',
 			'schema', 'result', 'cast', 'relationship', 'calculation', '__construct', '__destruct',
-			'_init', 'isConnected', 'name', 'methods', 'configureClass', 'item', 'applyFilter',
-			'invokeMethod', '__set_state', '_instance', '_filter', '_parents', '_stop'
+			'_init', 'isConnected', 'name', 'methods', 'configureClass', 'item', 'finalizeQuery',
+			'applyFilter', 'invokeMethod', '__set_state', '_instance', '_filter', '_parents',
+			'_stop'
 		);
 		$this->assertEqual($expected, $methods);
 	}

--- a/tests/cases/data/model/QueryTest.php
+++ b/tests/cases/data/model/QueryTest.php
@@ -8,7 +8,6 @@
 
 namespace lithium\tests\cases\data\model;
 
-use lithium\data\Connections;
 use lithium\data\model\Query;
 use lithium\data\entity\Record;
 use lithium\tests\mocks\data\MockPostObject;
@@ -275,6 +274,7 @@ class QueryTest extends \lithium\test\Unit {
 			'source',
 			'type',
 			'whitelist',
+			'with',
 			'relationships'
 		);
 		$result = array_keys($export);
@@ -324,30 +324,34 @@ class QueryTest extends \lithium\test\Unit {
 
 	public function testJoin() {
 		$query = new Query(array('joins' => array(array('foo' => 'bar'))));
-		$query->join(array('bar' => 'baz'));
+		$query->joins(array('bar' => 'baz'));
 		$expected = array(array('foo' => 'bar'), array('bar' => 'baz'));
-		$joins = $query->join();
+		$joins = $query->joins();
+		$this->assertEqual($expected, $joins);
 
-		$this->assertEqual('bar', $joins[0]->foo());
-		$this->assertNull($joins[0]->bar());
+		$this->assertEqual('bar', $joins[0]['foo']);
+		$this->assertFalse(isset($joins[0]['bar']));
 
-		$this->assertEqual('baz', $joins[1]->bar());
-		$this->assertNull($joins[1]->foo());
+		$this->assertEqual('baz', $joins[1]['bar']);
+		$this->assertFalse(isset($joins[1]['foo']));
 
-		$query->join('zim', array('dib' => 'gir'));
-		$this->assertEqual(3, count($query->join()));
+		$query->joins('zim', array('dib' => 'gir'));
+		$joins = $query->joins();
+		$this->assertEqual(3, count($joins));
+
+		$this->assertEqual('gir', $joins['zim']['dib']);
 
 		$expected = array(
 			array('foo' => 'bar'),
 			array('bar' => 'baz'),
 			'zim' => array('dib' => 'gir')
 		);
-		$this->assertEqual(3, count($query->join()));
-		$this->assertEqual('gir', $query->join('zim')->dib());
+		$this->assertEqual($expected, $joins);
 	}
 
 	public function testWithAssociation() {
 		$model = $this->_model;
+		$model::meta('source', 'foo');
 		$model::bind('hasMany', 'MockQueryComment', array(
 			'class' => 'lithium\tests\mocks\data\model\MockQueryComment'
 		));
@@ -355,10 +359,12 @@ class QueryTest extends \lithium\test\Unit {
 		$query = new Query(compact('model') + array('with' => 'MockQueryComment'));
 		$export = $query->export(new MockDatabase());
 
-		$expected = array('MockQueryComment' => array(
+		$expected = array('MockQueryPost.MockQueryComment' => array(
 			'type' => 'hasMany',
 			'model' => 'lithium\tests\mocks\data\model\MockQueryComment',
-			'fieldName' => 'mock_query_comments'
+			'fieldName' => 'mock_query_comments',
+			'fromAlias' => 'MockQueryPost',
+			'toAlias' => 'MockQueryComment'
 		));
 		$keyExists = isset($export['relationships']);
 		$this->assertTrue($keyExists);
@@ -480,6 +486,72 @@ class QueryTest extends \lithium\test\Unit {
 		$result = $query->export($this->db);
 		$this->assertEqual('{my_custom_table}', $result['source']);
 		$this->assertEqual('AS {MyCustomAlias}', $result['alias']);
+	}
+
+	public function testRelationships() {
+		$query = new Query(array('relationships' => array('Model1' => array('foo' => 'bar'))));
+		$query->relationships('Model1.Model2', array('bar' => 'baz'));
+		$expected = array(
+			'Model1' => array('foo' => 'bar'),
+			'Model1.Model2' => array('bar' => 'baz')
+		);
+		$relationships = $query->relationships();
+		$this->assertEqual($expected, $relationships);
+
+		$query = new Query();
+		$query->relationships('Model1', array('foo' => 'bar'));
+		$query->relationships('Model1.Model2', array('bar' => 'baz'));
+		$relationships = $query->relationships();
+		$this->assertEqual($expected, $relationships);
+	}
+
+	public function testAlias() {
+		$model = 'lithium\tests\mocks\data\model\MockQueryComment';
+		$query = new Query(compact('model'));
+		$this->assertIdentical('MockQueryComment', $query->alias());
+		$this->assertIdentical('MockQueryComment', $query->alias(null));
+		$this->assertIdentical('MockQueryComment2', $query->alias('MockQueryComment2'));
+		$this->assertIdentical('MockQueryComment2', $query->alias());
+		$this->assertIdentical('MockQueryComment2', $query->alias(null));
+
+		$this->assertIdentical('MockQueryComment__2', $query->alias('MockQueryComment', 'Model1'));
+		$this->assertIdentical('MockQueryComment2__2', $query->alias('MockQueryComment2', 'Model2'));
+		$this->assertIdentical('MockQueryComment__2', $query->alias(true, 'Model1'));
+		$this->assertIdentical('MockQueryComment2__2', $query->alias(true, 'Model2'));
+
+		$query = new Query(compact('model') + array(
+			'source' => 'my_custom_table',
+			'alias' => 'MyCustomAlias'
+		));
+		$result = $query->export($this->db);
+		$this->assertIdentical('{my_custom_table}', $result['source']);
+		$this->assertIdentical('AS {MyCustomAlias}', $result['alias']);
+		$this->assertIdentical('MyCustomAlias__2', $query->alias('MyCustomAlias', 'OtherModel1'));
+		$this->assertIdentical('MyCustomAlias__3', $query->alias('MyCustomAlias', 'OtherModel2'));
+		$this->assertIdentical('MyCustomAlias2', $query->alias('MyCustomAlias2', 'OtherModel3'));
+
+		$this->assertIdentical('MyCustomAlias', $query->alias());
+		$this->assertIdentical('MyCustomAlias__2', $query->alias(true, 'OtherModel1'));
+		$this->assertIdentical('MyCustomAlias__3', $query->alias(true, 'OtherModel2'));
+		$this->assertIdentical('MyCustomAlias2', $query->alias(true, 'OtherModel3'));
+		$this->assertIdentical('OtherModel4', $query->alias(null, 'OtherModel4'));
+		$this->assertIdentical('OtherModel5', $query->alias(null, 'OtherModel5'));
+		$this->assertIdentical('OtherModel6', $query->alias(null, 'OtherModel6'));
+
+		$this->assertIdentical('OtherModel4', $query->alias(null, 'OtherModel4'));
+		$this->assertIdentical('OtherModel5', $query->alias(null, 'OtherModel5'));
+		$this->assertIdentical('OtherModel6', $query->alias(null, 'OtherModel6'));
+		$expected = array (
+			'MyCustomAlias' => 'MyCustomAlias',
+			'MyCustomAlias__2' => 'OtherModel1',
+			'MyCustomAlias__3' => 'OtherModel2',
+			'MyCustomAlias2' => 'OtherModel3',
+			'OtherModel4' => 'OtherModel4',
+			'OtherModel5' => 'OtherModel5',
+			'OtherModel6' => 'OtherModel6'
+		);
+
+		$this->assertEqual($expected, $query->aliases($this->db));
 	}
 }
 

--- a/tests/cases/data/source/DatabaseTest.php
+++ b/tests/cases/data/source/DatabaseTest.php
@@ -313,7 +313,8 @@ class DatabaseTest extends \lithium\test\Unit {
 		));
 		$result = $this->db->renderCommand($query);
 
-		$sql = "SELECT * FROM {mock_database_posts} AS {MockDatabasePost} WHERE {MockDatabasePost}.{title} = '007';";
+		$sql = "SELECT * FROM {mock_database_posts} AS {MockDatabasePost} WHERE ";
+		$sql .= "{MockDatabasePost}.{title} = '007';";
 		$this->assertEqual($sql, $result);
 	}
 
@@ -325,7 +326,7 @@ class DatabaseTest extends \lithium\test\Unit {
 			'conditions' => array('MockDatabaseTag.tag' => array('foo', 'bar', 'baz')),
 			'joins' => array(new Query(array(
 				'model' => 'lithium\tests\mocks\data\model\MockDatabaseTag',
-				'constraint' => '{MockDatabaseTagging}.{tag_id} = {MockDatabaseTag}.{id}'
+				'constraints' => '{MockDatabaseTagging}.{tag_id} = {MockDatabaseTag}.{id}'
 			)))
 		));
 		$result = $this->db->renderCommand($query);
@@ -826,21 +827,21 @@ class DatabaseTest extends \lithium\test\Unit {
 		$expected .= ' {MockDatabaseComment}.{created}';
 		$this->assertEqual($expected, $result);
 
-		$fields = array('MockDatabasePost as Post', 'MockDatabaseComment AS Comment');
+		$fields = array('MockDatabasePost.id as idPost', 'MockDatabaseComment.id AS idComment');
 		$result = $this->db->fields($fields, $query);
-		$expected = 'MockDatabasePost as Post, MockDatabaseComment AS Comment';
+		$expected = '{MockDatabasePost}.{id} as idPost, {MockDatabaseComment}.{id} as idComment';
 		$this->assertEqual($expected, $result);
 
-		$expected = array('MockDatabasePost' => array('Post', 'Comment'));
+		$expected = array('MockDatabasePost' => array('idPost'), 'MockDatabasePost.MockDatabaseComment' => array('idComment'));
 		$this->assertEqual($expected, $query->map());
 
 		$fields = array(array('count(MockDatabasePost.id)'));
-		$expected = 'count(MockDatabasePost.id)';
+		$expected = 'count(MockDatabasePost.id), {MockDatabasePost}.{id}';
 		$result = $this->db->fields($fields, $query);
 		$this->assertEqual($expected, $result);
 
 		$fields = array((object) 'count(MockDatabasePost.id)');
-		$expected = 'count(MockDatabasePost.id)';
+		$expected = 'count(MockDatabasePost.id), {MockDatabasePost}.{id}';
 		$result = $this->db->fields($fields, $query);
 		$this->assertEqual($expected, $result);
 	}
@@ -880,16 +881,17 @@ class DatabaseTest extends \lithium\test\Unit {
 
 		$hasMany = $this->db->relationship($this->_model, 'hasMany', 'PostRevisions', array(
 			'to' => $postRevision,
-			'constraint' => array('MockDatabasePostRevision.deleted' => null)
+			'constraints' => array('MockDatabasePostRevision.deleted' => null)
 		));
 		$this->assertEqual(array('id' => 'mock_database_post_id'), $hasMany->key());
 		$this->assertEqual('post_revisions', $hasMany->fieldName());
 
 		$expected = array(
-			'MockDatabasePost.id' => 'PostRevisions.mock_database_post_id',
-			'MockDatabasePostRevision.deleted' => null
+			'MockDatabasePostRevision.deleted' => null,
+			'MockDatabasePost.id' => (object) '{PostRevisions}.{mock_database_post_id}'
 		);
-		$this->assertEqual($expected, $hasMany->constraints());
+		$result = $this->db->on($hasMany);
+		$this->assertEqual($expected, $result);
 
 		$belongsTo = $this->db->relationship($postRevision, 'belongsTo', 'Posts', array(
 			'to' => $this->_model
@@ -925,8 +927,8 @@ class DatabaseTest extends \lithium\test\Unit {
 		$result = $this->db->read(new Query($options), $options);
 		$expected = 'SELECT * FROM {mock_database_posts} AS {MockDatabasePost} LEFT JOIN ';
 		$expected .= '{mock_database_post_revisions} AS {MockDatabasePostRevision} ON ';
-		$expected .= '{MockDatabasePost}.{id} = {MockDatabasePostRevision}.{mock_database_post_id}';
-		$expected .= ' AND {MockDatabasePostRevision}.{deleted} IS NULL;';
+		$expected .= '{MockDatabasePostRevision}.{deleted} IS NULL AND ';
+		$expected .= '{MockDatabasePost}.{id} = {MockDatabasePostRevision}.{mock_database_post_id};';
 		$this->assertEqual($expected, $this->db->sql);
 	}
 
@@ -938,7 +940,7 @@ class DatabaseTest extends \lithium\test\Unit {
 			'limit' => 1
 		);
 		$result = $this->db->read(new Query($options), $options);
-		$this->assertTrue($result instanceof RecordSet);
+		$this->assertFalse($result instanceof RecordSet);
 	}
 
 	public function testGroup() {
@@ -975,12 +977,12 @@ class DatabaseTest extends \lithium\test\Unit {
 				'type' => 'INNER',
 				'source' => 'posts',
 				'alias' => 'Post',
-				'constraint' => array("Comment.post_id" => array('<=' => "Post.id"))
+				'constraints' => array("Comment.post_id" => array('<=' => (object) "{Post}.{id}"))
 			))
 		));
 
 		$expected = "SELECT * FROM {comments} AS {Comments} INNER JOIN {posts} AS {Post} ON ";
-		$expected .= "{Comment}.{post_id} <= {Post}.{id} WHERE {Comment}.{id} = 1;";
+		$expected .= "({Comment}.{post_id} <= {Post}.{id}) WHERE {Comment}.{id} = 1;";
 		$result = $this->db->renderCommand($query);
 		$this->assertEqual($expected, $result);
 	}
@@ -1000,17 +1002,14 @@ class DatabaseTest extends \lithium\test\Unit {
 				'type' => 'LEFT',
 				'source' => 'posts',
 				'alias' => 'Post',
-				'constraint' => array(
+				'constraints' => array(
 					"Comment.post_id" => array(
-						'<=' => "Post.id",
-						'>=' => "Post.id"
-					)
-				)
-			))
-		));
+						'<=' => (object) "{Post}.{id}",
+						'>=' => (object) "{Post}.{id}"
+		))))));
 
 		$expected = "SELECT * FROM {comments} AS {Comments} LEFT JOIN {posts} AS {Post} ON ";
-		$expected .= "{Comment}.{post_id} <= {Post}.{id} AND {Comment}.{post_id} >= {Post}.{id} ";
+		$expected .= "({Comment}.{post_id} <= {Post}.{id} AND {Comment}.{post_id} >= {Post}.{id}) ";
 		$expected .= "WHERE {Comment}.{id} = 1;";
 		$result = $this->db->renderCommand($query);
 		$this->assertEqual($expected, $result);
@@ -1023,12 +1022,12 @@ class DatabaseTest extends \lithium\test\Unit {
 				'type' => 'LEFT',
 				'source' => 'posts',
 				'alias' => 'Post',
-				'constraint' => array(
-					"Comment.post_id" => array('=>' => "Post.id")
+				'constraints' => array(
+					"Comment.post_id" => array('=>' => (object) "{Post}.{id}")
 				)
 			))
 		));
-		$this->expectException("Unsupported operator `=>` used in constraint.");
+		$this->expectException("Unsupported operator `=>` used in constraints.");
 		$this->db->renderCommand($query);
 	}
 
@@ -1044,7 +1043,7 @@ class DatabaseTest extends \lithium\test\Unit {
 				'type' => 'INNER',
 				'source' => 'posts',
 				'alias' => 'Post',
-				'constraint' => array('Comment.post_id' => 'Post.id')
+				'constraints' => array('Comment.post_id' => (object) "{Post}.{id}")
 			))
 		));
 
@@ -1060,20 +1059,79 @@ class DatabaseTest extends \lithium\test\Unit {
 		$this->db->log = false;
 
 		$result = MockDatabasePost::$connection->logs[0];
-		$expected = "SELECT {MockDatabasePost}.{id} FROM {mock_database_posts} AS ";
+		$expected = "SELECT DISTINCT({MockDatabasePost}.{id}) AS _ID_ FROM {mock_database_posts} AS ";
 		$expected .= "{MockDatabasePost} LEFT JOIN {mock_database_comments} AS ";
 		$expected .= "{MockDatabaseComment} ON {MockDatabasePost}.{id} = ";
 		$expected .= "{MockDatabaseComment}.{mock_database_post_id} WHERE ";
-		$expected .= "{MockDatabasePost}.{id} = 5 GROUP BY {MockDatabasePost}.{id} LIMIT 1;";
-		$this->assertEqual($expected, $result);
-
-		$result = MockDatabasePost::$connection->logs[1];
-		$expected = "SELECT * FROM {mock_database_posts} AS {MockDatabasePost} ";
-		$expected .= "LEFT JOIN {mock_database_comments} AS {MockDatabaseComment} ON ";
-		$expected .= "{MockDatabasePost}.{id} = {MockDatabaseComment}.{mock_database_post_id} ";
-		$expected .= "WHERE {MockDatabasePost}.{id} = 5 LIMIT 1;";
+		$expected .= "{MockDatabasePost}.{id} = 5 LIMIT 1;";
 		$this->assertEqual($expected, $result);
 	}
+
+	public function testOn() {
+		$conn = MockDatabasePost::connection();
+		$expected = array(
+			'MockDatabasePost.id' => (object) '{MockDatabaseComment}.{mock_database_post_id}'
+		);
+		$this->assertEqual($expected, $conn->on(MockDatabasePost::relations('MockDatabaseComment')));
+
+		$expected = array(
+			'MockDatabaseComment.mock_database_post_id' => (object) '{MockDatabasePost}.{id}'
+		);
+		$this->assertEqual($expected, $conn->on(MockDatabaseComment::relations('MockDatabasePost')));
+
+		$expected = array(
+			'MockDatabasePost.id' => (object) '{MockDatabaseComment}.{mock_database_post_id}',
+			'MockDatabaseComment.published' => 'yes'
+		);
+
+		$rel = MockDatabasePost::relations('MockDatabaseComment');
+		$result = $conn->on($rel, array('published' => 'yes'));
+		$this->assertEqual($expected, $result);
+
+		$expected = array(
+			'CustomPost.id' => (object) '{CustomComment}.{mock_database_post_id}',
+			'CustomComment.published' => 'no'
+		);
+
+		$result = $conn->on($rel, array('published' => 'no'), 'CustomPost', 'CustomComment');
+		$this->assertEqual($expected, $result);
+	}
+
+	public function testReadWithRelationshipAndCustomConstraint() {
+		$model = 'lithium\tests\mocks\data\model\MockDatabasePost';
+
+		$model::bind('hasMany', 'MockDatabaseTagging', array(
+			'to' => 'lithium\tests\mocks\data\model\MockDatabaseTagging'
+		));
+
+		$options = array(
+			'type' => 'read',
+			'model' => $model,
+			'with' => array(
+				'MockDatabaseTagging',
+				'MockDatabaseTagging.MockDatabaseTag' =>
+					array('conditions' =>
+						array('MockDatabaseTag.name' => 'MyTag')
+				),
+				'MockDatabasePostRevision'
+			)
+		);
+		$result = $this->db->read(new Query($options));
+		$query = new Query($options);
+		$expected = 'SELECT * FROM {mock_database_posts} AS {MockDatabasePost} ';
+		$expected .= 'LEFT JOIN {mock_database_taggings} AS {MockDatabaseTagging} ';
+		$expected .= 'ON {MockDatabasePost}.{id} = {MockDatabaseTagging}.{mock_database_post_id} ';
+		$expected .= 'LEFT JOIN {mock_database_tags} AS {MockDatabaseTag} ';
+		$expected .= 'ON {MockDatabaseTag}.{name} = \'MyTag\' ';
+		$expected .= 'AND {MockDatabaseTagging}.{mock_database_tag_id} = {MockDatabaseTag}.{id} ';
+		$expected .= 'LEFT JOIN {mock_database_post_revisions} AS {MockDatabasePostRevision} ';
+		$expected .= 'ON {MockDatabasePostRevision}.{deleted} IS NULL AND {MockDatabasePost}.{id} ';
+		$expected .= '= {MockDatabasePostRevision}.{mock_database_post_id};';
+
+		$this->assertEqual($expected, $this->db->sql);
+		$model::reset();
+	}
+
 }
 
 ?>

--- a/tests/cases/data/source/MongoDbTest.php
+++ b/tests/cases/data/source/MongoDbTest.php
@@ -536,7 +536,7 @@ class MongoDbTest extends \lithium\test\Unit {
 			'to'   => $to,
 			'fields' => true,
 			'fieldName' => 'mockPost',
-			'constraint' => null,
+			'constraints' => null,
 			'init' => true
 		);
 		$this->assertEqual($expected, $result->data());

--- a/tests/mocks/data/model/MockDatabasePost.php
+++ b/tests/mocks/data/model/MockDatabasePost.php
@@ -15,7 +15,7 @@ class MockDatabasePost extends \lithium\tests\mocks\data\MockBase {
 	public $hasMany = array(
 		'MockDatabaseComment',
 		'MockDatabasePostRevision' => array(
-			'constraint' => array('MockDatabasePostRevision.deleted' => null)
+			'constraints' => array('MockDatabasePostRevision.deleted' => null)
 		)
 	);
 


### PR DESCRIPTION
BC break:
- the `'constraint'` option is now `'constraints'` (i.e with an extra 's')
- the constraints now behave like conditions (i.e the right hand side are automagically escaped, use (object) casting to avoid this behavior)
- Query::constraints() has been removed (see Database::on() for PDO datasources)

New Features :
- Queries are now exported according a datasource strategy (Acutally only the joined strategy (i.e. LEFT JOIN) have been implemented).

Experimental :
- If such notation : `Post::find('all', array('with' => array('Tagging.Tags')));` would now works on PDO datasources, the lacks of "fixtures" (#603) makes tests impossible (for me at least) for this part.
- Feel free to comment this PR if you notice something wrong.

Next step :
- Allow Queries to contain subqueries.
- Allow Datasource to manage queries with  subqueries.
- Implements the "subquery strategy" for both PDO and NoSql datasource.
