### PR TITLE
Radio inputs don't check if bound to subdocument

### DIFF
--- a/template/helper/Form.php
+++ b/template/helper/Form.php
@@ -681,12 +681,13 @@ class Form extends \lithium\template\Helper {
 		$defaults = array('value' => '1');
 		$options += $defaults;
 		$default = $options['value'];
+		$key = $name;
 
 		list($name, $options, $template) = $this->_defaults(__FUNCTION__, $name, $options);
 		list($scope, $options) = $this->_options($defaults, $options);
 
 		if (!isset($options['checked'])) {
-			$options['checked'] = ($this->binding($name)->data == $default);
+			$options['checked'] = ($this->binding($key)->data == $default);
 		}
 
 		$options['value'] = $scope['value'];

--- a/tests/cases/template/helper/FormTest.php
+++ b/tests/cases/template/helper/FormTest.php
@@ -568,6 +568,24 @@ class FormTest extends \lithium\test\Unit {
 				'type' => 'radio', 'value' => '1', 'name' => 'foo', 'id' => 'MockFormPostFoo'
 			))
 		));
+
+		$document = new Document(array(
+			'model' => $this->_model,
+			'data' => array(
+				'subdocument' => array(
+					'foo' => true
+				)
+			)
+		));
+		$this->form->create($document);
+
+		$result = $this->form->radio('subdocument.foo');
+		$this->assertTags($result, array(
+			array('input' => array(
+				'type' => 'radio', 'value' => '1', 'name' => 'subdocument[foo]', 'id' => 'MockFormPostSubdocumentFoo',
+				'checked' => 'checked'
+			))
+		));
 	}
 
 	public function testCustomRadio() {


### PR DESCRIPTION
Copying the behavior of `Form->checkbox()`, adding support for binding subdocuments to radio inputs.

Updating #668 against current dev branch, and adding tests.

Test case is copied from `FormTest->testCheckboxGeneration()`, [line 425](https://github.com/UnionOfRAD/lithium/blob/dev/tests/cases/template/helper/FormTest.php#L425)
