### PR TITLE
Warning BC Break: `data\Model::_classes` and `data\Model_autoConfig` are no more static

### DIFF
--- a/tests/mocks/data/MockPost.php
+++ b/tests/mocks/data/MockPost.php
@@ -8,8 +8,6 @@
 
 namespace lithium\tests\mocks\data;
 
-use lithium\data\Schema;
-
 class MockPost extends \lithium\tests\mocks\data\MockBase {
 
 	public $hasMany = array('MockComment');


### PR DESCRIPTION
Unlike all other variables in `data\Model_autoConfig`, `data\Model::_classes` is the only static one. I don't really understand this inconsistency.
Moreover this specificity forces us to redefine all entries in `_classes` when some custom dependencies is needed.

With with PR you can write: 

``` php
class MyModel extends \lithium\data\Model {
    protected $_classes = array(
        'custom' => 'my\custom\Dependency'
    );
}
```

Instead of:

``` php
class MyModel extends \lithium\data\Model {
    protected static $_classes = array(
        'connections' => 'lithium\data\Connections',
        'query'       => 'lithium\data\model\Query',
        'validator'   => 'lithium\util\Validator',
        'entity'      => 'lithium\data\Entity'
        'custom' => 'my/custom/Dependency'
    );
}
```

when you need a custom dependency. 
