### PR TITLE
Fix for _processDotPath in Environment class.

### DIFF
--- a/core/Environment.php
+++ b/core/Environment.php
@@ -239,7 +239,7 @@ class Environment {
 		}
 		$pathKeys = explode('.', $path);
 		foreach ($pathKeys as $pathKey) {
-			if (!isset($arrayPointer[$pathKey])) {
+			if (!is_array($arrayPointer) || !isset($arrayPointer[$pathKey])) {
 				return false;
 			}
 			$arrayPointer = &$arrayPointer[$pathKey];

--- a/tests/cases/core/EnvironmentTest.php
+++ b/tests/cases/core/EnvironmentTest.php
@@ -206,13 +206,15 @@ class EnvironmentTest extends \lithium\test\Unit {
 	public function testDotPath() {
 		$data = array(
 			'foo' => array('bar' => array('baz' => 123)),
-			'some' => array('path' => true)
+			'some' => array('path' => true),
+			'string' => 'lorem ipsum'
 		);
 		Environment::set('dotPathIndex', $data);
 
 		$this->assertEqual(123, Environment::get('dotPathIndex.foo.bar.baz'));
 		$this->assertEqual($data['foo'], Environment::get('dotPathIndex.foo'));
 		$this->assertTrue(Environment::get('dotPathIndex.some.path'));
+		$this->assertFalse(Environment::get('dotPathIndex.string.b'));
 	}
 
 	/**


### PR DESCRIPTION
For example:
$data = array(
    'string' => 'lorem ipsum'
);
Environment::set('dotPathIndex', $data);

Environment::get('dotPathIndex.string.b'); // Without this patch we will get fatal error
