### PR TITLE
Adding Set::slice()

### DIFF
--- a/tests/cases/util/SetTest.php
+++ b/tests/cases/util/SetTest.php
@@ -1436,6 +1436,28 @@ class SetTest extends \lithium\test\Unit {
 		$result = Set::normalize($input, false);
 		$this->assertEqual(array('baz' => 'foo', 'bar' => null), $result);
 	}
+
+	public function testSetSlice() {
+		$data = array('key1' => 'val1', 'key2' => 'val2', 'key3' => 'val3');
+		list($kept, $removed) = Set::slice($data, array('key3'));
+		$this->assertEqual(array('key3' => 'val3'), $removed);
+		$this->assertEqual(array('key1' => 'val1', 'key2' => 'val2'), $kept);
+
+		$data = array('key1' => 'val1', 'key2' => 'val2', 'key3' => 'val3');
+		list($kept, $removed) = Set::slice($data, array('key1', 'key3'));
+		$this->assertEqual(array('key1' => 'val1', 'key3' => 'val3'), $removed);
+		$this->assertEqual(array('key2' => 'val2'), $kept);
+
+		$data = array('key1' => 'val1', 'key2' => 'val2', 'key3' => 'val3');
+		list($kept, $removed) = Set::slice($data, 'key2');
+		$this->assertEqual(array('key2' => 'val2'), $removed);
+		$this->assertEqual(array('key1' => 'val1', 'key3' => 'val3'), $kept);
+
+		$data = array('key1' => 'val1', 'key2' => 'val2', 'key3' => array('foo' => 'bar'));
+		list($kept, $removed) = Set::slice($data, array('key1', 'key3'));
+		$this->assertEqual(array('key1' => 'val1', 'key3' => array('foo' => 'bar')), $removed);
+		$this->assertEqual(array('key2' => 'val2'), $kept);
+	}
 }
 
 ?>

--- a/util/Set.php
+++ b/util/Set.php
@@ -794,6 +794,25 @@ class Set {
 		}
 		return $sorted;
 	}
+
+	/**
+	 * Slices an array into two, separating them determined by an array of keys.
+	 *
+	 * Usage examples:
+	 *
+	 * {{{ embed:lithium\tests\cases\util\SetTest::testSetSlice(1-4) }}}
+	 *
+	 * @param array $subject Array that gets split apart
+	 * @param array|string $keys An array of keys or a single key as string
+	 * @return array An array containing both arrays, having the array with requested keys first and
+	 *         the remainder as second element
+	 */
+	public static function slice(array $data, $keys) {
+		$removed = array_intersect_key($data, array_fill_keys((array) $keys, true));
+		$data = array_diff_key($data, $removed);
+		return array($data, $removed);
+	}
+
 }
 
 ?>


### PR DESCRIPTION
Set::slice() separates one array into two, determined by a keys array that is then extracted and reduced from a subject.

implements #700 as proposed by @nateabele
