### PR TITLE
Fix bad radio and checkboxes values binding in case of booleans

### DIFF
--- a/template/helper/Form.php
+++ b/template/helper/Form.php
@@ -645,8 +645,8 @@ class Form extends \lithium\template\Helper {
 		list($name, $options, $template) = $this->_defaults(__FUNCTION__, $name, $options);
 		list($scope, $options) = $this->_options($defaults, $options);
 
-		if (!isset($options['checked']) && ($bound = $this->binding($key)->data)) {
-			$options['checked'] = ($bound == $default);
+		if (!isset($options['checked'])) {
+			$options['checked'] = ($this->binding($key)->data == $default);
 		}
 		if ($scope['hidden']) {
 			$out = $this->hidden($name, array('value' => '', 'id' => false));
@@ -674,8 +674,8 @@ class Form extends \lithium\template\Helper {
 		list($name, $options, $template) = $this->_defaults(__FUNCTION__, $name, $options);
 		list($scope, $options) = $this->_options($defaults, $options);
 
-		if (!isset($options['checked']) && ($bound = $this->binding($name)->data)) {
-			$options['checked'] = ($bound == $default);
+		if (!isset($options['checked'])) {
+			$options['checked'] = ($this->binding($name)->data == $default);
 		}
 
 		$options['value'] = $scope['value'];

--- a/tests/cases/template/helper/FormTest.php
+++ b/tests/cases/template/helper/FormTest.php
@@ -396,8 +396,19 @@ class FormTest extends \lithium\test\Unit {
 		$this->assertTags($result, array(
 			array('input' => array('type' => 'hidden', 'value' => '', 'name' => 'foo')),
 			array('input' => array(
-				'type' => 'checkbox', 'value' => '1', 'name' => 'foo',
-				'checked' => 'checked', 'id' => 'MockFormPostFoo'
+				'type' => 'checkbox', 'value' => '1', 'name' => 'foo', 'id' => 'MockFormPostFoo',
+				'checked' => 'checked'
+			))
+		));
+
+		$record = new Record(array('model' => $this->_model, 'data' => array('foo' => false)));
+		$this->form->create($record);
+
+		$result = $this->form->checkbox('foo');
+		$this->assertTags($result, array(
+			array('input' => array('type' => 'hidden', 'value' => '', 'name' => 'foo')),
+			array('input' => array(
+				'type' => 'checkbox', 'value' => '1', 'name' => 'foo', 'id' => 'MockFormPostFoo'
 			))
 		));
 
@@ -497,6 +508,17 @@ class FormTest extends \lithium\test\Unit {
 				'type' => 'checkbox', 'value' => 'nose', 'name' => 'foo', 'id' => 'MockFormPostFoo'
 			))
 		));
+
+		$record = new Record(array('model' => $this->_model, 'data' => array('foo' => false)));
+		$this->form->create($record);
+		$result = $this->form->checkbox('foo', array('value' => '0'));
+		$this->assertTags($result, array(
+			array('input' => array('type' => 'hidden', 'value' => '', 'name' => 'foo')),
+			array('input' => array(
+				'type' => 'checkbox', 'value' => '0', 'name' => 'foo', 'id' => 'MockFormPostFoo',
+				'checked' => 'checked'
+			))
+		));
 	}
 
 	public function testRadioGeneration() {
@@ -527,8 +549,18 @@ class FormTest extends \lithium\test\Unit {
 		$result = $this->form->radio('foo');
 		$this->assertTags($result, array(
 			array('input' => array(
-				'type' => 'radio', 'value' => '1', 'name' => 'foo',
-				'checked' => 'checked', 'id' => 'MockFormPostFoo'
+				'type' => 'radio', 'value' => '1', 'name' => 'foo', 'id' => 'MockFormPostFoo',
+				'checked' => 'checked'
+			))
+		));
+
+		$record = new Record(array('model' => $this->_model, 'data' => array('foo' => false)));
+		$this->form->create($record);
+
+		$result = $this->form->radio('foo');
+		$this->assertTags($result, array(
+			array('input' => array(
+				'type' => 'radio', 'value' => '1', 'name' => 'foo', 'id' => 'MockFormPostFoo'
 			))
 		));
 	}
@@ -603,6 +635,16 @@ class FormTest extends \lithium\test\Unit {
 			array('input' => array('type' => 'hidden', 'value' => '', 'name' => 'foo')),
 			array('input' => array(
 				'type' => 'checkbox', 'value' => 'nose', 'name' => 'foo', 'id' => 'MockFormPostFoo'
+			))
+		));
+
+		$record = new Record(array('model' => $this->_model, 'data' => array('foo' => false)));
+		$this->form->create($record);
+		$result = $this->form->radio('foo', array('value' => '0'));
+		$this->assertTags($result, array(
+			array('input' => array(
+				'type' => 'radio', 'value' => '0',  'name' => 'foo',
+				'id' => 'MockFormPostFoo', 'checked' => 'checked'
 			))
 		));
 	}


### PR DESCRIPTION
In case of a `false` field value, the bindings for radio and checkboxes breaks, because of the second part of this condition, which is evaluated to `false`.

``` php
if (!isset($options['checked']) && ($bound = $this->binding($name)->data)) {
    $options['checked'] = ($bound == $default);
}
```

This PR adds a couple of test cases to show that, and fix the condition for both `radio()` and `checkbox()` Form helper methods
