### PR TITLE
Reduce potential pollution by globally defined functions

### DIFF
--- a/template/View.php
+++ b/template/View.php
@@ -351,12 +351,14 @@ class View extends \lithium\core\Object {
 		if (!$conditions = $step['conditions']) {
 			return true;
 		}
-		if (is_callable($conditions) && !$conditions($params, $data, $options)) {
+		$isCallable = is_callable($conditions) && !is_string($conditions);
+		if ($isCallable && !$conditions($params, $data, $options)) {
 			return false;
 		}
 		if (is_string($conditions) && !(isset($options[$conditions]) && $options[$conditions])) {
 			return false;
 		}
+
 		return true;
 	}
 


### PR DESCRIPTION
In my php installation, there's a global function layout(), which screws up condition checking since is_callable("layout") returns true.

Check to ensure that the condition is actually a closure, and not just a string, before attempting to call it.
