### PR TITLE
Close #671

### DIFF
--- a/net/http/Route.php
+++ b/net/http/Route.php
@@ -190,7 +190,7 @@ class Route extends \lithium\core\Object {
 	protected function _init() {
 		parent::_init();
 
-		if (!$this->_config['continue']) {
+		if (!$this->_config['continue'] && !preg_match('@{:action:.*?}@', $this->_template)) {
 			$this->_params += array('action' => 'index');
 		}
 		if (!$this->_config['pattern']) {
@@ -229,18 +229,14 @@ class Route extends \lithium\core\Object {
 				return false;
 			}
 		}
-
 		if (isset($match['args'])) {
 			$match['args'] = explode('/', $match['args']);
 		}
+		$result = array_filter(array_intersect_key($match, $this->_keys));
 		if (isset($this->_keys['args'])) {
-			$match += array('args' => array());
+			$result += array('args' => array());
 		}
-		$result = array_intersect_key($match, $this->_keys) + $this->_params + $this->_defaults;
-
-		if (isset($result['action']) && !$result['action']) {
-			$result['action'] = 'index';
-		}
+		$result += $this->_params + $this->_defaults;
 		$request->params = $result + (array) $request->params;
 		$request->persist = array_unique(array_merge($request->persist, $this->_persist));
 
@@ -464,6 +460,7 @@ class Route extends \lithium\core\Object {
 		} else {
 			$regex = '[^\/]+';
 		}
+
 		$req = $param === 'args' || array_key_exists($param, $this->_params) ? '?' : '';
 
 		if ($prefix === '/') {

--- a/tests/cases/net/http/RouteTest.php
+++ b/tests/cases/net/http/RouteTest.php
@@ -62,7 +62,6 @@ class RouteTest extends \lithium\test\Unit {
 	 */
 	public function testSimpleRouteMatching() {
 		$route = new Route(array('template' => '/{:controller}'));
-
 		$result = $route->match(array('controller' => 'posts', 'action' => 'index'));
 		$this->assertEqual('/posts', $result);
 
@@ -695,6 +694,59 @@ class RouteTest extends \lithium\test\Unit {
 
 		$nonDefault = array('controller' => 'Admin', 'action' => 'view');
 		$this->assertIdentical('/Admin/view', $route->match($nonDefault));
+	}
+
+	public function testRouteParsingWithRegexAction() {
+		$route = new Route(array(
+			'template' => '/products/{:action:add|edit|remove}/{:category}',
+			'params' => array('controller' => 'Products')
+		));
+		$request = new Request();
+		$request->url = '/products/add/computer';
+		$result = $route->parse($request);
+		$expected = array(
+			'controller' => 'Products',
+			'action' => 'add',
+			'category' => 'computer'
+		);
+		$this->assertEqual($expected, $result->params);
+
+		$request = new Request();
+		$request->url = '/products/index/computer';
+		$result = $route->parse($request);
+		$this->assertEqual(false, $result);
+	}
+
+	public function testRouteParsingWithRegexActionAndParamWithAction() {
+		$route = new Route(array(
+			'template' => '/products/{:action:add|edit|remove}/{:category}',
+			'params' => array('controller' => 'Products', 'action' => 'index')
+		));
+		$request = new Request();
+		$request->url = '/products/hello';
+		$result = $route->parse($request);
+		$expected = array(
+			'controller' => 'Products',
+			'action' => 'index',
+			'category' => 'hello'
+		);
+		$this->assertEqual($expected, $result->params);
+	}
+
+	public function testRouteParsingWithRegexActionAndParamWithoutAction() {
+		$route = new Route(array(
+			'template' => '/products/{:action:add|edit|remove}/{:category}',
+			'params' => array('controller' => 'Products')
+		));
+		$request = new Request();
+		$request->url = '/products/hello';
+		$result = $route->parse($request);
+		$this->assertEqual(false, $result);
+
+		$request = new Request();
+		$request->url = '/products';
+		$result = $route->parse($request);
+		$this->assertEqual(false, $result);
 	}
 }
 


### PR DESCRIPTION
A possible solution for #671.
- If a `Route`'s template has an action parameter with a regex, the default `array('action' => 'index')` is not set in `Route::_init()`.
