### PR TITLE
Warning BC break: Fix typo, change `data\Model::_init()` to `data\Model::_initialize()` to avoid confusion.

### DIFF
--- a/data/Model.php
+++ b/data/Model.php
@@ -134,7 +134,7 @@ class Model extends \lithium\core\StaticObject {
 	/**
 	 * List of initialized instances.
 	 *
-	 * @see lithium\data\Model::_init();
+	 * @see lithium\data\Model::_initialize();
 	 * @var array
 	 */
 	protected static $_initialized = array();
@@ -375,7 +375,7 @@ class Model extends \lithium\core\StaticObject {
 	 * @param string $class The fully-namespaced class name to initialize.
 	 * @return object Returns the initialized model instance.
 	 */
-	protected static function _init($class) {
+	protected static function _initialize($class) {
 		$self = static::$_instances[$class];
 
 		if (isset(static::$_initialized[$class]) && static::$_initialized[$class]) {
@@ -1233,7 +1233,7 @@ class Model extends \lithium\core\StaticObject {
 			static::$_instances[$class] = new $class();
 			static::config();
 		}
-		$object = static::_init($class);
+		$object = static::_initialize($class);
 		return $object;
 	}
 

--- a/tests/cases/data/ModelTest.php
+++ b/tests/cases/data/ModelTest.php
@@ -808,7 +808,7 @@ class ModelTest extends \lithium\test\Unit {
 		$object = MockPost::invokeMethod('_object');
 		$object->belongsTo = array('Unexisting');
 		MockPost::config();
-		MockPost::invokeMethod('_init', array('lithium\tests\mocks\data\MockPost'));
+		MockPost::invokeMethod('_initialize', array('lithium\tests\mocks\data\MockPost'));
 		$exception = 'Related model class \'lithium\tests\mocks\data\Unexisting\' not found.';
 		$this->expectException($exception);
 		MockPost::relations('Unexisting');


### PR DESCRIPTION
Since `data\Model::_init()` is not a `::_init()` method, It would be better to rename it to avoid confusion.
