### PR TITLE
Doing a recursive unset of _id fields in the DB exporter, as MongoDB

### DIFF
--- a/data/source/mongo_db/Exporter.php
+++ b/data/source/mongo_db/Exporter.php
@@ -46,7 +46,20 @@ class Exporter extends \lithium\core\StaticObject {
 			}
 			$result[$to] = $changes[$from];
 		}
-		unset($result['$set']['_id']);
+		
+		$unsetKeyRecursive = function(&$array, $key = "_id") use (&$unsetKeyRecursive)
+		{
+			unset($array[$key]);
+			
+			foreach($array as &$value) {
+				if(is_array($value)) {
+					$unsetKeyRecursive($value, $key);
+				}
+			}
+		};
+		
+		$unsetKeyRecursive($result['$set']);
+		
 		return $result;
 	}
 


### PR DESCRIPTION
doesn't let you use $set and modify _id. So if you have a document that has a sub-object and that object also has a _id field, the existing implementation breaks because it only considers the top-level _id key. This patch recursively traverses the data and removes all _id key references during an update.
