### PR TITLE
Create the correct file structure in the systems tmp directory

### DIFF
--- a/console/lithium.php
+++ b/console/lithium.php
@@ -34,11 +34,17 @@ $bootstrap = function() use ($working) {
 		throw new ErrorException($message);
 	}
 
+	$resources = sys_get_temp_dir();
+	$templates = $resources . '/tmp/cache/templates/';
+	if (!is_dir($templates)) {
+		mkdir($resources . '/tmp/cache/templates/', 0777, true);
+	}
+
 	lithium\core\Libraries::add('lithium');
 	lithium\core\Libraries::add(basename($working), array(
 		'default' => true,
 		'path' => $working,
-		'resources' => sys_get_temp_dir()
+		'resources' => $resources
 	));
 };
 

--- a/tests/cases/console/RequestTest.php
+++ b/tests/cases/console/RequestTest.php
@@ -175,6 +175,12 @@ class RequestTest extends \lithium\test\Unit {
 		$result = $request->params;
 		$this->assertEqual($expected, $result);
 	}
+
+	public function testTemporaryFileStructureExists() {
+		$resources = Libraries::get(true, 'resources');
+		$template = $resources . '/tmp/cache/templates/';
+		$this->assert(is_dir($template));
+	}
 }
 
 ?>


### PR DESCRIPTION
To reproduce the error:
- Pull a fresh install of the framework
- Upgrade lithium
- Install a library
- Run the library tests through the command line

You can see the exact steps on this [traivs build](https://travis-ci.org/BlaineSch/li3_analytics/jobs/3670137).
