### PR TITLE
Optimise Model::key() and fix some issues

### DIFF
--- a/tests/cases/data/ModelTest.php
+++ b/tests/cases/data/ModelTest.php
@@ -25,6 +25,8 @@ use lithium\tests\mocks\data\MockBadConnection;
 
 class ModelTest extends \lithium\test\Unit {
 
+	protected $_model = 'lithium\tests\mocks\data\MockModelCompositePk';
+
 	protected $_database = 'lithium\tests\mocks\data\MockSource';
 
 	protected $_altSchema = null;
@@ -404,6 +406,21 @@ class ModelTest extends \lithium\test\Unit {
 		$key->foo = 'bar';
 
 		$this->assertEqual(array('id' => $key), MockPost::key($key));
+
+		$this->assertNull(MockPost::key(array()));
+
+		$model = $this->_model;
+		$this->assertNull($model::key(array('client_id' => 3)));
+
+		$result = $model::key(array('invoice_id' => 5, 'payment' => '100'));
+		$this->assertNull($result);
+
+		$expected = array('client_id' => 3, 'invoice_id' => 5);
+		$result = $model::key(array(
+			'client_id' => 3,
+			'invoice_id' => 5,
+			'payment' => '100'));
+		$this->assertEqual($expected, $result);
 	}
 
 	public function testValidatesFalse() {

--- a/tests/cases/data/source/MongoDbTest.php
+++ b/tests/cases/data/source/MongoDbTest.php
@@ -68,8 +68,9 @@ class MongoDbTest extends \lithium\test\Unit {
 
 		$model::config(array('meta' => array('key' => '_id')));
 		$model::$connection = $this->db;
+		$type = 'create';
 
-		$this->query = new Query(compact('model') + array(
+		$this->query = new Query(compact('model', 'type') + array(
 			'entity' => new Document(compact('model'))
 		));
 	}
@@ -377,8 +378,9 @@ class MongoDbTest extends \lithium\test\Unit {
 		$this->assertTrue($this->query->entity()->exists());
 
 		$model = $this->_model;
+		$id = new MongoId();
 		$this->query = new Query(compact('model') + array(
-			'entity' => new Document(compact('model'))
+			'entity' => new Document(compact('model') + array('data' => array('_id' => $id)))
 		));
 
 		array_push($this->db->connection->results, true);

--- a/tests/cases/data/source/http/adapter/CouchDbTest.php
+++ b/tests/cases/data/source/http/adapter/CouchDbTest.php
@@ -9,7 +9,6 @@
 namespace lithium\tests\cases\data\source\http\adapter;
 
 use lithium\data\model\Query;
-use lithium\data\Connections;
 use lithium\data\entity\Document;
 use lithium\data\source\http\adapter\CouchDb;
 
@@ -40,7 +39,8 @@ class CouchDbTest extends \lithium\test\Unit {
 		$model::$connection = $this->db;
 
 		$entity = new Document(compact('model'));
-		$this->query = new Query(compact('model', 'entity'));
+		$type = 'create';
+		$this->query = new Query(compact('model', 'entity', 'type'));
 	}
 
 	public function testAllMethodsNoConnection() {


### PR DESCRIPTION
Refactoring of #582:
- function added to reduce the per-method cyclomatic complexity limit (It also reduce one nest level).

Fix :
- with multiples keys return `null` if one of them miss in the datas
- Model::key(array()) return `null` instead of returning the id.

Optimisation :
- `::to('array')` is no more the default behavior for looking for key in entities
- removing the use of method_exists()
