### PR TITLE
`data\source\Database::fields()` && `data\model\Query::fields()` refactoring

### DIFF
--- a/data/collection/RecordSet.php
+++ b/data/collection/RecordSet.php
@@ -124,7 +124,7 @@ class RecordSet extends \lithium\data\Collection {
 				$offset += $fieldCount;
 			}
 			$i++;
-		} while ($data = $this->_result->next());
+		} while ($main && $data = $this->_result->next());
 
 		$relMap = $this->_query->relationships();
 		return $this->_hydrateRecord($this->_dependencies, $primary, $record, 0, $i, '', $relMap, $conn);
@@ -152,15 +152,12 @@ class RecordSet extends \lithium\data\Collection {
 				$relName = $name ? $name . '.' . $relation : $relation;
 				$field = $relMap[$relName]['fieldName'];
 				$relModel = $relMap[$relName]['model'];
-				$relPk = $relModel::key();
-				$index = is_array($relPk) ? false: true;
 
 				if ($relMap[$relName]['type'] === 'hasMany') {
-					$main = null;
+					$rel = array();
+					$main = $relModel::key($record[$min][$relName]);
 					$i = $min;
 					$j = $i + 1;
-					$main = $relModel::key($record[$i][$relName]);
-					$rel = array();
 					while ($j < $max) {
 						$keys = $relModel::key($record[$j][$relName]);
 						if ($main != $keys) {
@@ -180,7 +177,7 @@ class RecordSet extends \lithium\data\Collection {
 				}
 			}
 		}
-		return $conn->item($primary, $record[$min][$name], $options);
+		return $conn->item($primary, isset($record[$min][$name]) ? $record[$min][$name] : array(), $options);
 	}
 
 	protected function _columnMap() {

--- a/tests/cases/data/ModelTest.php
+++ b/tests/cases/data/ModelTest.php
@@ -741,7 +741,7 @@ class ModelTest extends \lithium\test\Unit {
 		$this->assertEqual(array('published' => false), $query->conditions());
 
 		$keys = array_keys(array_filter($query->export(MockPost::$connection)));
-		$this->assertEqual(array('type', 'name', 'conditions', 'model', 'source', 'alias'), $keys);
+		$this->assertEqual(array('type', 'conditions', 'model', 'source', 'alias'), $keys);
 	}
 
 	public function testFindFirst() {

--- a/tests/mocks/data/model/MockGallery.php
+++ b/tests/mocks/data/model/MockGallery.php
@@ -25,6 +25,11 @@ class MockGallery extends \lithium\tests\mocks\data\MockBase {
 		'source' => 'mock_gallery',
 		'connection' => false
 	);
+
+	protected $_schema = array(
+		'id' => array('type' => 'integer'),
+		'title' => array('type' => 'name')
+	);
 }
 
 ?>

--- a/tests/mocks/data/model/MockImage.php
+++ b/tests/mocks/data/model/MockImage.php
@@ -26,6 +26,13 @@ class MockImage extends \lithium\tests\mocks\data\MockBase {
 		'source' => 'mock_image',
 		'connection' => false
 	);
+
+	protected $_schema = array(
+		'id' => array('type' => 'integer'),
+		'title' => array('type' => 'string'),
+		'image' => array('type' => 'string'),
+		'gallery_id' => array('type' => 'integer')
+	);
 }
 
 ?>

--- a/tests/mocks/data/model/MockImageTag.php
+++ b/tests/mocks/data/model/MockImageTag.php
@@ -22,6 +22,12 @@ class MockImageTag extends \lithium\tests\mocks\data\MockBase {
 		'source' => 'mock_image_tag',
 		'connection' => false
 	);
+
+	protected $_schema = array(
+		'id' => array('type' => 'integer'),
+		'image_id' => array('type' => 'integer'),
+		'tag_id' => array('type' => 'integer')
+	);
 }
 
 ?>

--- a/tests/mocks/data/model/MockTag.php
+++ b/tests/mocks/data/model/MockTag.php
@@ -22,6 +22,11 @@ class MockTag extends \lithium\tests\mocks\data\MockBase {
 		'source' => 'mock_tag',
 		'connection' => false
 	);
+
+	protected $_schema = array(
+		'id' => array('type' => 'integer'),
+		'name' => array('type' => 'string')
+	);
 }
 
 ?>


### PR DESCRIPTION
- Additionnal tests for `data\model\Query::fields()`
- Some cleanup & more tests for #705
- `data\source\Query::fields()` return flat fields array.

Note 1:

<pre lang="php">
$query->fields('id');
$query->fields('id');
$query->fields('id');
...
</pre>


will no no more add 'id' several times.

Note 2:

<pre lang="php">
Model::find('all'); // produce a 'SELECT * ...'
Model::find('all', array('fields' => '*'); // WARNING : doesn't mean 'SELECT * ...' but 'SELECT Model.* ...'
Model::find('all', array('fields' => 'Model.*'); // same as previous, produce a 'SELECT Model.* ...'
Model::find('all', array('fields' => 'Model'); // same as previous, produce a 'SELECT Model.* ...'
Model::find('all', array('fields' => 'title'); // produce a 'SELECT Model.title ...'
</pre>
