### PR TITLE
Fix for _processDotPath in Environment class.

### DIFF
--- a/core/Environment.php
+++ b/core/Environment.php
@@ -239,7 +239,7 @@ class Environment {
 		}
 		$pathKeys = explode('.', $path);
 		foreach ($pathKeys as $pathKey) {
-			if (! is_array($arrayPointer) || ! isset ($arrayPointer[$pathKey])) {
+			if (!is_array($arrayPointer) || !isset($arrayPointer[$pathKey])) {
 				return false;
 			}
 			$arrayPointer = &$arrayPointer[$pathKey];


### PR DESCRIPTION
Happen fatal error if we try to get value from array but it variable is not array.
Add an additional condition.
