### PR TITLE
Fix `data\source\Database::read()` hack

### DIFF
--- a/tests/mocks/data/model/MockDatabase.php
+++ b/tests/mocks/data/model/MockDatabase.php
@@ -41,6 +41,8 @@ class MockDatabase extends \lithium\data\source\Database {
 
 	public $log = false;
 
+	public $return = array();
+
 	protected $_quotes = array('{', '}');
 
 	public function __construct(array $config = array()) {
@@ -94,7 +96,17 @@ class MockDatabase extends \lithium\data\source\Database {
 		if ($this->log) {
 			$this->logs[] = $sql;
 		}
+		if (isset($this->return['_execute'])) {
+			return $this->return['_execute'];
+		}
 		return new MockResult();
+	}
+
+	public function schema($query, $resource = null, $context = null) {
+		if (isset($this->return['schema'])) {
+			return $this->return['schema'];
+		}
+		return parent::schema($query, $resource = null, $context = null);
 	}
 
 	protected function _insertId($query) {


### PR DESCRIPTION
With this PR `array('return' => 'array')` option on queries with relations will return something like the following:

``` php
array(
    'field1' => 'value1',
    'field2' => 'value2',
    'field3' => 'value3',
    /* ... other fields ... */
    'Dotted.Relation.Path' => array(
             'field1' => 'value1',
             'field2' => 'value2',
             'field3' => 'value3',
             /* ... other fields ... */
 );
```

When the `'joined'` strategy is used, all primary keys of relations are automagically added to the query to allow a correct hydratation of nested entities. However with the  `array('return' => 'array')` you will get the following:

``` php
array(
    'field1' => 'value1',
    'field2' => 'value2',
    'field3' => 'value3',
    /* ... other fields ... */
    'Relation' => array( 'id' => #),
    'Relation.Sub' => array( 'id' => #),
    'Relation.Sub.Sub'  => array( 'id' => #),
    'Relation.Sub.Sub.Sub' => array( 'id' => #)
 );
```

If you are only interested by the root level fields, you will need something like the following for removing the "pollution":

``` php
    $result = $db->query(/*the query*/, array('return' => 'array'));
    $filtered = array_filter($result, function($v) {return !is_array($v);})
```

To avoid this 'tricky step", you can get only the first level using the `array('return' => 'root')` option.

``` php
    $result = $db->query(/*the query*/, array('return' => 'root'));
```
