### PR TITLE
Avoid integer and float values false pass 'inList' validation

### DIFF
--- a/tests/cases/util/ValidatorTest.php
+++ b/tests/cases/util/ValidatorTest.php
@@ -436,6 +436,10 @@ class ValidatorTest extends \lithium\test\Unit {
 
 		$this->assertFalse(Validator::isInList(2, null, array('list' => array('0', '1'))));
 		$this->assertFalse(Validator::isInList('2', null, array('list' => array('0', '1'))));
+
+		$this->assertFalse(Validator::isInList(0, null, array('list' => array('a', 'b'))));
+		$this->assertFalse(Validator::isInList(10, null, array('list' => array(0, '10a'))));
+		$this->assertFalse(Validator::isInList(1.1, null, array('list' => array(0, '1.1a'))));
 	}
 
 

--- a/util/Validator.php
+++ b/util/Validator.php
@@ -274,6 +274,9 @@ class Validator extends \lithium\core\StaticObject {
 			'inList' => function($value, $format, $options) {
 				$options += array('list' => array());
 				$strict = is_bool($value) || $value === '';
+				if (is_int($value) || is_float($value)) {
+					$value = strval($value);
+				}
 				return in_array($value, $options['list'], $strict);
 			},
 			'lengthBetween' => function($value, $format, $options) {


### PR DESCRIPTION
As PHP prefers to compare integers/floats if one of the arguments have type int/float false positives are very common, like 0 == 'a'. This patch prevents such behavior for `'inList'` validation rule but only for case when validated value have type int/float. It does not process list of allowed values.
