### PR TITLE
Fix Compiler::template() not respecting custom cache paths.

### DIFF
--- a/template/view/Compiler.php
+++ b/template/view/Compiler.php
@@ -67,7 +67,7 @@ class Compiler extends \lithium\core\StaticObject {
 		}
 		$compiled = static::compile(file_get_contents($file));
 
-		if (is_writable($cachePath) && file_put_contents($template, $compiled) !== false) {
+		if (is_writable($options['path']) && file_put_contents($template, $compiled) !== false) {
 			foreach (glob("{$options['path']}/template_{$oname}_*.php") as $expired) {
 				if ($expired !== $template) {
 					unlink($expired);


### PR DESCRIPTION
The method uses it's default cache path when checking if the directory is writable. It should use the path from the $config parameter if available. This fixes the issue.
