### PR TITLE
The `'joined'` strategy now lazy load primary keys when needed.

### DIFF
--- a/tests/cases/data/source/DatabaseTest.php
+++ b/tests/cases/data/source/DatabaseTest.php
@@ -181,7 +181,7 @@ class DatabaseTest extends \lithium\test\Unit {
 		$options['fields'] = array('id', 'title');
 		$result = $this->db->schema(new Query($options));
 
-		$expected = array($modelName => $options['fields'], 'MockDatabaseComment' => array('id'));
+		$expected = array($modelName => $options['fields']);
 		$this->assertEqual($expected, $result);
 
 		$options['fields'] = array(
@@ -192,7 +192,7 @@ class DatabaseTest extends \lithium\test\Unit {
 		$result = $this->db->schema(new Query($options));
 		$expected = array(
 			$modelName => array('id', 'title'),
-			'MockDatabaseComment' => array('body', 'id')
+			'MockDatabaseComment' => array('body')
 		);
 		$this->assertEqual($expected, $result);
 
@@ -203,7 +203,7 @@ class DatabaseTest extends \lithium\test\Unit {
 		$result = $this->db->schema(new Query($options));
 		$expected = array(
 			$modelName => array('id', 'title'),
-			'MockDatabaseComment' => array('body', 'created', 'id')
+			'MockDatabaseComment' => array('body', 'created')
 		);
 		$this->assertEqual($expected, $result);
 
@@ -1154,6 +1154,9 @@ class DatabaseTest extends \lithium\test\Unit {
 
 		$result = $this->db->invokeMethod('_splitFieldname', array('lower(Alias.fieldname)'));
 		$this->assertEqual(array(null, 'lower(Alias.fieldname)'), $result);
+
+		$result = $this->db->invokeMethod('_splitFieldname', array('Alias.*'));
+		$this->assertEqual(array('Alias', '*'), $result);
 	}
 
 	public function testOn() {
@@ -1407,7 +1410,7 @@ class DatabaseTest extends \lithium\test\Unit {
 			'with' => array('Image.ImageTag.Tag')
 		));
 		$result = $query->export($this->db);
-		$expected = '{Gallery}.{id}, {Image}.{id}, {ImageTag}.{id}, {Tag}.{id}';
+		$expected = '{Gallery}.{id}';
 		$this->assertEqual($expected, $result['fields']);
 
 		$query = new Query(array(
@@ -1453,7 +1456,7 @@ class DatabaseTest extends \lithium\test\Unit {
 			'with' => array('Parent.Parent')
 		));
 		$result = $query->export($this->db);
-		$expected = '{Parent}.{name}, {Parent}.{id}, {Gallery}.{id}, {Parent__2}.{id}';
+		$expected = '{Parent}.{name}, {Gallery}.{id}';
 		$this->assertEqual($expected, $result['fields']);
 
 		$query = new Query(array(
@@ -1462,7 +1465,7 @@ class DatabaseTest extends \lithium\test\Unit {
 			'with' => array('Parent.Parent' => array('alias' => 'ParentOfParent'))
 		));
 		$result = $query->export($this->db);
-		$expected = '{ParentOfParent}.{name}, {ParentOfParent}.{id}, {Gallery}.{id}, {Parent}.{id}';
+		$expected = '{ParentOfParent}.{name}, {Gallery}.{id}, {Parent}.{id}';
 		$this->assertEqual($expected, $result['fields']);
 	}
 


### PR DESCRIPTION
When the `'joined'` strategy is used, all primary keys of relations are automagically added to the query to allow a correct hydratation of nested entities. However this strategy pollute the result with extra datas.

previously:

``` php
Images::find('all',
    'fields' => array('Image'),
    'with' => array('ImagesTags.Tags'),
    'conditions' => array('Tags.name' => 'flower')
);
```

produce:

``` php
array(
    0 => array(
        'id' => 5,
        'name' => 'Tulip',
        'images_tags' => array(
            0=> array(
                'id' => 1
                'tags' => array(
                    'id' => 2
                )
            )
            /*...and so on....*/
        )
    )
    /*...and so on....*/
```

Since `'fields' => array('Image')` is defined, the hydratation up to `Tags` is not necessary.

This PR allow to produce results with less "polluting datas".
