### PR TITLE
Fix infinite loop that occurs when an `data\Entity` class is used as `data\Entity::_model`.

### DIFF
--- a/data/Entity.php
+++ b/data/Entity.php
@@ -187,7 +187,7 @@ class Entity extends \lithium\core\Object {
 	 * @return mixed
 	 */
 	public function __call($method, $params) {
-		if ($model = $this->_model) {
+		if (($model = $this->_model) && method_exists($model, '_object')) {
 			array_unshift($params, $this);
 			$class = $model::invokeMethod('_object');
 			return call_user_func_array(array(&$class, $method), $params);

--- a/tests/cases/data/EntityTest.php
+++ b/tests/cases/data/EntityTest.php
@@ -102,6 +102,14 @@ class EntityTest extends \lithium\test\Unit {
 		$entity->foo();
 	}
 
+	public function testMethodDispatchWithEntityAsModel() {
+		$data = array('foo' => true);
+		$model = 'lithium\data\Entity';
+		$entity = new Entity(compact('model', 'data'));
+		$this->expectException("/^No model bound to call `foo`.$/");
+		$entity->foo();
+	}
+
 	public function testErrors() {
 		$entity = new Entity();
 		$errors = array('foo' => 'Something bad happened.');


### PR DESCRIPTION
This may bug occurs when using external ORM which are not based on core `data\Model`.
I'm not sure for this one because at first glance it looks like `data\Entity::_model` shouldn't be filled with something which is not a core `data\Model` subclass.
However if it makes sense, maybe a:

``` php
!is_a($model, 'lithium\data\Entity', true)
```

would here be better than a: 

``` php
method_exists($model, '_object')
```

for fixing this issue ?
