### PR TITLE
Update filters to be reset-able

### DIFF
--- a/core/Object.php
+++ b/core/Object.php
@@ -137,16 +137,24 @@ class Object {
 	 * @see lithium\core\Object::_filter()
 	 * @see lithium\util\collection\Filters
 	 * @param mixed $method The name of the method to apply the closure to. Can either be a single
-	 *        method name as a string, or an array of method names.
-	 * @param closure $filter The closure that is used to filter the method(s).
+	 *        method name as a string, or an array of method names. Can also be false to remove
+	 *        all filters on the current object.
+	 * @param closure $filter The closure that is used to filter the method(s), can also be false
+	 *        to remove all the current filters for the given method.
 	 * @return void
 	 */
 	public function applyFilter($method, $filter = null) {
+		if ($method === false) {
+			$this->_methodFilters = array();
+			return;
+		}
 		foreach ((array) $method as $m) {
-			if (!isset($this->_methodFilters[$m])) {
+			if (!isset($this->_methodFilters[$m]) || $filter === false) {
 				$this->_methodFilters[$m] = array();
 			}
-			$this->_methodFilters[$m][] = $filter;
+			if ($filter !== false) {
+				$this->_methodFilters[$m][] = $filter;
+			}
 		}
 	}
 
@@ -266,6 +274,7 @@ class Object {
 	protected function _stop($status = 0) {
 		exit($status);
 	}
+
 }
 
 ?>

--- a/core/StaticObject.php
+++ b/core/StaticObject.php
@@ -40,17 +40,25 @@ class StaticObject {
 	 * @see lithium\core\StaticObject::_filter()
 	 * @see lithium\util\collection\Filters
 	 * @param mixed $method The name of the method to apply the closure to. Can either be a single
-	 *        method name as a string, or an array of method names.
-	 * @param closure $filter The closure that is used to filter the method.
+	 *        method name as a string, or an array of method names. Can also be false to remove
+	 *        all filters on the current object.
+	 * @param closure $filter The closure that is used to filter the method(s), can also be false
+	 *        to remove all the current filters for the given method.
 	 * @return void
 	 */
 	public static function applyFilter($method, $filter = null) {
 		$class = get_called_class();
+		if ($method === false) {
+			static::$_methodFilters[$class] = array();
+			return;
+		}
 		foreach ((array) $method as $m) {
-			if (!isset(static::$_methodFilters[$class][$m])) {
+			if (!isset(static::$_methodFilters[$class][$m]) || $filter === false) {
 				static::$_methodFilters[$class][$m] = array();
 			}
-			static::$_methodFilters[$class][$m][] = $filter;
+			if ($filter !== false) {
+				static::$_methodFilters[$class][$m][] = $filter;
+			}
 		}
 	}
 
@@ -149,6 +157,7 @@ class StaticObject {
 	protected static function _stop($status = 0) {
 		exit($status);
 	}
+
 }
 
 ?>

--- a/tests/cases/core/ObjectTest.php
+++ b/tests/cases/core/ObjectTest.php
@@ -213,6 +213,53 @@ class ObjectTest extends \lithium\test\Unit {
 		$this->expectException('/^Invalid class lookup/');
 		$object->instance(false);
 	}
+
+	public function testResetMethodFilter() {
+		$obj = new MockMethodFiltering();
+		$obj->applyFilter(false);
+		$obj->applyFilter('method2', function($self, $params, $chain) {
+			return false;
+		});
+
+		$this->assertIdentical(false, $obj->method2());
+
+		$obj->applyFilter('method2', false);
+
+		$this->assertTrue($obj->method2() !== false);
+	}
+
+	public function testResetMultipleFilters() {
+		$obj = new MockMethodFiltering();
+		$obj->applyFilter(false);
+		$obj->applyFilter(array('method2', 'manual'), function($self, $params, $chain) {
+			return false;
+		});
+
+		$this->assertIdentical(false, $obj->method2());
+		$this->assertIdentical(false, $obj->manual(array()));
+
+		$obj->applyFilter('method2', false);
+
+		$this->assertTrue($obj->method2() !== false);
+		$this->assertIdentical(false, $obj->manual(array()));
+	}
+
+	public function testResetClass() {
+		$obj = new MockMethodFiltering();
+		$obj->applyFilter(false);
+		$obj->applyFilter(array('method2', 'manual'), function($self, $params, $chain) {
+			return false;
+		});
+
+		$this->assertIdentical(false, $obj->method2());
+		$this->assertIdentical(false, $obj->manual(array()));
+
+		$obj->applyFilter(false);
+
+		$this->assertTrue($obj->method2() !== false);
+		$this->assertTrue($obj->manual(array()) !== false);
+	}
+
 }
 
 ?>

--- a/tests/cases/core/StaticObjectTest.php
+++ b/tests/cases/core/StaticObjectTest.php
@@ -162,6 +162,53 @@ class StaticObjectTest extends \lithium\test\Unit {
 		$this->expectException('/^Invalid class lookup/');
 		MockStaticInstantiator::instance(false);
 	}
+
+	public function testResetMethodFilter() {
+		$class = 'lithium\tests\mocks\core\MockStaticMethodFiltering';
+		$class::applyFilter(false);
+		$class::applyFilter('method2', function($self, $params, $chain) {
+			return false;
+		});
+
+		$this->assertIdentical(false, $class::method2());
+
+		$class::applyFilter('method2', false);
+
+		$this->assertTrue($class::method2() !== false);
+	}
+
+	public function testResetMultipleFilters() {
+		$class = 'lithium\tests\mocks\core\MockStaticMethodFiltering';
+		$class::applyFilter(false);
+		$class::applyFilter(array('method2', 'manual'), function($self, $params, $chain) {
+			return false;
+		});
+
+		$this->assertIdentical(false, $class::method2());
+		$this->assertIdentical(false, $class::manual(array()));
+
+		$class::applyFilter('method2', false);
+
+		$this->assertTrue($class::method2() !== false);
+		$this->assertIdentical(false, $class::manual(array()));
+	}
+
+	public function testResetClass() {
+		$class = 'lithium\tests\mocks\core\MockStaticMethodFiltering';
+		$class::applyFilter(false);
+		$class::applyFilter(array('method2', 'manual'), function($self, $params, $chain) {
+			return false;
+		});
+
+		$this->assertIdentical(false, $class::method2());
+		$this->assertIdentical(false, $class::manual(array()));
+
+		$class::applyFilter(false);
+
+		$this->assertTrue($class::method2() !== false);
+		$this->assertTrue($class::manual(array()) !== false);
+	}
+
 }
 
 ?>

--- a/tests/cases/test/filter/ComplexityTest.php
+++ b/tests/cases/test/filter/ComplexityTest.php
@@ -36,7 +36,7 @@ class ComplexityTest extends \lithium\test\Unit {
 	protected $_metrics = array(
 		'invokeMethod' => 8,
 		'_filter' => 3,
-		'applyFilter' => 3,
+		'applyFilter' => 5,
 		'_parents' => 2,
 		'_instance' => 2,
 		'_stop' => 1
@@ -86,12 +86,12 @@ class ComplexityTest extends \lithium\test\Unit {
 		Complexity::apply($this->report, $group->tests());
 
 		$results = Complexity::analyze($this->report);
-		$expected = array('class' => array($testClass => 3));
+		$expected = array('class' => array($testClass => 3.5));
 		foreach ($this->_metrics as $method => $metric) {
 			$expected['max'][$testClass . '::' . $method . '()'] = $metric;
 		}
 		$this->assertEqual($expected['max'], $results['max']);
-		$this->assertEqual($expected['class'][$testClass], round($results['class'][$testClass]));
+		$this->assertIdentical($expected['class'][$testClass], $results['class'][$testClass]);
 	}
 
 	/**

--- a/tests/mocks/core/MockMethodFiltering.php
+++ b/tests/mocks/core/MockMethodFiltering.php
@@ -27,6 +27,14 @@ class MockMethodFiltering extends \lithium\core\Object {
 		};
 		return $this->_filter(__METHOD__, array(), $method);
 	}
+
+	public function manual($filters) {
+		$method = function($self, $params, $chain) {
+			return "Working";
+		};
+		return $this->_filter(__METHOD__, array(), $method, $filters);
+	}
+
 }
 
 ?>


### PR DESCRIPTION
This is mainly for testing/mocking purposes. For instance I was Mocking how the static class `Session` worked. In each test I was setting `Session::read` to return specific data. This worked great for a single test, however the filters are executed in insert order so the filter in my second test was called last.
