### PR TITLE
Radio buttons don't check if bound to subdocument

### DIFF
--- a/template/helper/Form.php
+++ b/template/helper/Form.php
@@ -670,11 +670,12 @@ class Form extends \lithium\template\Helper {
 		$defaults = array('value' => '1');
 		$options += $defaults;
 		$default = $options['value'];
+		$key = $name;
 
 		list($name, $options, $template) = $this->_defaults(__FUNCTION__, $name, $options);
 		list($scope, $options) = $this->_options($defaults, $options);
 
-		if (!isset($options['checked']) && ($bound = $this->binding($name)->data)) {
+		if (!isset($options['checked']) && ($bound = $this->binding($key)->data)) {
 			$options['checked'] = ($bound == $default);
 		}
 


### PR DESCRIPTION
As in the object I noticed that if a radio button set is bound to a subdocument using a dot notation (e.g. person.name) it doesn't checks. 

This happens because the $name variable passed is changed before the value check and so it always fails.
