### PR TITLE
Add support for X-Real-Ip header (from nginx)

### DIFF
--- a/action/Request.php
+++ b/action/Request.php
@@ -246,7 +246,7 @@ class Request extends \lithium\net\http\Request {
 		$this->_env[$key] = $val;
 
 		if ($key == 'REMOTE_ADDR') {
-			foreach (array('HTTP_X_FORWARDED_FOR', 'HTTP_PC_REMOTE_ADDR') as $altKey) {
+			foreach (array('HTTP_X_FORWARDED_FOR', 'HTTP_PC_REMOTE_ADDR', 'HTTP_X_REAL_IP') as $altKey) {
 				if ($addr = $this->env($altKey)) {
 					$val = $addr;
 					break;


### PR DESCRIPTION
Some nginx proxy_pass configurations have the remote address set to the HTTP_X_REAL_IP header. See http://wiki.nginx.org/HttpProxyModule for details.
