### PR TITLE
Accounting for ReflectionClass::getName() Bug

### DIFF
--- a/analysis/Inspector.php
+++ b/analysis/Inspector.php
@@ -435,7 +435,9 @@ class Inspector extends \lithium\core\StaticObject {
 				$list = array_diff(get_declared_classes(), $list);
 			} else {
 				$filter = function($class) use ($file) { return $class->getFileName() === $file; };
-				$list = $loaded->find($filter)->getName();
+				$list = $loaded->find($filter)->map(function ($class) {
+					return $class->getName() ?: $class->name;
+				}, array('collect' => false));
 			}
 		}
 


### PR DESCRIPTION
Related to https://bugs.php.net/bug.php?id=63256.

A ReflectionException can be thrown due to the ReflectionClass name getter incorrectly returning false.

I'm unsure of the various OS and PHP version scenarios where this is possible, but I discovered on this on Windows 7, running IIS 7.5 and PHP 5.4.2.
