### PR TITLE
Allowing Session id to be set manually (squash of https://github.com/UnionOfRAD/lithium/pull/818)

### DIFF
--- a/storage/Session.php
+++ b/storage/Session.php
@@ -55,14 +55,15 @@ class Session extends \lithium\core\Adaptable {
 	protected static $_strategies = 'strategy.storage.session';
 
 	/**
-	 * Returns the key used to identify the session.
+	 * Returns (and Sets) the key used to identify the session.
 	 *
 	 * @param mixed $name Optional named session configuration.
+   * @param mixed $session_id Optional session id to use for this session.
 	 * @return string Returns the value of the session identifier key, or `null` if no named
-	 *         configuration exists, or no session has been started.
+	 *         configuration exists, no session id has been set or no session has been started.
 	 */
-	public static function key($name = null) {
-		return is_object($adapter = static::adapter($name)) ? $adapter->key() : null;
+	public static function key($name = null, $sessionId = null) {
+		return is_object($adapter = static::adapter($name)) ? $adapter->key($sessionId) : null;
 	}
 
 	/**

--- a/storage/session/adapter/Php.php
+++ b/storage/session/adapter/Php.php
@@ -77,23 +77,25 @@ class Php extends \lithium\core\Object {
 	 *         false otherwise.
 	 */
 	protected static function _start() {
-		if (session_id()) {
+		if (static::isStarted()) {
 			return true;
 		}
-		if (!isset($_SESSION)) {
-			session_cache_limiter('nocache');
-		}
+		session_cache_limiter('nocache');
 		return session_start();
 	}
 
 	/**
 	 * Obtain the status of the session.
 	 *
-	 * @return boolean True if $_SESSION is accessible and if a '_timestamp' key
-	 *         has been set, false otherwise.
+	 * @return boolean True if a session is currently started, False otherwise. If PHP5.4
+	 *                 then we know, if PHP5.3 then we cannot tell for sure if a session
+	 *                 has been closed.
 	 */
 	public static function isStarted() {
-		return (boolean) session_id();
+		if (function_exists("session_status")) {
+			return session_status() === PHP_SESSION_ACTIVE;
+		}
+		return isset($_SESSION) && session_id();
 	}
 
 	/**
@@ -103,7 +105,7 @@ class Php extends \lithium\core\Object {
 	 * @return mixed Session ID, or `null` if the session has not been started.
 	 */
 	public static function key($key = null) {
-		if ($key) {
+		if ($key !== null) {
 			return session_id($key);
 		}
 		return session_id() ?: null;
@@ -217,10 +219,13 @@ class Php extends \lithium\core\Object {
 	/**
 	 * Determines if PHP sessions are enabled.
 	 *
-	 * @return boolean True if enabled (that is, if session_id() returns a value), false otherwise.
+	 * @return boolean True if enabled (php session functionality can be disabled completely), false otherwise
 	 */
 	public static function enabled() {
-		return (boolean) session_id();
+		if (function_exists("session_status")) {
+			return session_status() !== PHP_SESSION_DISABLED;
+		}
+		return in_array('session', get_loaded_extensions());
 	}
 
 	/**

--- a/tests/cases/storage/session/adapter/PhpTest.php
+++ b/tests/cases/storage/session/adapter/PhpTest.php
@@ -51,8 +51,9 @@ class PhpTest extends \lithium\test\Unit {
 
 	public function testEnabled() {
 		$php = $this->php;
-		$this->_destroySession(session_name());
-		$this->assertFalse($php::enabled());
+		/* Is PHP Session support enabled? */
+		$sessionsSupported = in_array('session', get_loaded_extensions());
+		$this->assertEqual($sessionsSupported, $php::enabled());
 	}
 
 	public function testInit() {


### PR DESCRIPTION
Updated the Session adaptable to pass through an optional
session_id parameter in the `::key` method, to set the
session id, rather than only allowing getting of the id.
The PHP adapter supported this, but the functionality was
masked by the Session adaptable not passing the id on.

This uncovered a bug in the PHP adaptable in the `::isStarted`
method which would false-positive if `session_id($non_empty)`
had been called beforehand. Also, the `::enabled()` method
was checking whether a session had been started, and not whether
php session functionality was enabled. Both of these have been
fixed and the test updated.

NB session started detection is vastly superior in PHP5.4 due
to the presence of the `session_status()` function.
