### PR TITLE
Fix #577

### DIFF
--- a/data/Collection.php
+++ b/data/Collection.php
@@ -493,7 +493,7 @@ abstract class Collection extends \lithium\util\Collection {
 	 * @return array Returns the array value of the data in this `Collection`.
 	 */
 	public function data() {
-		return $this->to('array');
+		return $this->to('array', array('indexed' => null));
 	}
 
 	/**
@@ -529,7 +529,8 @@ abstract class Collection extends \lithium\util\Collection {
 
 		$this->offsetGet(null);
 
-		if (!$options['indexed']) {
+		$index = $options['indexed'] || ($options['indexed'] === null && $this->_parent === null);
+		if (!$index) {
 			$data = array_values($this->_data);
 		} else {
 			$data = $options['internal'] ? $this->_data : $this;

--- a/data/DocumentSchema.php
+++ b/data/DocumentSchema.php
@@ -67,7 +67,12 @@ class DocumentSchema extends \lithium\data\Schema {
 		}
 
 		if ($options['wrap']) {
-			$config = array('data' => $val, 'model' => $options['model'], 'schema' => $this);
+			$config = array(
+				'data' => $val,
+				'parent' => $object,
+				'model' => $options['model'],
+				'schema' => $this
+			);
 			$config += compact('pathKey') + array_diff_key($options, $defaults);
 			$val = $this->_instance($class, $config);
 		} elseif ($class == 'set') {

--- a/tests/cases/data/source/mongo_db/ExporterTest.php
+++ b/tests/cases/data/source/mongo_db/ExporterTest.php
@@ -625,6 +625,67 @@ class ExporterTest extends \lithium\test\Unit {
 			$this->assertTrue($result['update']['list'][$i] instanceof MongoId);
 		}
 	}
+
+	public function testToData() {
+		$data = array(
+			array(
+			'_id' => '4c8f86167675abfabd970300',
+			'accounts' => array(array(
+				'_id' => "4fb6e2dd3e91581fe6e75736",
+				'name' => 'Foo1'
+			),array(
+				'_id' => "4fb6e2df3e91581fe6e75737",
+				'name' => 'Bar1'
+			))),
+			array(
+			'_id' => '4c8f86167675abfabd970301',
+			'accounts' => array(array(
+				'_id' => "4fb6e2dd3e91581fe6e75738",
+				'name' => 'Foo2'
+			),array(
+				'_id' => "4fb6e2df3e91581fe6e75739",
+				'name' => 'Bar2'
+			)))
+		);
+
+		$model = $this->_model;
+		$handlers = $this->_handlers;
+		$options = compact('model', 'handlers');
+		$schema = new Schema(array('fields' => $this->_schema));
+		$set = $schema->cast(null, null, $data, $options);
+
+		$result = $set->data();
+		$accounts = $result['4c8f86167675abfabd970300']['accounts'];
+		$this->assertEqual('Foo1', $accounts[0]['name']);
+		$this->assertEqual('Bar1', $accounts[1]['name']);
+		$accounts = $result['4c8f86167675abfabd970301']['accounts'];
+		$this->assertEqual('Foo2', $accounts[0]['name']);
+		$this->assertEqual('Bar2', $accounts[1]['name']);
+
+		$result = $set->to('array', array('indexed' => false));
+		$accounts = $result[0]['accounts'];
+		$this->assertEqual('Foo1', $accounts[0]['name']);
+		$this->assertEqual('Bar1', $accounts[1]['name']);
+		$accounts = $result[1]['accounts'];
+		$this->assertEqual('Foo2', $accounts[0]['name']);
+		$this->assertEqual('Bar2', $accounts[1]['name']);
+
+		$result = $set->to('array', array('indexed' => true));
+		$accounts = $result['4c8f86167675abfabd970300']['accounts'];
+		$this->assertEqual('Foo1', $accounts['4fb6e2dd3e91581fe6e75736']['name']);
+		$this->assertEqual('Bar1', $accounts['4fb6e2df3e91581fe6e75737']['name']);
+		$accounts = $result['4c8f86167675abfabd970301']['accounts'];
+		$this->assertEqual('Foo2', $accounts['4fb6e2dd3e91581fe6e75738']['name']);
+		$this->assertEqual('Bar2', $accounts['4fb6e2df3e91581fe6e75739']['name']);
+
+		$result = $set->to('array');
+		$accounts = $result['4c8f86167675abfabd970300']['accounts'];
+		$this->assertEqual('Foo1', $accounts['4fb6e2dd3e91581fe6e75736']['name']);
+		$this->assertEqual('Bar1', $accounts['4fb6e2df3e91581fe6e75737']['name']);
+		$accounts = $result['4c8f86167675abfabd970301']['accounts'];
+		$this->assertEqual('Foo2', $accounts['4fb6e2dd3e91581fe6e75738']['name']);
+		$this->assertEqual('Bar2', $accounts['4fb6e2df3e91581fe6e75739']['name']);
+	}
 }
 
 ?>


### PR DESCRIPTION
To avoid indexation to be saved in the database, `DocumentSet` will no more be indexed if its parent is not `null`on a `::data()` call.

For a full indexation use :

<pre lang="php">
$elem->to('array');
</pre>


For no indexation at all :

<pre lang="php">
$elem->to('array', array('indexed' => false);
</pre>
