### PR TITLE
Docblock fix.

### DIFF
--- a/g11n/Message.php
+++ b/g11n/Message.php
@@ -125,7 +125,7 @@ class Message extends \lithium\core\StaticObject {
 	 * Usage:
 	 * {{{
 	 * 	$t('bike');
-	 * 	$tn('bike', 'bikes', array('count' => 3));
+	 * 	$tn('bike', 'bikes', 3);
 	 * }}}
 	 *
 	 * Using in a method:


### PR DESCRIPTION
lithium\g11n\Message::aliases() had a bad usage for $tn method since the
3rd arg is supposed to be a numeric value and the example had an array
which could lead to bad uses and not the expected result.
