### PR TITLE
Added support for time zone config setting for PostgreSql adapter.

### DIFF
--- a/data/source/database/adapter/PostgreSql.php
+++ b/data/source/database/adapter/PostgreSql.php
@@ -81,7 +81,12 @@ class PostgreSql extends \lithium\data\source\Database {
 	 * list of active connections.
 	 */
 	public function __construct(array $config = array()) {
-		$defaults = array('host' => 'localhost:5432', 'encoding' => null, 'schema' => 'public');
+		$defaults = array(
+			'host' => 'localhost:5432',
+			'encoding' => null,
+			'schema' => 'public',
+			'timezone' => null
+		);
 		parent::__construct($config + $defaults);
 	}
 
@@ -229,6 +234,25 @@ class PostgreSql extends \lithium\data\source\Database {
 		}
 		try{
 			$this->connection->exec("SET search_path TO ${search_path}");
+			return true;
+		} catch (PDOException $e) {
+			return false;
+		}
+	}
+
+	/**
+	 * Gets or sets the time zone for the connection
+	 * @param $timezone
+	 * @return mixed If setting the time zone; returns true on success, else false
+	 *         When getting, returns the time zone
+	 */
+	public function timezone($timezone = null) {
+		if (empty($timezone)) {
+			$query = $this->connection->query('SHOW TIME ZONE');
+			return $query->fetchColumn();
+		}
+		try {
+			$this->connection->exec("SET TIME ZONE '{$timezone}'");
 			return true;
 		} catch (PDOException $e) {
 			return false;

--- a/tests/cases/data/source/database/adapter/PostgreSqlTest.php
+++ b/tests/cases/data/source/database/adapter/PostgreSqlTest.php
@@ -52,7 +52,7 @@ class PostgreSqlTest extends \lithium\test\Unit {
 			'autoConnect' => false, 'encoding' => null,'persistent' => true,
 			'host' => 'localhost:5432', 'login' => 'root', 'password' => '',
 			'database' => null, 'dsn' => null, 'options' => array(),
-			'init' => true, 'schema' => 'public'
+			'init' => true, 'schema' => 'public', 'timezone' => null
 		);
 		$this->assertEqual($expected, $result);
 	}
@@ -91,6 +91,15 @@ class PostgreSqlTest extends \lithium\test\Unit {
 
 		$this->assertTrue($this->db->encoding('UTF-8'));
 		$this->assertEqual('UTF-8', $this->db->encoding());
+	}
+
+	public function testDatabaseTimezone() {
+		$this->assertTrue($this->db->isConnected());
+		$this->assertTrue($this->db->timezone('UTC'));
+		$this->assertEqual('UTC', $this->db->timezone());
+
+		$this->assertTrue($this->db->timezone('US/Eastern'));
+		$this->assertEqual('US/Eastern', $this->db->timezone());
 	}
 
 	public function testValueByIntrospect() {
@@ -149,7 +158,12 @@ class PostgreSqlTest extends \lithium\test\Unit {
 		$this->assertTrue(is_numeric($result[0]['id']));
 		unset($result[0]['id']);
 
-		$expected = array('name' => 'Test', 'active' => true, 'created' => null, 'modified' => null);
+		$expected = array(
+			'name' => 'Test',
+			'active' => true,
+			'created' => null,
+			'modified' => null
+		);
 		$this->assertIdentical($expected, $result[0]);
 
 		$this->assertTrue($this->db->delete('DELETE From companies WHERE name = {:name}', array(


### PR DESCRIPTION
Added support for a timezone parameter in the connection config for the PostgreSql adapter. Allows you to control the time zone that is used for your database connection. Important to be able to enforce the connection time zone when dealing with time zone aware timestamps.
