### PR TITLE
Some refactoring of `data\model\Query::alias()`.

### DIFF
--- a/data/source/Database.php
+++ b/data/source/Database.php
@@ -213,8 +213,7 @@ abstract class Database extends \lithium\data\Source {
 								'type' => $rel->type(),
 								'model' => $rel->to(),
 								'fieldName' => $rel->fieldName(),
-								'fromAlias' => $from,
-								'toAlias' => $to
+								'alias' => $to
 							));
 							$self->join($context, $rel, $from, $to, $constraints);
 						}
@@ -473,11 +472,10 @@ abstract class Database extends \lithium\data\Source {
 				case 'array':
 					$columns = $args['schema'] ?: $self->schema($query, $result);
 
-					if (!isset($columns['']) || !is_array($columns[''])) {
+					if (!is_array(reset($columns))) {
 						$columns = array('' => $columns);
 					}
 
-					$relationNames = is_object($query) ? $query->relationNames($self) : array();
 					$i = 0;
 					$records = array();
 					foreach ($result as $data) {
@@ -487,7 +485,7 @@ abstract class Database extends \lithium\data\Source {
 							$len = count($cols);
 							$values = array_combine($cols, array_slice($data, $offset, $len));
 							if ($path) {
-								$records[$i][$relationNames[$path]] = $values;
+								$records[$i][$path] = $values;
 							} else {
 								$records[$i] += $values;
 							}

--- a/tests/cases/data/source/DatabaseTest.php
+++ b/tests/cases/data/source/DatabaseTest.php
@@ -1584,13 +1584,13 @@ class DatabaseTest extends \lithium\test\Unit {
 			'author_id' => '2',
 			'title' => 'Post title',
 			'created' => '2012-12-17 17:04:00',
-			'mock_database_comments' => array(
+			'MockDatabaseComment' => array(
 				'id' => '3',
 				'post_id' => '1',
 				'author_id' => '2',
 				'body' => 'Very good post',
 				'created' => '2012-12-17 17:05:00',
-				'mock_database_post' => array(
+				'MockDatabasePost' => array(
 					'id' => '1',
 					'author_id' => '2',
 					'title' => 'Post title',


### PR DESCRIPTION
- Some refactoring
- Reverting #752. Looks like I did it wrong on this one. Imo the `array('return' => 'array')` option should provide a consistent format for "High level" queries (i.e with model defined) as well as raw SQL's ones.
