### PR TITLE
Added an options parameter to lithium\data\source\Database::name() to override escaping.

### DIFF
--- a/data/source/Database.php
+++ b/data/source/Database.php
@@ -308,12 +308,21 @@ abstract class Database extends \lithium\data\Source {
 	 * Field name handler to ensure proper escaping.
 	 *
 	 * @param string $name Field or identifier name.
+	 * @param array $options if the `escape` key is set to `false`, escaping a dot (`.`)
+	 *              is ignored since MySQL 5.1.6> allow this. Default is true.
 	 * @return string Returns `$name` quoted according to the rules and quote characters of the
 	 *         database adapter subclass.
 	 */
-	public function name($name) {
+	public function name($name, array $options = array()) {
+		$defaults = array('escape' => true);
+		$options += $defaults;
+
 		$open  = reset($this->_quotes);
 		$close = next($this->_quotes);
+
+		if ($options['escape'] === false) {
+			return "{$open}{$name}{$close}";
+		}
 
 		list($first, $second) = $this->_splitFieldname($name);
 		if ($first) {

--- a/tests/cases/data/source/DatabaseTest.php
+++ b/tests/cases/data/source/DatabaseTest.php
@@ -87,6 +87,12 @@ class DatabaseTest extends \lithium\test\Unit {
 
 		$result = $this->db->name("Model.name");
 		$this->assertEqual("{Model}.{name}", $result);
+
+		$result = $this->db->name("Model.name", array('escape' => false));
+		$this->assertEqual("{Model.name}", $result);
+
+		$result = $this->db->name("Model.name", array('escape' => true));
+		$this->assertEqual("{Model}.{name}", $result);
 	}
 
 	public function testValueWithSchema() {


### PR DESCRIPTION
I'm on MySQL 5.1.66:

```
mysql> STATUS;
--------------
mysql  Ver 14.14 Distrib 5.1.66, for debian-linux-gnu (i486) using readline 6.1
```

According to
[MySQL 5.1 Reference Manual :: 9 Language Structure :: 9.2 Schema Object Names](http://dev.mysql.com/doc/refman/5.1/en/identifiers.html):

```
Before MySQL 5.1.6, database and table names cannot contain “/”, “\”, “.”, or characters that are not permitted in file names.
```

So, even though it's discouraged, I should be able to have a database named `example.com`, for example :)

I can perform CRUD operations fine, using the regular Lithium app models which do not use `lithium\data\source\database\adapter\MySql::sources()` which, in turn, calls `lithium\data\source\Database::name()`.
If we were to call the above methods using a table name such as `example.com`, it will yield an error similar to the following:

```
SHOW TABLES FROM `example`.`com`;: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '.`com`' at line 1
```

@jails suggested I add an extra option to `lithium\data\source\Database::name()` to override escaping. I've also included the tests for this.
