### PR TITLE
Update bleeding line number to be less specific.

### DIFF
--- a/analysis/Parser.php
+++ b/analysis/Parser.php
@@ -75,9 +75,7 @@ class Parser extends \lithium\core\StaticObject {
 			}
 			$tokens[] = array('id' => $id, 'name' => $name, 'content' => $content, 'line' => $line);
 
-			if ($id === T_WHITESPACE) {
-				$line += count(preg_split('/\r\n|\r|\n/', $content)) - 1;
-			}
+			$line += count(preg_split('/\r\n|\r|\n/', $content)) - 1;
 		}
 
 		if ($options['wrap'] && empty($options['include'])) {

--- a/tests/cases/analysis/ParserTest.php
+++ b/tests/cases/analysis/ParserTest.php
@@ -153,6 +153,17 @@ EOD;
 		$this->assertIdentical(3, $tokens[13]['line']);
 	}
 
+	public function testParserGuessesLineBleedWithNonWhitespace() {
+		$code = <<<EOD
+if (false) {
+	// hello world
+}
+EOD;
+		$tokens = Parser::tokenize($code);
+		$this->assertIdentical('}', $tokens[9]['content']);
+		$this->assertIdentical(3, $tokens[9]['line']);
+	}
+
 }
 
 ?>


### PR DESCRIPTION
Not as important as the last one, but whitespace isn't the only multiline token, just making it less generic.
