### PR TITLE
Close #674

### DIFF
--- a/tests/cases/net/http/MediaTest.php
+++ b/tests/cases/net/http/MediaTest.php
@@ -151,29 +151,33 @@ class MediaTest extends \lithium\test\Unit {
 	public function testCustomAssetUrls() {
 		$env = Environment::get();
 
+		$path = Libraries::get(true, 'path');
 		Libraries::add('cdn_js_test', array(
-			'path' => Libraries::get(true, 'path'),
+			'path' => $path,
 			'assets' => array(
 				'js' => 'http://static.cdn.com'
-			)
+			),
+			'bootstrap' => false
 		));
 
 		Libraries::add('cdn_env_test', array(
-			'path' => Libraries::get(true, 'path'),
+			'path' => $path,
 			'assets' => array(
 				'js' => 'wrong',
 				$env => array('js' => 'http://static.cdn.com/myapp')
-			)
+			),
+			'bootstrap' => false
 		));
+		$library = basename($path);
 
 		$result = Media::asset('foo', 'js', array('library' => 'cdn_js_test'));
-		$this->assertEqual("http://static.cdn.com/lithium/js/foo.js", $result);
+		$this->assertEqual("http://static.cdn.com/{$library}/js/foo.js", $result);
 
 		$result = Media::asset('foo', 'css', array('library' => 'cdn_js_test'));
-		$this->assertEqual("/lithium/css/foo.css", $result);
+		$this->assertEqual("/{$library}/css/foo.css", $result);
 
 		$result = Media::asset('foo', 'js', array('library' => 'cdn_env_test'));
-		$this->assertEqual("http://static.cdn.com/myapp/lithium/js/foo.js", $result);
+		$this->assertEqual("http://static.cdn.com/myapp/{$library}/js/foo.js", $result);
 
 		Libraries::remove('cdn_env_test');
 		Libraries::remove('cdn_js_test');


### PR DESCRIPTION
Close #674.
Add 'boostrap' => false to avoid the bootstrap.php file to be loaded twice which occurs the following error : 
"Fatal error: include(): Cannot redeclare class lithium\core\libraries in /var/www/lithium_app/app/config/bootstrap/libraries.php on line 68"

Ps: it seems not everyone was affected by this error (which seems weird)
