### PR TITLE
Implementing new features for queries Warning BC BREAK

### DIFF
--- a/data/Source.php
+++ b/data/Source.php
@@ -288,6 +288,14 @@ abstract class Source extends \lithium\core\Object {
 		unset($options['class']);
 		return $this->_instance($class, compact('model', 'data') + $options);
 	}
+
+	/**
+	 * Applying a strategy to a `lithium\data\model\Query` object
+	 *
+	 * @param array $options The option array
+	 * @param object $context A query object to configure
+	 */
+	public function applyStrategy($options, $context) {}
 }
 
 ?>

--- a/data/model/Query.php
+++ b/data/model/Query.php
@@ -8,9 +8,9 @@
 
 namespace lithium\data\model;
 
+use lithium\util\Set;
 use lithium\data\Source;
 use lithium\core\ConfigException;
-use lithium\data\model\QueryException;
 
 /**
  * The `Query` class acts as a container for all information necessary to perform a particular
@@ -79,6 +79,34 @@ class Query extends \lithium\core\Object {
 	);
 
 	/**
+	 * Count the number of identical models in a query for building
+	 * unique aliases
+	 *
+	 * @see lithium\data\model\Query::alias()
+	 *
+	 * @var array
+	 */
+	protected $_alias = array();
+
+	/**
+	 * Map the generated aliases to their corresponding relation path
+	 *
+	 * @see lithium\data\model\Query::alias()
+	 *
+	 * @var array
+	 */
+	protected $_paths = array();
+
+	/**
+	 * Map the generated aliases to their corresponding model
+	 *
+	 * @see lithium\data\model\Query::alias()
+	 *
+	 * @var array
+	 */
+	protected $_models = array();
+
+	/**
 	 * Auto configuration properties.
 	 *
 	 * @var array
@@ -86,38 +114,81 @@ class Query extends \lithium\core\Object {
 	protected $_autoConfig = array('type', 'map');
 
 	/**
-	 * Class constructor, which initializes the default values this object supports. Even though
-	 * only a specific list of configuration parameters is available by default, the `Query` object
-	 * uses the `__call()` method to implement automatic getters and setters for any arbitrary piece
-	 * of data.
+	 * Importing methods
 	 *
-	 * This means that any information may be passed into the constructor may be used by the backend
-	 * data source executing the query (or ignored, if support is not implemented). This is useful
-	 * if, for example, you wish to extend a core data source and implement custom fucntionality.
-	 * @param array $config
+	 * @var array
+	 */
+	protected $_importMethods = array(
+		'model', 'entity', 'fields', 'conditions', 'having', 'group', 'order',
+		'limit', 'offset', 'page', 'data', 'calculate', 'schema', 'comment'
+	);
+
+	/**
+	 * Boolean indicate if the query is built or not
+	 *
+	 * @var string
+	 */
+	protected $_built = false;
+
+	/**
+	 * Class constructor, which initializes the default values this object supports.
+	 * Even though only a specific list of configuration parameters is available
+	 * by default, the `Query` object uses the `__call()` method to implement
+	 * automatic getters and setters for any arbitrary piece of data.
+	 *
+	 * This means that any information may be passed into the constructor may be
+	 * used by the backend data source executing the query (or ignored, if support
+	 * is not implemented). This is useful if, for example, you wish to extend a
+	 * core data source and implement custom fucntionality.
+	 *
+	 * @param array $config Config options:
+	 *        - `'type'` _string_: The type of the query (`read`, `insert`, `update`, `delete`).
+	 *        - `'entity'` _object_: The base entity to query on. If set `'model'` is optionnal.
+	 *        - `'model'` _string_: The base model to query on.
+	 *        - `'source'` _string_: The name of the table/collection. Unnecessary
+	 *          if `model` is set.
+	 *        - `'alias'` _string_: Alias for the source. Unnecessary if `model` is set.
+	 *        - `'schema'` _object_: A schema model. Unnecessary if `model` is set.
+	 *        - `'fields'` _array_: The fields to retreive.
+	 *        - `'conditions'` _array_: The conditions of the queries
+	 *        - `'having'` _array_: The having conditions of the queries
+	 *        - `'group'` _string_: The group by parameter.
+	 *        - `'order'` _string_: The order by parameter.
+	 *        - `'limit'` _string_: The limit parameter.
+	 *        - `'offset'` _string_: The offset of the `limit` options.
+	 *        - `'page'` _string_: Convenience parameter for setting the `offset`:
+	 *          `offset` = `page` * `limit`.
+	 *        - `'with'` _array_: Contain dependencies. Works only if `model` is set.
+	 *        - `'joins'` _array_: Contain manual join dependencies.
+	 *        - `'data'` _array_: Datas for update queries.
+	 *        - `'whitelist'` _array_: Allowed fields for updating queries.
+	 *        - `'calculate'` _string_: Alias name of the count.
+	 *        - `'comment'` _string_: Comment for the query.
+	 *        - `'map'` _object_: Unnecessary if `model` is set.
+	 *        - `'relationships'` _array_: Unnecessary if `model` is set.
 	 */
 	public function __construct(array $config = array()) {
 		$defaults = array(
-			'calculate'  => null,
-			'schema'     => null,
+			'model' => null,
+			'entity' => null,
+			'source' => null,
+			'alias' => null,
+			'fields' => array(),
 			'conditions' => array(),
-			'having'     => array(),
-			'fields'     => array(),
-			'data'       => array(),
-			'model'      => null,
-			'alias'      => null,
-			'source'     => null,
-			'order'      => null,
-			'offset'     => null,
-			'name'       => null,
-			'limit'      => null,
-			'page'       => null,
-			'group'      => null,
-			'comment'    => null,
-			'joins'      => array(),
-			'with'       => array(),
-			'map'        => array(),
-			'whitelist'  => array(),
+			'having' => array(),
+			'group' => null,
+			'order' => null,
+			'limit' => null,
+			'offset' => null,
+			'page' => null,
+			'with' => array(),
+			'joins' => array(),
+			'data' => array(),
+			'whitelist' => array(),
+			'calculate' => null,
+			'schema' => null,
+			'comment' => null,
+			'map' => array(),
 			'relationships' => array()
 		);
 		parent::__construct($config + $defaults);
@@ -127,9 +198,11 @@ class Query extends \lithium\core\Object {
 		parent::_init();
 		unset($this->_config['type']);
 
-		foreach ($this->_config as $key => $val) {
-			if (method_exists($this, $key) && $val !== null) {
-				$this->_config[$key] = is_array($this->_config[$key]) ? array() : null;
+		$keys = array_keys($this->_config);
+		foreach ($this->_importMethods as $key) {
+			$val = $this->_config[$key];
+			if ($val !== null) {
+				$this->_config[$key] = is_array($val) ? array() : null;
 				$this->{$key}($val);
 			}
 		}
@@ -139,16 +212,23 @@ class Query extends \lithium\core\Object {
 		if ($this->_config['with']) {
 			$this->_associate($this->_config['with']);
 		}
-		$joins = $this->_config['joins'];
-		$this->_config['joins'] = array();
 
-		foreach ($joins as $i => $join) {
-			$this->join($i, $join);
-		}
 		if ($this->_entity && !$this->_config['model']) {
 			$this->model($this->_entity->model());
 		}
-		unset($this->_config['entity'], $this->_config['init'], $this->_config['with']);
+
+		if ($this->_config['with']) {
+			if (!$model = $this->model()) {
+				throw new ConfigException("The `'with'` option needs a valid binded model.");
+			}
+			$this->_config['with'] = Set::normalize($this->_config['with']);
+		}
+
+		if ($model = $this->model()) {
+			$this->alias($this->_config['alias'] ?: $model::meta('name'));
+		}
+
+		unset($this->_config['entity'], $this->_config['init']);
 	}
 
 	/**
@@ -161,8 +241,8 @@ class Query extends \lithium\core\Object {
 	}
 
 	/**
-	 * Generates a schema map of the query's result set, where the keys are fully-namespaced model
-	 * class names, and the values are arrays of field names.
+	 * Generates a schema map of the query's result set, where the keys are aliases, and the values
+	 * are arrays of field names.
 	 *
 	 * @param array $map
 	 * @return array
@@ -202,8 +282,7 @@ class Query extends \lithium\core\Object {
 		}
 		$this->_config['model'] = $model;
 		$this->_config['source'] = $this->_config['source'] ?: $model::meta('source');
-		$this->_config['alias'] = $this->_config['alias'] ?: $model::meta('name');
-		$this->_config['name'] = $this->_config['name'] ?: $this->_config['alias'];
+		$this->_config['name'] = $model::meta('name');
 		return $this;
 	}
 
@@ -407,71 +486,131 @@ class Query extends \lithium\core\Object {
 	}
 
 	/**
-	 * Set and get the join queries
+	 * Set and get the relationships.
+	 *
+	 * @param string $relpath A dotted path.
+	 * @param array $config the config array to set.
+	 * @return mixed The relationships array or a relationship array if `$relpath` is set. Returns
+	 *         `null` if a join doesn't exist.
+	 */
+	public function relationships($relpath = null, $config = null) {
+		if ($config) {
+			if (!$relpath) {
+				throw new ConfigException("The relation dotted path is empty.");
+			}
+			$this->_config['relationships'][$relpath] = $config;
+			return $this;
+		}
+		if (!$relpath) {
+			return $this->_config['relationships'];
+		}
+		if (isset($this->_config['relationships'][$relpath])) {
+			return $this->_config['relationships'][$relpath];
+		}
+	}
+
+	/**
+	 * Set and get the joins
 	 *
 	 * @param string $name Optional name of join. Unless two parameters are passed, this parameter
 	 *               is regonized as `$join`.
 	 * @param object|string $join A single query object or an array of query objects
-	 * @return array of query objects
+	 * @return mixed The joins array or a join array if `$name` is set. Returns `null` if a join
+	 *         doesn't exist.
 	 */
-	public function join($name = null, $join = null) {
-		if (is_scalar($name) && !$join && isset($this->_config['joins'][$name])) {
-			return $this->_config['joins'][$name];
-		}
-		if ($name && !$join) {
+	public function joins($name = null, $join = null) {
+		if (is_array($name)) {
 			$join = $name;
 			$name = null;
 		}
 		if ($join) {
-			$join = is_array($join) ? $this->_instance(get_class($this), $join) : $join;
-			$name ? $this->_config['joins'][$name] = $join : $this->_config['joins'][] = $join;
+			if (!$name) {
+				$this->_config['joins'][] = $join;
+			} else {
+				$this->_config['joins'][$name] = $join;
+			}
 			return $this;
 		}
-		return $this->_config['joins'];
+		if (!$name) {
+			return $this->_config['joins'];
+		}
+		if (isset($this->_config['joins'][$name])) {
+			return $this->_config['joins'][$name];
+		}
 	}
 
 	/**
 	 * Convert the query's properties to the data sources' syntax and return it as an array.
 	 *
-	 * @param object $dataSource Instance of the data source (`lithium\data\Source`) to use for
-	 *               conversion.
+	 * @param object $source Instance of the data source (`lithium\data\Source`) to use for
+	 *        conversion.
 	 * @param array $options Options to use when exporting the data.
 	 * @return array Returns an array containing a data source-specific representation of a query.
 	 */
-	public function export(Source $dataSource, array $options = array()) {
+	public function export(Source $source, array $options = array()) {
 		$defaults = array('keys' => array());
 		$options += $defaults;
 
 		$keys = $options['keys'] ?: array_keys($this->_config);
-		$methods = $dataSource->methods();
+
 		$results = array('type' => $this->_type);
 
-		$apply = array_intersect($keys, $methods);
+		$apply = array_intersect($keys, $source->methods());
 		$copy = array_diff($keys, $apply);
 
-		foreach ($apply as $item) {
-			$results[$item] = $dataSource->{$item}($this->{$item}(), $this);
+		if (in_array('with', $keys)) {
+			$this->_applyStrategy($source);
 		}
+
+		foreach ($apply as $item) {
+			$results[$item] = $source->{$item}($this->{$item}(), $this);
+		}
+
 		foreach ($copy as $item) {
 			if (in_array($item, $keys)) {
 				$results[$item] = $this->_config[$item];
 			}
 		}
+
 		if (in_array('data', $keys)) {
 			$results['data'] = $this->_exportData();
 		}
+
 		if (isset($results['source'])) {
-			$results['source'] = $dataSource->name($results['source']);
+			$results['source'] = $source->name($results['source']);
 		}
+
 		if (!isset($results['fields'])) {
 			return $results;
 		}
+
 		$created = array('fields', 'values');
 
 		if (is_array($results['fields']) && array_keys($results['fields']) == $created) {
 			$results = $results['fields'] + $results;
 		}
 		return $results;
+	}
+
+	/**
+	 * Helper method used by `export()` which delegate the query generation to the datasource.
+	 *
+	 * @param object $source Instance of the data source (`lithium\data\Source`) to use for
+	 *        conversion.
+	 */
+	protected function _applyStrategy(Source $source) {
+		if ($this->_built) {
+			return;
+		}
+		$this->_built = true;
+		if (!$this->_config['with']) {
+			return;
+		}
+		$options = array();
+		if (isset($this->_config['mode'])) {
+			$options = array('mode' => $this->_config['mode']);
+		}
+		$source->applyStrategy($options, $this);
 	}
 
 	/**
@@ -482,7 +621,6 @@ class Query extends \lithium\core\Object {
 	 */
 	protected function _exportData() {
 		$data = $this->_entity ? $this->_entity->export() : $this->_data;
-
 		if (!$list = $this->_config['whitelist']) {
 			return $data;
 		}
@@ -491,6 +629,7 @@ class Query extends \lithium\core\Object {
 		if (!$this->_entity) {
 			return array_intersect_key($data, $list);
 		}
+
 		foreach ($data as $type => $values) {
 			if (!is_array($values)) {
 				continue;
@@ -515,15 +654,91 @@ class Query extends \lithium\core\Object {
 		}
 	}
 
-	public function alias($alias = null) {
-		if ($alias) {
-			$this->_config['alias'] = $alias;
-			return $this;
+	/**
+	 * Get or Set a unique alias for the query or a query's relation if `$relpath` is set.
+	 *
+	 * @param mixed $alias The value of the alias to set for the passed `$relpath`. For getting an
+	 *        alias value set alias to `true`.
+	 * @param string $relpath A dotted relation name or `null` for identifying the query's model.
+	 * @return string An alias value or `null` for an unexisting `$relpath` alias.
+	 */
+	public function alias($alias = true, $relpath = null) {
+
+		if ($alias === true) {
+			if (!$relpath) {
+				return $this->_config['alias'];
+			}
+			$return = array_search($relpath, $this->_paths);
+			return $return ?: null;
 		}
-		if (!$this->_config['alias'] && ($model = $this->_config['model'])) {
-			$this->_config['alias'] = $model::meta('name');
+
+		if ($relpath) {
+			$oldAlias = array_search($relpath, $this->_paths);
+		} else {
+			$oldAlias = array_search('', $this->_paths);
 		}
-		return $this->_config['alias'];
+		unset($this->_models[$oldAlias]);
+		unset($this->_paths[$oldAlias]);
+
+		$model = $this->_config['model'];
+
+		if (!$relpath) {
+			$this->_alias[$alias] = 1;
+			$this->_models[$alias] = $model;
+			$this->_paths[$alias] = null;
+			return $this->_config['alias'] = $alias;
+		}
+
+		$paths = explode('.', $relpath);
+		if (!$alias) {
+			$alias = end($paths);
+		}
+
+		if (isset($this->_alias[$alias])) {
+			$this->_alias[$alias]++;
+			$alias .= '__' . $this->_alias[$alias];
+		} else {
+			$this->_alias[$alias] = 1;
+		}
+
+		$this->_paths[$alias] = $relpath;
+		foreach ($paths as $path) {
+			if (!$relation = $model::relations($path)) {
+				$model = null;
+				break;
+			}
+			$model = $relation->to();
+		}
+		$this->_models[$alias] = $model;
+		return $alias;
+	}
+
+	/**
+	 * Return the generated aliases mapped to their relation path
+	 *
+	 * @param object $source Instance of the data source (`lithium\data\Source`) to use for
+	 *        conversion.
+	 * @return array Map between alias and their corresponding dotted relation
+	 */
+	public function paths(Source $source = null) {
+		if ($source) {
+			$this->_applyStrategy($source);
+		}
+		return $this->_paths;
+	}
+
+	/**
+	 * Return the generated aliases mapped to their corresponding model
+	 *
+	 * @param object $source Instance of the data source (`lithium\data\Source`) to use for
+	 *        conversion.
+	 * @return array Map between alias and their corresponding model
+	 */
+	public function models(Source $source = null) {
+		if ($source) {
+			$this->_applyStrategy($source);
+		}
+		return $this->_models;
 	}
 
 	/**
@@ -566,37 +781,27 @@ class Query extends \lithium\core\Object {
 		return $val ? array($key => $val) : array();
 	}
 
-	protected function _associate($related) {
+	/**
+	 * Get/set sub queries for the query.
+	 * The getter must be called after an export since the sub queries are built
+	 * during the export according the export's `mode` option and the query `with` option.
+	 *
+	 * @see lithium\data\model\Query::export()
+	 *
+	 * @param string $relpath a dotted relation path
+	 * @param string $query a query instance
+	 * @return mixed
+	 */
+
+	public function childs($relpath = null, $query = null) {
 		if (!$model = $this->model()) {
-			return;
+			throw new ConfigException("No binded model.");
 		}
-
-		foreach ((array) $related as $name => $config) {
-			if (is_int($name)) {
-				$name = $config;
-			}
-			if (!$relationship = $model::relations($name)) {
-				throw new QueryException("Model relationship `{$name}` not found.");
-			}
-			list($name, $query) = $this->_fromRelationship($relationship);
-			$this->join($name, $query);
+		if ($query) {
+			$this->_childs[$relpath] = $query;
+			return $this;
 		}
-	}
-
-	protected function _fromRelationship($rel) {
-		$model = $rel->to();
-		$name = $rel->name();
-		$type = $rel->type();
-		$fieldName = $rel->fieldName();
-		$this->_config['relationships'][$name] = compact('type', 'model', 'fieldName');
-
-		$constraint = $rel->constraints();
-		$class = get_class($this);
-
-		return array($name, $this->_instance($class, compact('constraint', 'model') + array(
-			'type' => 'LEFT',
-			'alias' => $rel->name()
-		)));
+		return $this->_childs;
 	}
 }
 

--- a/data/model/Relationship.php
+++ b/data/model/Relationship.php
@@ -53,44 +53,44 @@ class Relationship extends \lithium\core\Object {
 	 * Constructs an object that represents a relationship between two model classes.
 	 *
 	 * @param array $config The relationship's configuration, which defines how the two models in
-	 *              question are bound. The available options are:
+	 *        question are bound. The available options are:
 	 *
-	 *             - `'name'` _string_: The name of the relationship in the context of the
-	 *               originating model. For example, a `Posts` model might define a relationship to
-	 *               a `Users` model like so:
+	 *        - `'name'` _string_: The name of the relationship in the context of the
+	 *          originating model. For example, a `Posts` model might define a relationship to
+	 *          a `Users` model like so:
 	 * {{{ public $hasMany = array('Author' => array('to' => 'Users')); }}}
 	 * In this case, the relationship is bound to the `Users` model, but `'Author'` would be the
 	 * relationship name. This is the name with which the relationship is referenced in the
 	 * originating model.
-	 *             - `'key'` _mixed_: An array of fields that define the relationship, where the
-	 *               keys are fields in the originating model, and the values are fields in the
-	 *               target model. If the relationship is not deined by keys, this array should be
-	 *               empty.
-	 *             - `'type'` _string_: The type of relationship. Should be one of `'belongsTo'`,
-	 *               `'hasOne'` or `'hasMany'`.
-	 *             - `'from'` _string_: The fully namespaced class name of the model where this
-	 *                relationship originates.
-	 *             - `'to'` _string_: The fully namespaced class name of the model that this
-	 *               relationship targets.
-	 *             - `'link'` _string_: A constant specifying how the object bound to the
-	 *               originating model is linked to the object bound to the target model. For
-	 *               relational databases, the only valid value is `LINK_KEY`, which means a foreign
-	 *               key in one object matches another key (usually the primary key) in the other.
-	 *               For document-oriented and other non-relational databases, different types of
-	 *               linking, including key lists, database reference objects (such as MongoDB's
-	 *               `MongoDBRef`), or even embedding.
-	 *             - `'fields'` _mixed_: An array of the subset of fields that should be selected
-	 *               from the related object(s) by default. If set to `true` (the default), all
-	 *               fields are selected.
-	 *             - `'fieldName'` _string_: The name of the field used when accessing the related
-	 *               data in a result set. For example, in the case of `Posts hasMany Comments`, the
-	 *               field name defaults to `'comments'`, so comment data is accessed (assuming
-	 *               `$post = Posts::first()`) as `$post->comments`.
-	 *             - `'constraint'` _mixed_: A string or array containing additional constraints
-	 *               on the relationship query. If a string, can contain a literal SQL fragment or
-	 *               other database-native value. If an array, maps fields from the related object
-	 *               either to fields elsewhere, or to arbitrary expressions. In either case, _the
-	 *               values specified here will be literally interpreted by the database_.
+	 *        - `'key'` _mixed_: An array of fields that define the relationship, where the
+	 *          keys are fields in the originating model, and the values are fields in the
+	 *          target model. If the relationship is not deined by keys, this array should be
+	 *          empty.
+	 *        - `'type'` _string_: The type of relationship. Should be one of `'belongsTo'`,
+	 *          `'hasOne'` or `'hasMany'`.
+	 *        - `'from'` _string_: The fully namespaced class name of the model where this
+	 *          relationship originates.
+	 *        - `'to'` _string_: The fully namespaced class name of the model that this
+	 *          relationship targets.
+	 *        - `'link'` _string_: A constant specifying how the object bound to the
+	 *          originating model is linked to the object bound to the target model. For
+	 *          relational databases, the only valid value is `LINK_KEY`, which means a foreign
+	 *          key in one object matches another key (usually the primary key) in the other.
+	 *          For document-oriented and other non-relational databases, different types of
+	 *          linking, including key lists, database reference objects (such as MongoDB's
+	 *          `MongoDBRef`), or even embedding.
+	 *        - `'fields'` _mixed_: An array of the subset of fields that should be selected
+	 *          from the related object(s) by default. If set to `true` (the default), all
+	 *          fields are selected.
+	 *        - `'fieldName'` _string_: The name of the field used when accessing the related
+	 *          data in a result set. For example, in the case of `Posts hasMany Comments`, the
+	 *          field name defaults to `'comments'`, so comment data is accessed (assuming
+	 *          `$post = Posts::first()`) as `$post->comments`.
+	 *        - `'constraints'` _mixed_: A string or array containing additional constraints
+	 *          on the relationship query. If a string, can contain a literal SQL fragment or
+	 *          other database-native value. If an array, maps fields from the related object
+	 *          either to fields elsewhere, or to arbitrary expressions. In either case, _the
+	 *          values specified here will be literally interpreted by the database_.
 	 */
 	public function __construct(array $config = array()) {
 		$defaults = array(
@@ -102,7 +102,7 @@ class Relationship extends \lithium\core\Object {
 			'link' => static::LINK_KEY,
 			'fields' => true,
 			'fieldName' => null,
-			'constraint' => array()
+			'constraints' => array()
 		);
 		parent::__construct($config + $defaults);
 	}
@@ -129,18 +129,6 @@ class Relationship extends \lithium\core\Object {
 			return $this->_config;
 		}
 		return isset($this->_config[$key]) ? $this->_config[$key] : null;
-	}
-
-	public function constraints() {
-		$constraints = array();
-		$config  = $this->_config;
-		$relFrom = $config['from']::meta('name');
-		$relTo   = $config['name'];
-
-		foreach ($this->_config['key'] as $from => $to) {
-			$constraints["{$relFrom}.{$from}"] = "{$relTo}.{$to}";
-		}
-		return $constraints + (array) $this->_config['constraint'];
 	}
 
 	public function __call($name, $args = array()) {

--- a/data/source/Database.php
+++ b/data/source/Database.php
@@ -10,6 +10,7 @@ namespace lithium\data\source;
 
 use PDO;
 use PDOException;
+use lithium\util\Set;
 use lithium\util\String;
 use lithium\util\Inflector;
 use InvalidArgumentException;
@@ -52,7 +53,7 @@ abstract class Database extends \lithium\data\Source {
 		'update' => "UPDATE {:source} SET {:fields} {:conditions};{:comment}",
 		'delete' => "DELETE {:flags} FROM {:source} {:conditions};{:comment}",
 		'schema' => "CREATE TABLE {:source} (\n{:columns}{:indexes});{:comment}",
-		'join'   => "{:type} JOIN {:source} {:alias} {:constraint}"
+		'join'   => "{:type} JOIN {:source} {:alias} {:constraints}"
 	);
 
 	/**
@@ -64,7 +65,9 @@ abstract class Database extends \lithium\data\Source {
 		'entity' => 'lithium\data\entity\Record',
 		'set' => 'lithium\data\collection\RecordSet',
 		'relationship' => 'lithium\data\model\Relationship',
-		'schema' => 'lithium\data\Schema'
+		'result' => 'lithium\data\source\database\adapter\pdo\Result',
+		'schema' => 'lithium\data\Schema',
+		'query' => 'lithium\data\model\Query'
 	);
 
 	/**
@@ -101,6 +104,14 @@ abstract class Database extends \lithium\data\Source {
 	 * @var array
 	 */
 	protected $_quotes = array();
+
+	/**
+	 * Array of named callable objects representing different strategies for performing specific
+	 * types of queries.
+	 *
+	 * @var array
+	 */
+	protected $_strategies = array();
 
 	/**
 	 * Getter/Setter for the connection's encoding
@@ -165,6 +176,49 @@ abstract class Database extends \lithium\data\Source {
 		$this->_strings += array(
 			'read' => 'SELECT {:fields} FROM {:source} {:alias} {:joins} {:conditions} {:group} ' .
 			          '{:having} {:order} {:limit};{:comment}'
+		);
+		$strategies = &$this->_strategies;
+		$strategies += array(
+			'joined' => function($self, $model, $relations, $relation, $fromAlias, &$with, $context) use (&$strategies){
+
+				$relationships = function ($context, $relname, $model, $type, $fieldName, $fromAlias, $toAlias) {
+					$context->relationships($relname, compact(
+						'type', 'model', 'fieldName','fromAlias', 'toAlias'
+					));
+				};
+
+				foreach ($relations as $name => $subrelations) {
+					if (!$rel = $model::relations($name)) {
+						throw new QueryException("Model relationship `{$name}` not found.");
+					}
+
+					$relPath = $relation ? $relation . '.' . $name : $name;
+
+					$constraints = array();
+					if (isset($with[$relPath]['constraints'])) {
+						$constraints = $with[$relPath]['constraints'];
+					}
+
+					$alias = isset($with[$relPath]['alias']) ? $with[$relPath]['alias'] : $name;
+					$toAlias = $context->alias($alias, $relPath);
+
+
+					if ($context->relationships($relPath) === null) {
+						$relationships(
+							$context, $relPath, $rel->to(), $rel->type(),
+							$rel->fieldName(), $fromAlias, $toAlias
+						);
+						$self->join($context, $rel, $fromAlias, $toAlias, $constraints);
+					}
+
+					if (!empty($subrelations)) {
+						$strategies['joined']($self, $rel->to(), $subrelations, $relPath, $toAlias, $with, $context);
+					}
+				}
+			},
+			'nested' => function($self, $model, $relations, $relation, $fromAlias, &$with, $context) {
+				throw new QueryException("This strategy is not yet implemented.");
+			}
 		);
 		parent::__construct($config + $defaults);
 	}
@@ -233,11 +287,27 @@ abstract class Database extends \lithium\data\Source {
 		$open  = reset($this->_quotes);
 		$close = next($this->_quotes);
 
-		if (preg_match('/^[a-z0-9_-]+\.[a-z0-9_-]+$/i', $name)) {
-			list($first, $second) = explode('.', $name, 2);
+		list($first, $second) = $this->_splitFieldname($name);
+		if ($first) {
 			return "{$open}{$first}{$close}.{$open}{$second}{$close}";
 		}
 		return preg_match('/^[a-z0-9_-]+$/i', $name) ? "{$open}{$name}{$close}" : $name;
+	}
+
+	/**
+	 * Return the alias and the field name from an identifier name.
+	 *
+	 * @param string $field Field name or identifier name.
+	 * @return array Returns an array with the alias (or `null` if not applicable) as first value
+	 *         and the field name as second value.
+	 */
+	protected function _splitFieldname($field) {
+		if (is_string($field)) {
+			if (preg_match('/^[a-z0-9_-]+\.[a-z0-9_-]+$/i', $field)) {
+				return explode('.', $field, 2);
+			}
+		}
+		return array(null, $field);
 	}
 
 	/**
@@ -364,33 +434,10 @@ abstract class Database extends \lithium\data\Source {
 			if (is_string($query)) {
 				$sql = String::insert($query, $self->value($args));
 			} else {
-				$limit = $query->limit();
-
-				if ($model && $limit && !isset($args['subquery']) && $model::relations('hasMany')) {
-					$name = $model::meta('name');
-					$key = $model::key();
-
-					$subQuery = $self->invokeMethod('_instance', array(get_class($query), array(
-						'type' => 'read',
-						'model' => $model,
-						'group' => $self->name("{$name}.{$key}"),
-						'fields' => array("{$name}.{$key}"),
-						'joins' => $query->joins(),
-						'conditions' => $query->conditions(),
-						'limit' => $query->limit(),
-						'page' => $query->page(),
-						'order' => $query->order()
-					)));
-					$ids = $self->read($subQuery, array('subquery' => true));
-
-					if ($ids->count()) {
-						$query->limit(false)->conditions(array("{$name}.{$key}" => array_map(
-							function($index) use ($key) { return $index[$key]; },
-							$ids->data()
-						)));
-					}
+				if (!$data = $self->invokeMethod('_queryExport', array($query))) {
+					return false;
 				}
-				$sql = $self->renderCommand($query);
+				$sql = $self->renderCommand($data['type'], $data);
 			}
 			$result = $self->invokeMethod('_execute', array($sql));
 
@@ -417,6 +464,44 @@ abstract class Database extends \lithium\data\Source {
 					));
 			}
 		});
+	}
+
+	/**
+	 * Helper which export the query export
+	 *
+	 * @param object $query The query object
+	 * @return array The export array
+	 */
+	protected function &_queryExport($query) {
+		$data = $query->export($this);
+		if ($query->limit() && ($model = $query-> model())) {
+			foreach ($query->relationships() as $relation) {
+				if ($relation['type'] === 'hasMany') {
+					$name = $model::meta('name');
+					$key = $model::key();
+					$fields = $data['fields'];
+					$fieldname = $this->name("{$name}.{$key}");
+					$data['fields'] = "DISTINCT({$fieldname}) AS _ID_";
+					$sql = $this->renderCommand('read', $data);
+					$result = $this->_execute($sql);
+
+					$ids = array();
+					while ($row = $result->next()) {
+						$ids[] = $row[0];
+					}
+
+					if (!$ids) {
+						$return = null;
+						return $return;
+					}
+					$data['fields'] = $fields;
+					$data['limit'] = '';
+					$data['conditions'] = $this->conditions(array("{$name}.{$key}" => $ids), $query);
+					return $data;
+				}
+			}
+		}
+		return $data;
 	}
 
 	/**
@@ -565,22 +650,34 @@ abstract class Database extends \lithium\data\Source {
 	 *
 	 * @param object $query A `lithium\data\model\Query` object
 	 * @param string $resource
-	 * @param string $context
+	 * @param string $alias
 	 * @return void
 	 */
-	public function schema($query, $resource = null, $context = null) {
+	public function schema($query, $resource = null, $alias = null) {
 		$model = is_scalar($resource) ? $resource : $query->model();
-		$modelName = (method_exists($context, 'alias') ? $context->alias() : $query->alias());
+		$alias = $alias ? $alias : $query->alias();
+		$paths = $query->paths($this);
 		$fields = $query->fields();
-		$joins = (array) $query->joins();
+
 		$result = array();
 
 		if (!$model && is_array($fields)) {
+			foreach ($fields as $key => $field) {
+				if (preg_match('/^.*?\.(.*)/', $field, $match)) {
+					$fields[$key] = $match[1];
+				}
+			}
 			return array($fields);
 		}
 
-		if (!$fields && !$joins) {
-			return array($modelName => $model::schema()->names());
+		if (!$fields) {
+			$result = array('' => $model::schema()->names());
+
+			foreach ($query->relationships() as $key => $relation) {
+				$model = $relation['model'];
+				$result[$key] = $model::schema()->names();
+			}
+			return $result;
 		}
 
 		if (!$fields && $joins) {
@@ -593,50 +690,43 @@ abstract class Database extends \lithium\data\Source {
 			return $result;
 		}
 
-		$relations = array_keys((array) $query->relationships());
+		$relations = $query->relationships();
 		$schema = $model::schema();
-		$pregDotMatch = '/^(' . implode('|', array_merge($relations, array($modelName))) . ')\./';
-		$forJoin = ($modelName != $query->alias());
+		$pregDotMatch = '/^(' . implode('|', array_merge(array_keys($paths))) . ')\./';
 
 		foreach ($fields as $scope => $field) {
 			switch (true) {
-				case (is_numeric($scope) && ($field == '*' || $field == $modelName)):
-					$result[$modelName] = $model::schema()->names();
-				break;
+				case (is_numeric($scope) && ($field == '*' || $field == $alias)):
+					$result[''] = $model::schema()->names();
+					break;
 				case (is_numeric($scope) && isset($schema[$field])):
-					$result[$modelName][] = $field;
-				break;
+					$result[''][] = $field;
+					break;
 				case is_numeric($scope) && preg_match($pregDotMatch, $field):
 					list($dotModelName, $field) = explode('.', $field);
+					$dotModelName = $dotModelName === $alias ? '' : $dotModelName;
 					$result[$dotModelName][] = $field;
 					break;
-				case is_array($field) && $scope == $modelName:
-					$result[$modelName] = $field;
-				break;
-				case $forJoin || !$joins;
-					continue;
-				case in_array($scope, $relations) && is_array($field):
-					$join = isset($joins[$scope]) ? $joins[$scope] : null;
-					if ($join) {
-						$relSchema = $this->schema($query, $join->model(), $join);
+				case is_array($field) && $scope === $alias:
+					$result[''] = $field;
+					break;
+				case is_array($field) && array_key_exists($scope, $paths):
+					$name = $paths[$scope];
+					if (isset($relations[$name]['model'])) {
+						$relSchema = $this->schema($query, $relations[$name]['model'], $scope);
 						$result[$scope] = reset($relSchema);
 					}
-				break;
-				case is_numeric($scope) && in_array($field, $relations):
-					$join = isset($joins[$field]) ? $joins[$field] : null;
-					if (!$join) {
-						continue;
+					break;
+				case is_numeric($scope) && array_key_exists($field, $paths):
+					$name = $paths[$field];
+					if (isset($relations[$name]['model'])) {
+						$scope = $relations[$name]['model'];
+						$result[$field] = $scope::schema()->names();
+					} else {
+						$result[''] = $model::schema()->names();
 					}
-					$scope = $join->model();
-					$result[$field] = $scope::schema()->names();
-				break;
+					break;
 			}
-		}
-		if (!$forJoin) {
-			$sortOrder = array_flip(array_merge(array($modelName), $relations));
-			uksort($result, function($a, $b) use ($sortOrder) {
-				return $sortOrder[$a] - $sortOrder[$b];
-			});
 		}
 		return $result;
 	}
@@ -672,7 +762,7 @@ abstract class Database extends \lithium\data\Source {
 	 * - If `$key` is numeric and `$value` is a string, `$value` is treated as a literal SQL
 	 *   fragment and returned.
 	 *
-	 * @param string|array $having The havings for this query.
+	 * @param string|array $conditions The havings for this query.
 	 * @param object $context The current `lithium\data\model\Query` instance.
 	 * @param array $options
 	 *               - `prepend` _boolean_: Whether the return string should be prepended with the
@@ -704,8 +794,6 @@ abstract class Database extends \lithium\data\Source {
 		$defaults = array('prepend' => false);
 		$ops = $this->_operators;
 		$options += $defaults;
-		$model = $context->model();
-		$schema = $model ? $model::schema() : array();
 
 		switch (true) {
 			case empty($conditions):
@@ -718,7 +806,7 @@ abstract class Database extends \lithium\data\Source {
 		$result = array();
 
 		foreach ($conditions as $key => $value) {
-			$return = $this->_processConditions($key, $value, $context, $schema);
+			$return = $this->_processConditions($key, $value, $context);
 
 			if ($return) {
 				$result[] = $return;
@@ -728,9 +816,19 @@ abstract class Database extends \lithium\data\Source {
 		return ($options['prepend'] && $result) ? $options['prepend'] . " {$result}" : $result;
 	}
 
-	public function _processConditions($key, $value, $context, $schema, $glue = 'AND') {
+	public function _processConditions($key, $value, $context, $glue = 'AND') {
 		$constraintTypes =& $this->_constraintTypes;
-		$fieldMeta = $schema->fields($this->_fieldName($key)) ?: array();
+		$model = $context->model();
+		$models = $context->models();
+
+		$schema = null;
+		list($first, $second) = $this->_splitFieldname($key);
+		if ($first && isset($models[$first]) && $class = $models[$first]) {
+			$schema = $class::schema();
+		} elseif ($model) {
+			$schema = $model::schema();
+		}
+		$fieldMeta = $schema ? (array) $schema->fields($second) : array();
 
 		switch (true) {
 			case (is_numeric($key) && is_string($value)):
@@ -740,10 +838,8 @@ abstract class Database extends \lithium\data\Source {
 					return $this->value($value);
 				}
 			case is_scalar($value) || is_null($value):
-				if ($context->type() == 'read' && ($alias = $context->alias())) {
-					if (preg_match('/^[a-z0-9_-]+$/i', $key)) {
-						$key = $alias . "." . $key;
-					}
+				if ($context && ($context->type() == 'read') && ($alias = $context->alias())) {
+					$key = $this->_aliasing($key, $alias);
 				}
 				if (isset($value)) {
 					return $this->name($key) . ' = ' . $this->value($value, $fieldMeta);
@@ -752,7 +848,7 @@ abstract class Database extends \lithium\data\Source {
 			case is_numeric($key) && is_array($value):
 				$result = array();
 				foreach ($value as $cField => $cValue) {
-					$result[] = $this->_processConditions($cField, $cValue, $context, $schema, $glue);
+					$result[] = $this->_processConditions($cField, $cValue, $context, $glue);
 				}
 				return '(' . implode(' ' . $glue . ' ', $result) . ')';
 			case (is_string($key) && is_object($value)):
@@ -763,7 +859,7 @@ abstract class Database extends \lithium\data\Source {
 				$glue = strtoupper($key);
 
 				foreach ($value as $cField => $cValue) {
-					$result[] = $this->_processConditions($cField, $cValue, $context, $schema, $glue);
+					$result[] = $this->_processConditions($cField, $cValue, $context, $glue);
 				}
 				return '(' . implode(' ' . $glue . ' ', $result) . ')';
 			case (is_string($key) && is_array($value) && isset($this->_operators[key($value)])):
@@ -772,106 +868,90 @@ abstract class Database extends \lithium\data\Source {
 				}
 				return '(' . implode(' ' . $glue . ' ', $result) . ')';
 			case is_array($value):
+				if (!is_numeric($op = key($value))) {
+					throw new QueryException("Unsupported operator `{$op}`.");
+				}
 				$value = join(', ', $this->value($value, $fieldMeta));
 				return "{$this->name($key)} IN ({$value})";
 		}
 	}
 
-	/**
-	 * Returns either a formatted string for a select query, or an array of key/value pairs for a
-	 * create or update query.
-	 *
-	 * @param array $fields Either an array of field names for a select, or key/value pairs for
-	 *              a create or update query.
-	 * @param string $context An instance of `Query`, containing the details of the query to be run.
-	 * @return mixed Returns a string or array, depending on the query type to be performed (as
-	 *         determined by `$context->type()`).
-	 */
 	public function fields($fields, $context) {
 		$type = $context->type();
-		$schema = (array) $context->schema()->fields();
-		$modelNames = (array) $context->name();
-		$modelNames = array_merge($modelNames, array_keys((array) $context->relationships()));
+		$schema = $schema = $context->schema()->fields();
+		$models = $context->models($this);
+		$alias = $context->alias();
 
 		if (!is_array($fields)) {
 			return $this->_fieldsReturn($type, $context, $fields, $schema);
 		}
+
 		$toMerge = array();
 		$keys = array_keys($fields);
-		$groupFields = function($item, $key) use (&$toMerge, &$keys, $modelNames, &$context) {
-			$name = current($keys);
-			next($keys);
-			switch (true) {
-				case is_array($item):
-					$toMerge[$name] = $item;
-					continue;
-				case is_object($item) && isset($item->scalar):
-					$toMerge[$name] = array($item->scalar);
-					continue;
-				case in_array($item, $modelNames):
-					if ($item == reset($modelNames)) {
-						$schema = $context->schema();
-					} else {
-						$joins = $context->joins();
-						$schema = $joins[$item]->schema();
-					}
-					$toMerge[$item] = $schema->names();
-					continue;
-				case strpos($item, '.') !== false:
-					list($name, $field) = explode('.', $item);
-					$toMerge[$name][] = $field;
-					continue;
-				default:
-					$mainSchema = $context->schema()->names();
 
-					if (in_array($item, $mainSchema)) {
-						$toMerge[reset($modelNames)][] = $item;
+		/**
+		 * Group fields list by alias name.
+		 * keys of the result array are alias and values are list of fields.
+		 */
+		$groupFields = function($item, $key) use (&$toMerge, &$keys, $alias, $models, &$context) {
+				$name = current($keys);
+				next($keys);
+				switch (true) {
+					case is_array($item):
+						$toMerge[$name] = $item;
 						continue;
-					}
-					$toMerge[0][] = $item;
-					continue;
-			}
-		};
+					case is_object($item) && isset($item->scalar):
+						$toMerge[$name] = array($item->scalar);
+						continue;
+					case isset($models[$item]):
+						if ($model = $models[$item]) {
+							$schema = $model::schema();
+							$toMerge[$item] = $schema->names();
+						}
+						continue;
+					case strpos($item, '.') !== false:
+						list($name, $field) = explode('.', $item);
+						$toMerge[$name][] = $field;
+						continue;
+					default:
+						$mainSchema = $context->schema()->names();
+						if ($alias && !preg_match('/[\(\)]/', $item)) {
+							$toMerge[$alias][] = $item;
+							continue;
+						}
+						$toMerge[0][] = $item;
+						continue;
+				}
+			};
+
 		array_walk($fields, $groupFields);
 		$fields = $toMerge;
 
-		if (count($modelNames) > 1) {
-			$sortOrder = array_flip($modelNames);
-			uksort($fields, function($a, $b) use ($sortOrder) {
-				return $sortOrder[$a] - $sortOrder[$b];
-			});
+		if ($fields && $context->with() && !isset($fields[$alias]) && ($model = $context->model())) {
+			$keys = $model::meta('key');
+			$keys = is_array($keys) ? $keys : array($keys);
+			$fields[$alias] = $keys;
 		}
-		$mapFields = function() use($fields, $modelNames) {
-			$return = array();
-			foreach ($fields as $key => $items) {
-				if (!is_array($items)) {
-					$return[$key] = $items;
-					continue;
-				}
-				if (is_numeric($key)) {
-					$key = reset($modelNames);
-				}
-				$pointer = &$return[$key];
-				foreach ($items as $field) {
-					if (stripos($field, ' as ') !== false) {
-						list($real, $as) = explode(' as ', str_replace(' AS ', ' as ', $field));
-						$pointer[] = trim($as);
-						continue;
-					}
-					$pointer[] = $field;
-				}
-			}
-			return $return;
-		};
-		$context->map($mapFields());
+
+		$map = $this->_mapFields($fields, $context->paths($this));
+		$context->map($map);
 
 		$toMerge = array();
+
+		/**
+		 * Format fields in a SQL format.
+		 */
 		foreach ($fields as $scope => $items) {
 			foreach ($items as $field) {
 				if (!is_numeric($scope)) {
-					$open  = reset($this->_quotes);
-					$close = next($this->_quotes);
-					$toMerge[] = $open . $scope . $close . '.' . $open . $field . $close;
+					$open = $this->_quotes[0];
+					$close = $this->_quotes[1];
+					if (stripos($field, ' as ') !== false) {
+						list($real, $as) = explode(' as ', str_replace(' AS ', ' as ', $field));
+						$toMerge[] = $open . $scope . $close . '.' . $open . $real . $close . ' as ' . $as;
+					} else {
+						$toMerge[] = $open . $scope . $close . '.' . $open . $field . $close;
+					}
 					continue;
 				}
 				$toMerge[] = $field;
@@ -879,6 +959,63 @@ abstract class Database extends \lithium\data\Source {
 		}
 		$fields = $toMerge;
 		return $this->_fieldsReturn($type, $context, $fields, $schema);
+	}
+
+	/**
+	 * Group fields list by relation name.
+	 *
+	 * Example :
+	 * {{{
+	 * $this->_mapFields(
+	 *               array('id', 'title', 'Comment'),
+	 *               array('Post' => 'Post', 'Comment' => 'Post.Comment')
+	 * }}}
+	 *
+	 * will return the following array :
+	 *
+	 * {{{
+	 * array(
+	 *    'Post' => array(
+	 * 		              0 => id,
+	 *                    1 => title
+	 *              ),
+	 *    'Post.Comment' => array(
+	 * 		              0 => id,
+	 *                    1 => post_id
+	 *                    2 => email
+	 *                    3 => body
+	 *                    4 => created
+	 *              )
+	 * )
+	 * }}}
+	 *
+	 * @param array $fields List of fields
+	 * @param array $aliases The mapping between query alias name and relation name (see
+	 *        the `'with'` options of `Model::find()`)
+	 * @return array The fields array grouped by relations
+	 */
+	protected function _mapFields($fields, $aliases) {
+		$return = array();
+		foreach ($fields as $key => $items) {
+			$key = isset($aliases[$key]) ? $aliases[$key] : '';
+			if (!is_array($items)) {
+				$return[$key] = $items;
+				continue;
+			}
+			if (is_numeric($key)) {
+				$key = reset($aliases);
+			}
+			$pointer = &$return[$key];
+			foreach ($items as $field) {
+				if (stripos($field, ' as ') !== false) {
+					list($real, $as) = explode(' as ', str_replace(' AS ', ' as ', $field));
+					$pointer[] = trim($as);
+					continue;
+				}
+				$pointer[] = $field;
+			}
+		}
+		return $return;
 	}
 
 	protected function _fieldsReturn($type, $context, $fields, $schema) {
@@ -921,46 +1058,57 @@ abstract class Database extends \lithium\data\Source {
 	public function joins(array $joins, $context) {
 		$result = null;
 
-		foreach ($joins as $model => $join) {
+		foreach ($joins as $key => $join) {
 			if ($result) {
 				$result .= ' ';
 			}
-			$result .= $this->renderCommand('join', $join->export($this));
+			$join = is_array($join) ? $this->_instance('query', $join) : $join;
+			$options['keys'] = array('source', 'alias', 'constraints');
+			$result .= $this->renderCommand('join', $join->export($this, $options));
 		}
 		return $result;
 	}
 
-	public function constraint($constraint, $context) {
-		if (!$constraint) {
-			return "";
+		/**
+	 * Returns a string of formatted constraints to be inserted into the query statement. If the
+	 * query constraints are defined as an array, key pairs are converted to SQL strings.
+	 *
+	 * Conversion rules are as follows:
+	 *
+	 * - If `$key` is numeric and `$value` is a string, `$value` is treated as a literal SQL
+	 *   fragment and returned.
+	 *
+	 * @param string|array $constraints The constraints for a `ON` clause.
+	 * @param object $context The current `lithium\data\model\Query` instance.
+	 * @param array $options
+	 *               - `prepend` _boolean_: Whether the return string should be prepended with the
+	 *                 `ON` keyword.
+	 * @return string Returns the `ON` clause of an SQL query.
+	 */
+	public function constraints($constraints, $context, array $options = array()) {
+		$defaults = array('prepend' => 'ON');
+		$options += $defaults;
+		if (is_array($constraints)) {
+			$constraints = $this->_constraints($constraints);
 		}
-		if (is_string($constraint)) {
-			return "ON {$constraint}";
-		}
-		$result = array();
+		return $this->_conditions($constraints, $context, $options);
+	}
 
-		foreach ($constraint as $field => $value) {
-			$field = $this->name($field);
+	/**
+	 * Auto escape string value to a field name value
+	 *
+	 * @param array $constraints The constraints array
+	 * @return array The escaped constraints array
+	 */
+	protected function _constraints(array $constraints) {
+		foreach ($constraints as &$value) {
 			if (is_string($value)) {
-				$result[] = $field . ' = ' . $this->name($value);
-				continue;
-			}
-			if ($value === null) {
-				$result[] = "{$field} IS NULL";
-				continue;
-			}
-			if (!is_array($value)) {
-				continue;
-			}
-			foreach ($value as $op => $val) {
-				if (!isset($this->_operators[$op])) {
-					throw new QueryException("Unsupported operator `{$op}` used in constraint.");
-				}
-				$val = $this->name($val);
-				$result[] = "{$field} {$op} {$val}";
+				$value = (object) $this->name($value);
+			} elseif (is_array($value)){
+				$value = $this->_constraints($value);
 			}
 		}
-		return 'ON ' . join(' AND ', $result);
+		return $constraints;
 	}
 
 	/**
@@ -1111,6 +1259,8 @@ abstract class Database extends \lithium\data\Source {
 			foreach ((array) $value as $val) {
 				$values[] = $this->value($val, $schema);
 			}
+		} elseif (isset($value->scalar)) {
+			return "{$key} {$op} {$value->scalar}";
 		}
 
 		switch (true) {
@@ -1204,7 +1354,7 @@ abstract class Database extends \lithium\data\Source {
 	/**
 	 * Throw a `QueryException` error
 	 *
-	 * @param string The offending SQL string
+	 * @param string $sql The offending SQL string
 	 * @filter
 	 */
 	protected function _error($sql){
@@ -1214,6 +1364,126 @@ abstract class Database extends \lithium\data\Source {
 			list($code, $error) = $self->error();
 			throw new QueryException("{$sql}: {$error}", $code);
 		});
+	}
+
+	/**
+	 * Applying a strategy to a `lithium\data\model\Query` object
+	 *
+	 * @param array $options The option array
+	 * @param object $context A query object to configure
+	 */
+	public function applyStrategy($options, $context) {
+		$options += array('mode' => 'joined');
+		if (!$model = $context->model()) {
+			throw new ConfigException('The `\'with\'` option need a valid `\'model\'` option.');
+		}
+		$with = $context->with();
+		$relations = Set::expand(Set::normalize(array_keys($context->with())));
+
+		$mode = $options['mode'];
+		if (isset($this->_strategies[$mode])) {
+			$strategy = $this->_strategies[$mode];
+			$strategy($this, $model, $relations, '', $context->alias(), $with, $context);
+		} else {
+			throw new QueryException("Undefined query strategy `{$mode}`.");
+		}
+	}
+
+	/**
+	 * Set a query's join according a Relationship.
+	 *
+	 * @param object $context A Query instance
+	 * @param object $rel A Relationship instance
+	 * @param string $fromAlias Set a specific alias for the `'from'` `Model`.
+	 * @param string $toAlias Set a specific alias for `'to'` `Model`.
+	 * @param mixed $constraints If `$constraints` is an array, it will be merged to defaults
+	 *        constraints. If `$constraints` is an object, defaults won't be merged.
+	 */
+	public function join($context, $rel, $fromAlias = null, $toAlias = null, $constraints = array()) {
+		$model = $rel->to();
+
+		if ($fromAlias === null) {
+			$from = $rel->from();
+			$fromAlias = $context->alias();
+		}
+		if ($toAlias === null) {
+			$toAlias = $context->alias(null, $rel->name());
+		}
+		if (!is_object($constraints)) {
+			$constraints = $this->on($rel, $fromAlias, $toAlias, $constraints);
+		} else {
+			$constraints = (array) $constraints;
+		}
+
+		$context->joins($toAlias, compact('constraints', 'model') + array(
+			'type' => 'LEFT',
+			'alias' => $toAlias
+		));
+	}
+
+	/**
+	 * Helper which add an alias basename to a field name if necessary
+	 *
+	 * @param string $name The field name.
+	 * @param string $alias The alias name
+	 * @param array $map An array of `'modelname' => 'aliasname'` mapping
+	 * @return string
+	 */
+	protected function _aliasing($name, $alias, $map = array()) {
+		list($first, $second) = $this->_splitFieldname($name);
+		if (!$first && preg_match('/^[a-z0-9_-]+$/i', $second)) {
+			return $alias . "." . $second;
+		} elseif(isset($map[$first])) {
+			return $map[$first] . "." . $second;
+		}
+		return $name;
+	}
+
+	/**
+	 * Build the `ON` constraints from a `Relationship` instance
+	 *
+	 * @param object $rel A Relationship instance
+	 * @param string $fromAlias Set a specific alias for the `'from'` `Model`.
+	 * @param string $toAlias Set a specific alias for `'to'` `Model`.
+	 * @param array $constraints Array of additionnal $constraints.
+	 * @return array A constraints array.
+	 */
+
+	public function on($rel, $aliasFrom = null, $aliasTo = null, $constraints = array()) {
+		$model = $rel->from();
+
+		$aliasFrom = $aliasFrom ?: $model::meta('name');
+		$aliasTo = $aliasTo ?: $rel->name();
+
+		$keyConstraints = array();
+		foreach ($rel->key() as $from => $to) {
+			$keyConstraints["{$aliasFrom}.{$from}"] = "{$aliasTo}.{$to}";
+		}
+
+		$mapAlias = array($model::meta('name') => $aliasFrom, $rel->name() => $aliasTo);
+
+		$relConstraints = $this->_on((array) $rel->constraints(), $aliasFrom, $aliasTo, $mapAlias);
+		$constraints = $this->_on($constraints, $aliasFrom, $aliasTo, array());
+
+		return $constraints + $relConstraints + $keyConstraints;
+	}
+
+	protected function _on(array $constraints, $aliasFrom, $aliasTo, $mapAlias = array()) {
+		$result = array();
+		foreach ($constraints as $key => $value) {
+			if (!is_numeric($key) && !isset($this->_constraintTypes[$key])
+					&& !isset($this->_operators[$key])) {
+				$key = $this->_aliasing($key, $aliasFrom, $mapAlias);
+			}
+			if (is_string($value)) {
+				$result[$key] = $this->_aliasing($value, $aliasTo, $mapAlias);
+			} elseif (is_array($value)) {
+				$result[$key] = $this->_on($value, $aliasFrom, $aliasTo, $mapAlias);
+			} else {
+				$result[$key] = $value;
+			}
+		}
+		return $result;
 	}
 }
 

--- a/data/source/database/adapter/MySql.php
+++ b/data/source/database/adapter/MySql.php
@@ -21,14 +21,6 @@ use PDOException;
  */
 class MySql extends \lithium\data\source\Database {
 
-	protected $_classes = array(
-		'entity' => 'lithium\data\entity\Record',
-		'set'    => 'lithium\data\collection\RecordSet',
-		'relationship' => 'lithium\data\model\Relationship',
-		'result' => 'lithium\data\source\database\adapter\pdo\Result',
-		'schema' => 'lithium\data\Schema'
-	);
-
 	/**
 	 * MySQL column type definitions.
 	 *

--- a/data/source/database/adapter/PostgreSql.php
+++ b/data/source/database/adapter/PostgreSql.php
@@ -22,19 +22,6 @@ use PDOException;
 class PostgreSql extends \lithium\data\source\Database {
 
 	/**
-	 * @var PDO
-	 */
-	public $connection;
-
-	protected $_classes = array(
-		'entity' => 'lithium\data\entity\Record',
-		'set' => 'lithium\data\collection\RecordSet',
-		'relationship' => 'lithium\data\model\Relationship',
-		'result' => 'lithium\data\source\database\adapter\pdo\Result',
-		'schema' => 'lithium\data\Schema'
-	);
-
-	/**
 	 * PostgreSQL column type definitions.
 	 *
 	 * @var array

--- a/data/source/database/adapter/Sqlite3.php
+++ b/data/source/database/adapter/Sqlite3.php
@@ -19,14 +19,6 @@ use lithium\core\ConfigException;
  */
 class Sqlite3 extends \lithium\data\source\Database {
 
-	protected $_classes = array(
-		'entity' => 'lithium\data\entity\Record',
-		'set' => 'lithium\data\collection\RecordSet',
-		'relationship' => 'lithium\data\model\Relationship',
-		'result' => 'lithium\data\source\database\adapter\pdo\Result',
-		'schema' => 'lithium\data\Schema'
-	);
-
 	/**
 	 * Pair of opening and closing quote characters used for quoting identifiers in queries.
 	 *

--- a/tests/cases/data/ModelTest.php
+++ b/tests/cases/data/ModelTest.php
@@ -253,13 +253,10 @@ class ModelTest extends \lithium\test\Unit {
 			'link' => 'key',
 			'fields' => true,
 			'fieldName' => 'mock_post',
-			'constraint' => array(),
+			'constraints' => array(),
 			'init' => true
 		);
 		$this->assertEqual($expected, MockComment::relations('MockPost')->data());
-
-		$expected = array('MockComment.mock_post_id' => 'MockPost.id');
-		$this->assertEqual($expected, MockComment::relations('MockPost')->constraints());
 
 		$expected = array(
 			'name' => 'MockComment',
@@ -270,13 +267,10 @@ class ModelTest extends \lithium\test\Unit {
 			'key' => array('id' => 'mock_post_id'),
 			'link' => 'key',
 			'fieldName' => 'mock_comments',
-			'constraint' => array(),
+			'constraints' => array(),
 			'init' => true
 		);
 		$this->assertEqual($expected, MockPost::relations('MockComment')->data());
-
-		$expected = array('MockPost.id' => 'MockComment.mock_post_id');
-		$this->assertEqual($expected, MockPost::relations('MockComment')->constraints());
 
 		MockPost::config(array('meta' => array('connection' => false)));
 		MockComment::config(array('meta' => array('connection' => false)));
@@ -747,7 +741,7 @@ class ModelTest extends \lithium\test\Unit {
 		$this->assertEqual(array('published' => false), $query->conditions());
 
 		$keys = array_keys(array_filter($query->export(MockPost::$connection)));
-		$this->assertEqual(array('type', 'name', 'conditions', 'model', 'alias', 'source'), $keys);
+		$this->assertEqual(array('type', 'name', 'conditions', 'model', 'source', 'alias'), $keys);
 	}
 
 	public function testFindFirst() {

--- a/tests/cases/data/SourceTest.php
+++ b/tests/cases/data/SourceTest.php
@@ -19,10 +19,11 @@ class SourceTest extends \lithium\test\Unit {
 		$expected = array(
 			'connect', 'disconnect', 'sources', 'describe', 'create', 'read', 'update', 'delete',
 			'schema', 'result', 'cast', 'relationship', 'calculation', '__construct', '__destruct',
-			'_init', 'isConnected', 'name', 'methods', 'configureClass', 'item', 'applyFilter',
-			'invokeMethod', '__set_state', '_instance', '_filter', '_parents', '_stop'
+			'_init', 'isConnected', 'name', 'methods', 'configureClass', 'item', 'applyStrategy',
+			'applyFilter', 'invokeMethod', '__set_state', '_instance', '_filter', '_parents',
+			'_stop'
 		);
-		$this->assertEqual($expected, $methods);
+		$this->assertEqual(sort($expected), sort($methods));
 	}
 
 	public function testBaseMethods() {

--- a/tests/cases/data/source/MongoDbTest.php
+++ b/tests/cases/data/source/MongoDbTest.php
@@ -538,7 +538,7 @@ class MongoDbTest extends \lithium\test\Unit {
 			'to'   => $to,
 			'fields' => true,
 			'fieldName' => 'mockPost',
-			'constraint' => null,
+			'constraints' => null,
 			'init' => true
 		);
 		$this->assertEqual($expected, $result->data());

--- a/tests/mocks/data/MockBase.php
+++ b/tests/mocks/data/MockBase.php
@@ -8,7 +8,6 @@
 
 namespace lithium\tests\mocks\data;
 
-use lithium\data\Schema;
 use lithium\tests\mocks\data\model\MockDatabase;
 
 class MockBase extends \lithium\data\Model {

--- a/tests/mocks/data/model/MockDatabasePost.php
+++ b/tests/mocks/data/model/MockDatabasePost.php
@@ -15,7 +15,7 @@ class MockDatabasePost extends \lithium\tests\mocks\data\MockBase {
 	public $hasMany = array(
 		'MockDatabaseComment',
 		'MockDatabasePostRevision' => array(
-			'constraint' => array('MockDatabasePostRevision.deleted' => null)
+			'constraints' => array('MockDatabasePostRevision.deleted' => null)
 		)
 	);
 

--- a/tests/mocks/data/model/MockGallery.php
+++ b/tests/mocks/data/model/MockGallery.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2012, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\tests\mocks\data\model;
+
+class MockGallery extends \lithium\tests\mocks\data\MockBase {
+
+	public $hasMany = array(
+		'Image' => array('to' => 'lithium\tests\mocks\data\model\MockImage')
+	);
+	public $belongsTo = array(
+		'Parent' => array('to' => 'lithium\tests\mocks\data\model\MockGallery')
+	);
+
+	public static $connection = null;
+
+	protected $_meta = array(
+		'key' => 'id',
+		'name' => 'Gallery',
+		'source' => 'mock_gallery',
+		'connection' => false
+	);
+}
+
+?>

--- a/tests/mocks/data/model/MockImage.php
+++ b/tests/mocks/data/model/MockImage.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2012, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\tests\mocks\data\model;
+
+class MockImage extends \lithium\tests\mocks\data\MockBase {
+
+	public $belongsTo = array(
+		'Gallery' => array('to' => 'lithium\tests\mocks\data\model\MockGallery')
+	);
+
+	public $hasMany = array(
+		'ImageTag' => array('to' => 'lithium\tests\mocks\data\model\MockImageTag')
+	);
+
+	public static $connection = null;
+
+	protected $_meta = array(
+		'key' => 'id',
+		'name' => 'Image',
+		'source' => 'mock_image',
+		'connection' => false
+	);
+}
+
+?>

--- a/tests/mocks/data/model/MockImageTag.php
+++ b/tests/mocks/data/model/MockImageTag.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2012, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\tests\mocks\data\model;
+
+class MockImageTag extends \lithium\tests\mocks\data\MockBase {
+
+	public $belongsTo = array(
+		'Image' => array('to' => 'lithium\tests\mocks\data\model\MockImage'),
+		'Tag' => array('to' => 'lithium\tests\mocks\data\model\MockTag'));
+
+    public static $connection = null;
+
+	protected $_meta = array(
+		'key' => 'id',
+		'name' => 'ImageTag',
+		'source' => 'mock_image_tag',
+		'connection' => false
+	);
+}
+
+?>

--- a/tests/mocks/data/model/MockQueryComment.php
+++ b/tests/mocks/data/model/MockQueryComment.php
@@ -12,6 +12,8 @@ class MockQueryComment extends \lithium\tests\mocks\data\MockBase {
 
 	public static $connection = null;
 
+	public $belongsTo = array('MockQueryPost');
+
 	protected $_meta = array('source' => false, 'connection' => false);
 
 	protected $_schema = array(

--- a/tests/mocks/data/model/MockTag.php
+++ b/tests/mocks/data/model/MockTag.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2012, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\tests\mocks\data\model;
+
+class MockTag extends \lithium\tests\mocks\data\MockBase {
+
+	public $hasMany = array(
+		'ImageTag' => array('to' => 'lithium\tests\mocks\data\model\MockImageTag')
+	);
+
+	public static $connection = null;
+
+	protected $_meta = array(
+		'key' => 'id',
+		'name' => 'Tag',
+		'source' => 'mock_tag',
+		'connection' => false
+	);
+}
+
+?>


### PR DESCRIPTION
BC break:
- the `'constraint'` option is now called `'constraints'` (i.e with an extra 's')
- Query::constraints() has been removed (see Database::on() for PDO datasources)
- Query has been refactored (is doesn't build the join's contraints)
- Queries are now exported according a datasource strategy (Acutally only the joined strategy (i.e. LEFT JOIN) have been implemented).
- Deep aliasing support. If Models define constraints in their relationship (i.e. 'constraints => array('Model1.id' => 'Model2.model1_id), Model1 and/or Model2 will be automagically aliased to avoid conflicts and make nested 'with' works as expected
- 'condititions' are unchanged (i.e. 'name escaped' => 'string escaped')
- 'constraints' are unchanged (i.e. 'name escaped' => 'name escaped'). However (object) casted value now won't be escaped.

Futur developments :
- Allow Queries to contain subqueries
- Allow Datasource to manage queries with  subqueries.
- Implements the "subquery strategy" for both PDO and NoSql datasource.

Ps:
Good luck for the reviewer ;-)
