### PR TITLE
Implements an ::_init() method for models

### DIFF
--- a/tests/mocks/data/MockPostFiltered.php
+++ b/tests/mocks/data/MockPostFiltered.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2012, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\tests\mocks\data;
+
+
+class MockPostFiltered extends \lithium\tests\mocks\data\MockBase {
+
+	public $hasMany = array('MockComment');
+
+	public static $connection = null;
+
+	public static $initCalled = 0;
+
+	protected $_meta = array('connection' => false, 'key' => 'id');
+
+	public function _init() {
+		parent::_init();
+
+		static::applyFilter('filteredStatic', function($self, $params, $chain) {
+		    $response = $chain->next($self, $params, $chain);
+		    return $response . ' filtered static';
+		});
+
+		static::applyFilter('filteredDynamic', function($self, $params, $chain) {
+		    $response = $chain->next($self, $params, $chain);
+		    return $response . ' filtered dynamic';
+		});
+
+		static::$initCalled++;
+	}
+
+	public function filteredDynamic($entity, $value) {
+		$params = compact('value');
+
+		return static::_filter(__METHOD__, $params, function($self, $params) {
+		    return $params['value'];
+		});
+	}
+
+	public static function filteredStatic($value) {
+		$params = compact('value');
+
+		return static::_filter(__FUNCTION__, $params, function($self, $params) {
+		    return $params['value'];
+		});
+	}
+}
+
+?>

--- a/tests/mocks/data/MockPostFilteredSubClass.php
+++ b/tests/mocks/data/MockPostFilteredSubClass.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2012, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\tests\mocks\data;
+
+
+class MockPostFilteredSubClass extends \lithium\tests\mocks\data\MockPostFiltered {
+
+	public $hasMany = array('MockComment');
+
+	public static $connection = null;
+
+	public static $initCalled = 0;
+
+	protected $_meta = array('connection' => false, 'key' => 'id');
+
+	public function filteredDynamic($entity, $value) {
+		$params = compact('value');
+
+		return static::_filter(__METHOD__, $params, function($self, $params) {
+		    return $params['value'] . ' sub class';
+		});
+	}
+
+	public static function filteredStatic($value) {
+		$params = compact('value');
+
+		return static::_filter(__FUNCTION__, $params, function($self, $params) {
+		    return $params['value'] . ' sub class';
+		});
+	}
+}
+
+?>


### PR DESCRIPTION
1 - If filters are applied outside a model A, and B extends A, filters won't get executed for B.
2 - Applying filter in `Model::__init()` using `static::applyFilter()` will make the lazy configuration with `Model::config()` useless. Moreover a Model::reset() won't reload the filters since  `Model::__init()` is called once on class autoloading.

With this PR Model::_init() can be used as all `::init()` methods.

Use case:

```
class MyModel extends \lithium\data\Model {

    public function _init() {
        parent::_init();
        static::applyFilter('save', function($self, $params, $chain) {
            $response = $chain->next($self, $params, $chain);
            return $response;
        });
    }
}
```
