### PR TITLE
Give `Mocker` the ability to stub global function calls.

### DIFF
--- a/tests/cases/test/MockerTest.php
+++ b/tests/cases/test/MockerTest.php
@@ -340,6 +340,58 @@ class MockerTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, Mocker::mergeResults($results, $staticResults));
 	}
 
+	public function testCreateFunction() {
+		$obj = new \lithium\tests\mocks\test\MockStdClass;
+		Mocker::overwriteFunction('lithium\tests\mocks\test\get_class', function() {
+			return 'foo';
+		});
+		$this->assertIdentical('foo', $obj->getClass());
+	}
+
+	public function testCallFunctionUsesGlobalFallback() {
+		$result = Mocker::callFunction('foo\bar\baz\get_called_class');
+		$this->assertIdentical('lithium\test\Mocker', $result);
+	}
+
+	public function testMultipleCreateFunction() {
+		$obj = new \lithium\tests\mocks\test\MockStdClass;
+		Mocker::overwriteFunction('lithium\tests\mocks\test\get_class', function() {
+			return 'foo';
+		});
+		Mocker::overwriteFunction('lithium\tests\mocks\test\get_class', function() {
+			return 'bar';
+		});
+		$this->assertIdentical('bar', $obj->getClass());
+	}
+
+	public function testResetSpecificFunctions() {
+		$obj = new \lithium\tests\mocks\test\MockStdClass;
+		Mocker::overwriteFunction('lithium\tests\mocks\test\get_class', function() {
+			return 'baz';
+		});
+		Mocker::overwriteFunction('lithium\tests\mocks\test\is_executable', function() {
+			return 'qux';
+		});
+		Mocker::overwriteFunction('lithium\tests\mocks\test\get_class', false);
+
+		$this->assertIdentical('lithium\tests\mocks\test\MockStdClass', $obj->getClass());
+		$this->assertIdentical('qux', $obj->isExecutable());
+	}
+
+	public function testResetAllFunctions() {
+		$obj = new \lithium\tests\mocks\test\MockStdClass;
+		Mocker::overwriteFunction('lithium\tests\mocks\test\get_class', function() {
+			return 'baz';
+		});
+		Mocker::overwriteFunction('lithium\tests\mocks\test\is_executable', function() {
+			return 'qux';
+		});
+		Mocker::overwriteFunction(false);
+
+		$this->assertIdentical('lithium\tests\mocks\test\MockStdClass', $obj->getClass());
+		$this->assertInternalType('bool', $obj->isExecutable());
+	}
+
 }
 
 ?>

--- a/tests/mocks/test/MockStdClass.php
+++ b/tests/mocks/test/MockStdClass.php
@@ -36,6 +36,14 @@ class MockStdClass extends \lithium\core\Object {
 		return false;
 	}
 
+	public function getClass() {
+		return get_class($this);
+	}
+
+	public function isExecutable() {
+		return is_executable(__FILE__);
+	}
+
 }
 
 ?>


### PR DESCRIPTION
This is more of a trick, since calling a funciton like `get_called_class()` in a namespace is first searched for in the current namespace, then globally. Here, we simply create it in the same namespace it's called allowing users to overwrite the return value of it. The user defined function can be overwritten, and if deleted will result in the global function being called normally.

Often times we make methods that call php-defined functions such as `define`, `compact`, `eval`, `json_decode`, `token_get_all`, and the list goes on. Often it's best to change the php-defined functions to manipulate the behavior of the method, but putting a giant list of php-defined functions in a config variable is not very elegant and would start making your code harder to read, and doing so for testing seems a bit over the top. This allows you to code normally and still have testable code.

This pull request provides a simple and reset-able api to allow stubbing of functions.

For example, nobody wants to create a new file for each test (starting to sound like a factory vs fixture debate...) so you could stub some functions which put your data a lot closer to your test. Here is an example I threw together:

``` php
<?php

namespace app\extensions;

class AwesomeFileEditor {

    public static function updateJson($file) {
        if (file_exists($file)) {
            $time = microtime(true);
            $packages = json_decode(file_get_contents($file), true);
            foreach ($packages['users'] as &$package) {
                $package['updated'] = $time;
            }
            return $packages;
        }
        return false;
    }

}

?>
```

``` php
<?php

namespace app\tests\cases\extensions;

use lithium\test\Mocker;
use app\extensions\AwesomeFileEditor;

class AwesomeFileEditorTest extends \lithium\test\Unit {
    public function setUp() {
        Mocker::overwriteFunction(false);
    }

    public function testUpdateJson() {
        Mocker::overwriteFunction('app\extensions\file_exists', function() {
            return true;
        });
        Mocker::overwriteFunction('app\extensions\file_get_contents', function() {
            return <<<EOD
{
    "users": [
        {
            "name": "BlaineSch",
            "updated": 0
        }
    ]
}
EOD;
        });

        $results = AwesomeFileEditor::updateJson('idontexist.json');
        $this->assertNotEqual(0, $results['users'][0]['updated']);
    }
}

?>
```
