### PR TITLE
WARNING BC Break : `data\source\Database::fields()` && `data\model\Query::fields()` refactoring

### DIFF
--- a/data/collection/RecordSet.php
+++ b/data/collection/RecordSet.php
@@ -124,7 +124,7 @@ class RecordSet extends \lithium\data\Collection {
 				$offset += $fieldCount;
 			}
 			$i++;
-		} while ($data = $this->_result->next());
+		} while ($main && $data = $this->_result->next());
 
 		$relMap = $this->_query->relationships();
 		return $this->_hydrateRecord($this->_dependencies, $primary, $record, 0, $i, '', $relMap, $conn);

--- a/tests/cases/data/model/QueryTest.php
+++ b/tests/cases/data/model/QueryTest.php
@@ -65,26 +65,27 @@ class QueryTest extends \lithium\test\Unit {
 	public function testFields() {
 		$query = new Query($this->_queryArr);
 
-		$expected = array('id','author_id','title');
+		$expected = array_fill_keys(array('id','author_id','title'), true);
 		$result = $query->fields();
 		$this->assertEqual($expected, $result);
 
 		$query->fields('content');
 
-		$expected = array('id','author_id','title','content');
+		$expected = array_fill_keys(array('id','author_id','title','content'), true);
 		$result = $query->fields();
 		$this->assertEqual($expected, $result);
 
 		$query->fields(array('updated','created'));
 
 		$expected = array('id','author_id','title','content','updated','created');
+		$expected = array_fill_keys($expected, true);
 		$result = $query->fields();
 		$this->assertEqual($expected, $result);
 
 		$query->fields(false);
 		$query->fields(array('id', 'title'));
 
-		$expected = array('id','title');
+		$expected = array_fill_keys(array('id','title'), true);
 		$result = $query->fields();
 		$this->assertEqual($expected, $result);
 	}
@@ -469,7 +470,7 @@ class QueryTest extends \lithium\test\Unit {
 		$result = $query->conditions($conditions)->fields($fields)->order($order);
 		$this->assertEqual($result, $query);
 		$this->assertEqual($conditions, $query->conditions());
-		$this->assertEqual($fields, $query->fields());
+		$this->assertEqual(array_fill_keys($fields, true), $query->fields());
 		$this->assertEqual($order, $query->order());
 	}
 

--- a/tests/cases/data/source/DatabaseTest.php
+++ b/tests/cases/data/source/DatabaseTest.php
@@ -215,7 +215,7 @@ class DatabaseTest extends \lithium\test\Unit {
 	public function testSchemaFromManualFieldList() {
 		$fields = array('id', 'name', 'created');
 		$result = $this->db->schema(new Query(compact('fields')));
-		$this->assertEqual(array($fields), $result);
+		$this->assertEqual(array('' => $fields), $result);
 	}
 
 	public function testSimpleQueryRender() {
@@ -833,14 +833,14 @@ class DatabaseTest extends \lithium\test\Unit {
 			'with' => array('MockDatabaseComment')
 		));
 
-		$fields = array('id', 'title');
+		$fields = array('id' => true, 'title' => true);
 		$result = $this->db->fields($fields, $query);
 		$expected = '{MockDatabasePost}.{id}, {MockDatabasePost}.{title}';
 		$this->assertEqual($expected,$result);
 
 		$fields = array(
-			'MockDatabasePost' => array('id', 'title', 'created'),
-			'MockDatabaseComment' => array('body')
+			'MockDatabasePost' => array('id' => true, 'title' => true, 'created' => true),
+			'MockDatabaseComment' => array('body' => true)
 		);
 		$result = $this->db->fields($fields, $query);
 		$expected = '{MockDatabasePost}.{id}, {MockDatabasePost}.{title},';
@@ -848,8 +848,8 @@ class DatabaseTest extends \lithium\test\Unit {
 		$this->assertEqual($expected,$result);
 
 		$fields = array(
-			'MockDatabasePost',
-			'MockDatabaseComment'
+			'MockDatabasePost' => true,
+			'MockDatabaseComment' => true
 		);
 		$result = $this->db->fields($fields, $query);
 		$expected = '{MockDatabasePost}.{id}, {MockDatabasePost}.{author_id},';
@@ -859,7 +859,10 @@ class DatabaseTest extends \lithium\test\Unit {
 		$expected .= ' {MockDatabaseComment}.{created}';
 		$this->assertEqual($expected, $result);
 
-		$fields = array('MockDatabasePost.id as idPost', 'MockDatabaseComment.id AS idComment');
+		$fields = array(
+			'MockDatabasePost' => array('id as idPost' => true),
+			'MockDatabaseComment' => array('id AS idComment' => true)
+		);
 		$result = $this->db->fields($fields, $query);
 		$expected = '{MockDatabasePost}.{id} as idPost, {MockDatabaseComment}.{id} as idComment';
 		$this->assertEqual($expected, $result);
@@ -867,13 +870,13 @@ class DatabaseTest extends \lithium\test\Unit {
 		$expected = array('' => array('idPost'), 'MockDatabaseComment' => array('idComment'));
 		$this->assertEqual($expected, $query->map());
 
-		$fields = array(array('count(MockDatabasePost.id)'));
-		$expected = 'count(MockDatabasePost.id), {MockDatabasePost}.{id}';
+		$fields = array('0' => array('count(MockDatabasePost.id)'));
+		$expected = 'count(MockDatabasePost.id)';
 		$result = $this->db->fields($fields, $query);
 		$this->assertEqual($expected, $result);
 
-		$fields = array((object) 'count(MockDatabasePost.id)');
-		$expected = 'count(MockDatabasePost.id), {MockDatabasePost}.{id}';
+		$fields = array('0' => array((object) 'count(MockDatabasePost.id)'));
+		$expected = 'count(MockDatabasePost.id)';
 		$result = $this->db->fields($fields, $query);
 		$this->assertEqual($expected, $result);
 	}


### PR DESCRIPTION
Currently fields are stored in a "raw way" in `data\model\Query` and `Source::fields()` is used for exporting  the fields to the desired format.

This low level field management by `data\model\Query` leads to a huge number of tests for correclty formating fields especially for `Databases` sources.

Moreover when you need to add fields to a query, this leads to a numbers of `in_array()` if you want to avoid adding them both.

This PR bring a "common logic" of fields management to `data\model\Query::fields()`.

The setter is still unchanged.
The getter will produce:

<pre lang="php">
array('id' => true, 'title' => true, 'body' => true, 'created' => true)
</pre>


instead of:

<pre lang="php">
array('id', 'title', 'body' , 'created' )
</pre>


It accepts one level of nesting using dot notation e.g.:

<pre lang="php">
array(
$query = new Query(array(
    'model' => 'lithium\tests\mocks\data\model\MockQueryPost',
    'type' => 'read',
    'with' => 'MockQueryComment'
));
$query->fields(array('MockQueryPost.id', 'title', 'MockQueryComment.comment'));
$result = $query->fields();
$expected = array(
    'id' => true,
    'title' => true,
    'MockQueryComment' => array(
        'comment' => true
    )
);
$this->assertEqual($expected, $result);
</pre>


Finally all non alphanumeric fields and object fields are stored as "special fields" in the '0' key e.g.:

<pre lang="php">
array(
$query = new Query(array(
    'model' => 'lithium\tests\mocks\data\model\MockQueryPost',
    'type' => 'read',
    'with' => 'MockQueryComment'
));
$query->fields(array('id', 'lower(MockQueryPost.id)', (object) 'count(*)'));
$result = $query->fields();
$expected = array(
    'id' => true,
    array(
        'lower(MockQueryPost.id)',
        (object) 'count(*)'
    )
);
$this->assertEqual($expected, $result);
</pre>
