### PR TITLE
Close #671

### DIFF
--- a/net/http/Route.php
+++ b/net/http/Route.php
@@ -464,7 +464,14 @@ class Route extends \lithium\core\Object {
 		} else {
 			$regex = '[^\/]+';
 		}
-		$req = $param === 'args' || array_key_exists($param, $this->_params) ? '?' : '';
+
+		$optionnal = false;
+		if (isset($this->_params[$param])) {
+			$optionnal = preg_match("@{$regex}@", $this->_params[$param]);
+		} elseif (array_key_exists($param, $this->_params)) {
+			$optionnal = true;
+		}
+		$req = $regex === '.*' || $optionnal ? '?' : '';
 
 		if ($prefix === '/') {
 			$pattern = "(?:/(?P<{$param}>{$regex}){$req}){$req}";

--- a/tests/cases/net/http/RouterTest.php
+++ b/tests/cases/net/http/RouterTest.php
@@ -142,6 +142,77 @@ class RouterTest extends \lithium\test\Unit {
 		$this->assertNull(Router::parse($this->request));
 	}
 
+	public function testRouteMatchingWithRegExAction() {
+		Router::connect(
+			'/products/{:action:add|edit|remove}/{:category}',
+			array('controller' => 'Products')
+		);
+		Router::connect('/products/{:category}', array('Products::category'));
+
+		$this->request = new Request();
+		$this->request->url = '/products/add/computer';
+		$result = Router::parse($this->request);
+		$expected = array(
+			'controller' => 'Products',
+			'action' => 'add',
+			'category' => 'computer'
+		);
+		$this->assertEqual($expected, $result->params);
+
+		$this->request = new Request();
+		$this->request->url = '/products/add';
+		$result = Router::parse($this->request);
+		$expected = array(
+			'controller' => 'Products',
+			'action' => 'category',
+			'category' => 'add'
+		);
+		$this->assertEqual($expected, $result->params);
+
+		$this->request = new Request();
+		$this->request->url = '/products/computer';
+		$result = Router::parse($this->request);
+		$expected = array(
+			'controller' => 'Products',
+			'action' => 'category',
+			'category' => 'computer'
+		);
+		$this->assertEqual($expected, $result->params);
+
+		Router::reset();
+		Router::connect(
+			'/products/{:action:add|edit|remove}/{:category:.*}',
+			array('controller' => 'Products')
+		);
+		Router::connect('/products/{:category}', array('Products::category'));
+
+		$this->request = new Request();
+		$this->request->url = '/products/add';
+		$result = Router::parse($this->request);
+		$expected = array(
+			'controller' => 'Products',
+			'action' => 'add'
+		);
+		$this->assertEqual($expected, $result->params);
+
+		Router::reset();
+		Router::connect(
+			'/products/{:action:add|edit|remove}/{:category:.*}',
+			array('controller' => 'Products', 'category' => 'default')
+		);
+		Router::connect('/products/{:category}', array('Products::category'));
+
+		$this->request = new Request();
+		$this->request->url = '/products/add';
+		$result = Router::parse($this->request);
+		$expected = array(
+			'controller' => 'Products',
+			'action' => 'add',
+			'category' => 'default'
+		);
+		$this->assertEqual($expected, $result->params);
+	}
+
 	/**
 	 * Tests that URLs specified as "Controller::action" are interpreted properly.
 	 */


### PR DESCRIPTION
A possible solution for #671.
- If not `null`, default route params must respect its regular expression to be considered as "optionnal":
- You can use `':.*'` to have the same behavior as `args` :

```
Router::connect('/{:controller}/{:action}/{:args}');
Router::connect('/{:controller}/{:action}/{:category:.*}');
```

maybe a "BC break" : the following syntax won't match on '/site' anymore:

```
Router::connect('/site/{:action:home}', array('Site::index'));
```

But I don't think such syntax really make sense.
