### PR TITLE
Alternative GridFS collection names issue fix.[dev]

### DIFF
--- a/data/source/MongoDb.php
+++ b/data/source/MongoDb.php
@@ -396,7 +396,7 @@ class MongoDb extends \lithium\data\Source {
 
 	protected function _saveFile($data) {
 		$uploadKeys = array('name', 'type', 'tmp_name', 'error', 'size');
-		$grid = $this->connection->getGridFS();
+		$grid = $this->connection->getGridFS($this->_config['gridPrefix']);
 		$file = null;
 		$method = null;
 
@@ -456,7 +456,7 @@ class MongoDb extends \lithium\data\Source {
 			$collection = $self->connection->{$source};
 
 			if ($source == "{$_config['gridPrefix']}.files") {
-				$collection = $self->connection->getGridFS();
+				$collection = $self->connection->getGridFS($_config['gridPrefix']);
 			}
 			$result = $collection->find($args['conditions'], $args['fields']);
 
@@ -563,7 +563,7 @@ class MongoDb extends \lithium\data\Source {
 	protected function _deleteFile($conditions, $options = array()) {
 		$defaults = array('safe' => true);
 		$options += $defaults;
-		return $this->connection->getGridFS()->remove($conditions, $options);
+		return $this->connection->getGridFS($this->_config['gridPrefix'])->remove($conditions, $options);
 	}
 
 	/**


### PR DESCRIPTION
There is a problem in source/MongoDb.php, it doesn't work with GridFS collections which is named different to defaults.

This call doesn't pass prefix to the getGridFS and defaults "fs.files" will be used, here it is:

``` php
$collection = $self->connection->getGridFS();
```

This PR has a fix for this issue.

But there is one more problem — unable to use different sources for gridfs collection, because of this:

``` php
if ($source == "{$_config['gridPrefix']}.files")
```

I'm afraid It's a wrong way to determine the type of collection  — is it gridfs or not.

I'm working now on the solution.
