### PR TITLE
Allow `data\source\Database` to support a generic syntax for creating records.

### DIFF
--- a/data/source/Database.php
+++ b/data/source/Database.php
@@ -972,6 +972,9 @@ abstract class Database extends \lithium\data\Source {
 	protected function _fieldsReturn($type, $context, $fields, $schema) {
 		if ($type == 'create' || $type == 'update') {
 			$data = $context->data();
+			if (isset($data['data']) && is_array($data['data']) && count($data) == 1){
+				$data = $data['data'];
+			}
 
 			if ($fields && is_array($fields) && is_int(key($fields))) {
 				$data = array_intersect_key($data, array_combine($fields, $fields));

--- a/tests/cases/data/source/DatabaseTest.php
+++ b/tests/cases/data/source/DatabaseTest.php
@@ -374,6 +374,30 @@ class DatabaseTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 	}
 
+	public function testCreateGenericSyntax() {
+		$entity = new Record(array(
+			'model' => $this->_model,
+			'data' => array('data' => array('title' => 'new post', 'body' => 'the body'))
+		));
+		$query = new Query(compact('entity') + array(
+			'type' => 'create',
+			'model' => $this->_model
+		));
+		$hash = $query->export($this->db);
+		ksort($hash);
+		$expected = sha1(serialize($hash));
+
+		$result = $this->db->create($query);
+		$this->assertTrue($result);
+		$result = $query->entity()->id;
+		$this->assertEqual($expected, $result);
+
+		$expected = "INSERT INTO {mock_database_posts} ({title}, {body})";
+		$expected .= " VALUES ('new post', 'the body');";
+		$result = $this->db->sql;
+		$this->assertEqual($expected, $result);
+	}
+
 	public function testCreateWithValueBySchema() {
 		$entity = new Record(array(
 			'model' => $this->_model,


### PR DESCRIPTION
Using `data\source\MongoDb`, the correct syntax to insert a element is:

<pre lang="php">
$db = Connections::get('mongo');
$options = array(
    'type' => 'create',
    'source' => 'source',
    'data' => array(
        'data' => array(/* the datas */)
    )
);
$db->create($query);
</pre>


Using `data\source\Database`, the correct syntax to insert a element is:

<pre lang="php">
$db = Connections::get('mongo');
$options = array(
    'type' => 'create',
    'source' => 'source',
    'data' => array(/* the datas */)
);
$db->create($query);
</pre>


This pull request allow the `'data' => array('data' => array(/* the datas */))` syntax for `data\source\Database` to allow a generic way to write queries and make `data\model\Query` non dependant of the datasource.
