### PR TITLE
Update to handle upcoming releases (and features) of MongoDB driver

### DIFF
--- a/data/source/MongoDb.php
+++ b/data/source/MongoDb.php
@@ -239,7 +239,6 @@ class MongoDb extends \lithium\data\Source {
 		$connection = "mongodb://{$login}{$host}" . ($login ? "/{$cfg['database']}" : '');
 
 		$options = array(
-			'connect' => true,
 			'timeout' => $cfg['timeout'],
 			'replicaSet' => $cfg['replicaSet']
 		);
@@ -249,7 +248,12 @@ class MongoDb extends \lithium\data\Source {
 				$options['persist'] = $persist === true ? 'default' : $persist;
 			}
 			$this->server = new Mongo($connection, $options);
-
+			$this->server->connect();
+			
+			if (isset($cfg['readPreference'])) {
+				$this->server->setReadPreference($cfg['readPreference']);
+			}
+			
 			if ($this->connection = $this->server->{$cfg['database']}) {
 				$this->_isConnected = true;
 			}


### PR DESCRIPTION
Upcoming releases of the MongoDB driver will provide the ability to configure ReadPreference (http://www.php.net/manual/en/mongo.setreadpreference.php) which is handy for people dealing with replica sets. It will also depricate the connect->true option on the constructor.
- Switch from mongodb driver depricated connect->true option on the constructor to the manual ->connect() call.
- Provide configuration ability for readPrefernce options
