### PR TITLE
Fix #427

### DIFF
--- a/tests/cases/util/ValidatorTest.php
+++ b/tests/cases/util/ValidatorTest.php
@@ -414,6 +414,28 @@ class ValidatorTest extends \lithium\test\Unit {
 		$this->assertTrue(Validator::isInList('one', null, array('list' => array('one', 'two'))));
 		$this->assertTrue(Validator::isInList('two', null, array('list' => array('one', 'two'))));
 		$this->assertFalse(Validator::isInList('3', null, array('list' => array('one', 'two'))));
+
+		$this->assertFalse(Validator::isInList('', null, array('list' => array('0', '1'))));
+		$this->assertFalse(Validator::isInList(null, null, array('list' => array('0', '1'))));
+		$this->assertFalse(Validator::isInList(false, null, array('list' => array('0', '1'))));
+		$this->assertFalse(Validator::isInList(true, null, array('list' => array('0', '1'))));
+
+		$this->assertFalse(Validator::isInList('', null, array('list' => array(0, 1))));
+		$this->assertFalse(Validator::isInList(null, null, array('list' => array(0, 1))));
+		$this->assertFalse(Validator::isInList(false, null, array('list' => array(0, 1))));
+		$this->assertFalse(Validator::isInList(true, null, array('list' => array(0, 1))));
+		$this->assertTrue(Validator::isInList(0, null, array('list' => array(0, 1))));
+		$this->assertTrue(Validator::isInList(1, null, array('list' => array(0, 1))));
+		$this->assertFalse(Validator::isInList(2, null, array('list' => array(0, 1))));
+
+		$this->assertTrue(Validator::isInList(0, null, array('list' => array('0', '1'))));
+		$this->assertTrue(Validator::isInList('1', null, array('list' => array('0', '1'))));
+
+		$this->assertTrue(Validator::isInList(1, null, array('list' => array('0', '1'))));
+		$this->assertTrue(Validator::isInList('1', null, array('list' => array('0', '1'))));
+
+		$this->assertFalse(Validator::isInList(2, null, array('list' => array('0', '1'))));
+		$this->assertFalse(Validator::isInList('2', null, array('list' => array('0', '1'))));
 	}
 
 

--- a/util/Validator.php
+++ b/util/Validator.php
@@ -273,7 +273,8 @@ class Validator extends \lithium\core\StaticObject {
 			},
 			'inList' => function($value, $format, $options) {
 				$options += array('list' => array());
-				return in_array($value, $options['list']);
+				$strict = is_bool($value) || $value === '';
+				return in_array($value, $options['list'], $strict);
 			},
 			'lengthBetween' => function($value, $format, $options) {
 				$length = strlen($value);


### PR DESCRIPTION
The main problem here concern the empty string `''` which match indifferently `0` or `'0'` due to PHP's casting.
This PR take this specific case into account to avoid matching issue with this specific value.

However other casting issues are left to the user e.g.:

<pre lang="php">
$this->assertTrue(Validator::isInList('0', null, array('list' => array(true, false)))); //Pass
$this->assertTrue(Validator::isInList('1', null, array('list' => array(true, false)))); //Pass
$this->assertTrue(Validator::isInList('Gwoo lent his boat in exchange of beer', null, array('list' => array(true, false)))); //Pass
</pre>
