### PR TITLE
Fixing issue #780.

### DIFF
--- a/data/Entity.php
+++ b/data/Entity.php
@@ -373,14 +373,16 @@ class Entity extends \lithium\core\Object {
 				return null;
 			}
 
-			$value = !($value = isset($this->_updated[$field])) ?: $this->_updated[$field];
-			if (!$value) {
+			if (!array_key_exists($field, $this->_updated)) {
 				return false;
-			} elseif (is_object($value) && method_exists($value, 'modified')) {
+			}
+
+			$value = $this->_updated[$field];
+			if (is_object($value) && method_exists($value, 'modified')) {
 				$modified = $value->modified();
 				return $modified === true || is_array($modified) && in_array(true, $modified, true);
 			}
-			return !isset($this->_data[$field]) || $this->_data[$field] !== $this->_updated[$field];
+			return !isset($this->_data[$field]) || ($this->_data[$field] !== $this->_updated[$field]);
 		}
 
 		$fields = array_fill_keys(array_keys($this->_data), false);

--- a/tests/cases/data/EntityTest.php
+++ b/tests/cases/data/EntityTest.php
@@ -133,6 +133,9 @@ class EntityTest extends \lithium\test\Unit {
 		$this->assertTrue($entity->modified('foo'));
 		$this->assertTrue($entity->modified('baz'));
 
+		/**
+		 * and last, checking a non-existing field
+		 */
 		$this->assertNull($entity->modified('ole'));
 
 		$subentity = new Entity();
@@ -143,6 +146,25 @@ class EntityTest extends \lithium\test\Unit {
 		$this->assertTrue($entity->ble->modified('foo'));
 		$this->assertFalse($entity->ble->modified('iak'));
 		$this->assertEqual($entity->ble->modified(), array('foo' => true, 'baz' => true));
+
+		$data = array('foo' => 'bar', 'baz' => 'dib'); //it's the default data array in the test
+		$entity = new Entity();
+		$entity->set($data);
+		$entity->sync();
+
+		/**
+		 * Checking empty values
+		 */
+		$entity->foo = '';
+		$this->assertTrue($entity->modified('foo'));
+		$this->assertEqual(array('foo' => true, 'baz' => false), $entity->modified());
+
+		/**
+		 * and checking null values
+		 */
+		$entity->sync();
+		$entity->foo = null;
+		$this->assertTrue($entity->modified('foo'));
 	}
 
 	/**


### PR DESCRIPTION
Entity->modified() behaves correctly with empty values (empty string,
zero and null).
