### PR TITLE
Fix Accept-Language extraction in g11n\Locale.

### DIFF
--- a/g11n/Locale.php
+++ b/g11n/Locale.php
@@ -258,11 +258,17 @@ class Locale extends \lithium\core\StaticObject {
 			if (preg_match($regex, $part, $matches)) {
 				$locale = static::canonicalize($matches['locale']);
 				$quality = isset($matches['quality']) ? $matches['quality'] : 1;
-				$result[$locale] = (float) $quality;
+				$result[$quality][] = $locale;
 			}
 		}
-		arsort($result);
-		return array_keys($result);
+
+		krsort($result);
+		$return = array();
+
+		foreach ($result as $locales) {
+			$return = array_merge($return, array_values($locales));
+		}
+		return $return;
 	}
 
 	/**

--- a/tests/cases/g11n/LocaleTest.php
+++ b/tests/cases/g11n/LocaleTest.php
@@ -269,6 +269,11 @@ class LocaleTest extends \lithium\test\Unit {
 			'HTTP_ACCEPT_LANGUAGE' => 'fr;q=1, en-gb;q=0.8, en;q=0.7'
 		)));
 		$result = Locale::preferred($request);
+
+		$request = new ActionRequest(array('env' => array(
+			'HTTP_ACCEPT_LANGUAGE' => 'fr,en,it,es;q=0.7'
+		)));
+		$result = Locale::preferred($request, array('en', 'fr', 'it'));
 		$this->assertEqual('fr', $result);
 
 		$request = new ActionRequest(array(


### PR DESCRIPTION
Quality values were not properly checked, per RFC they can be any floating
point 0 ≤ q ≤ 1. The regex expected that 0 < q < 1.
See [RFC 2616 section 3.9. Quality Values.](https://pretty-rfc.herokuapp.com/RFC2616#quality.values)
