### PR TITLE
Add GLOB_BRACE option for better pattern searches.

### DIFF
--- a/core/Libraries.php
+++ b/core/Libraries.php
@@ -979,8 +979,8 @@ class Libraries {
 		$suffix = $options['namespaces'] ? '' : $config['suffix'];
 		$suffix = ($options['suffix'] === null) ? $suffix : $options['suffix'];
 
-		$dFlags = GLOB_ONLYDIR;
-		$libs = (array) glob($path . $suffix, $options['namespaces'] ? $dFlags : 0);
+		$dFlags = GLOB_ONLYDIR & GLOB_BRACE;
+		$libs = (array) glob($path . $suffix, $options['namespaces'] ? $dFlags : GLOB_BRACE);
 
 		if ($options['recursive']) {
 			list($current, $match) = explode('/*', $path, 2);

--- a/tests/cases/core/LibrariesTest.php
+++ b/tests/cases/core/LibrariesTest.php
@@ -65,6 +65,23 @@ class LibrariesTest extends \lithium\test\Unit {
 		$this->assertEqual($paths, Libraries::paths());
 	}
 
+	public function testPathTemplateWithGlobBrace() {
+		Libraries::paths(array(
+			'analysis' => array(
+				'{:library}\analysis\*{Docblock,Debugger}',
+			),
+		));
+
+		$analysis = list($docblock, $debugger) = Libraries::locate('analysis', null, array(
+			'recursive' => false,
+			'format' => false,
+		));
+
+		$this->assertCount(2, $analysis);
+		$this->assertPattern('/Docblock\.php/', $docblock);
+		$this->assertPattern('/Debugger\.php/', $debugger);
+	}
+
 	public function testPathTransform() {
 		$expected = 'Library/Class/Separated/By/Underscore';
 		$result = Libraries::path('Library_Class_Separated_By_Underscore', array(


### PR DESCRIPTION
I'm basically trying to do something like this:

``` php
Libraries::paths(array(
    'rules' => array(
        '{:library}\extensions\test\rules\{:class}\{:name}',
        '{:library}\test\rules\{:class}\{:name}' => array('libraries' => 'li3_quality'),
    ),
    'ruleSets' => array(
        '{:library}\test\*{rules,defaultRules}',
    ),
));
$ruleSets = Libraries::locate('ruleSets', null, array(
    'recursive' => false,
    'suffix' => '.json',
    'preFilter' => '/(r|defaultR)ules\.json/',
    'format' => false,
));
```

This sets priority and better matching.

Removing the `*{rules,defaultRules}` and replacing it with `{:name}` would cause them to be out of order, at which point I'd need to sort them since I want to only match the first one and use `defaultRules` as a last resort.

If I remove the preFilter `rules.json` wont match since the default regex requires an uppercase letter to match.
