### PR TITLE
Allow to retrieve the default library name.

### DIFF
--- a/core/Libraries.php
+++ b/core/Libraries.php
@@ -277,6 +277,7 @@ class Libraries {
 	 */
 	public static function add($name, array $config = array()) {
 		$defaults = array(
+			'name' => $name,
 			'path' => null,
 			'prefix' => $name . "\\",
 			'suffix' => '.php',
@@ -398,7 +399,6 @@ class Libraries {
 	 *
 	 * @param mixed $name A string or array of library names indicating the libraries you wish to
 	 *        remove, i.e. `'app'` or `'lithium'`. This can also be used to unload plugins by  name.
-	 * @return void
 	 */
 	public static function remove($name) {
 		foreach ((array) $name as $library) {

--- a/tests/cases/core/LibrariesTest.php
+++ b/tests/cases/core/LibrariesTest.php
@@ -122,6 +122,7 @@ class LibrariesTest extends \lithium\test\Unit {
 	public function testLibraryConfigAccess() {
 		$config = Libraries::get('lithium'); // => ['path' => '/path/to/lithium', ...]
 		$expected = array(
+			'name' => 'lithium',
 			'path' => str_replace('\\', '/', realpath(realpath(LITHIUM_LIBRARY_PATH) . '/lithium')),
 			'prefix' => 'lithium\\',
 			'suffix' => '.php',
@@ -167,6 +168,17 @@ class LibrariesTest extends \lithium\test\Unit {
 		$library = Libraries::get('lithium\core\Libraries'); // 'lithium'
 		$this->assertEqual('lithium', $library);
 		$this->assertNull(Libraries::get('foo\bar\baz'));
+	}
+
+	public function testLibraryNameConfigAccess() {
+		$original = Libraries::get(true);
+		Libraries::remove($original['name']);
+
+		Libraries::add('myapp', array('default' => true));
+		$this->assertIdentical('myapp', Libraries::get(true, 'name'));
+
+		Libraries::remove('myapp');
+		Libraries::add($original['name'], $original);
 	}
 
 	/**


### PR DESCRIPTION
The following syntax:

``` php
Libraries::get(true, 'name');
```

returns the default library name (i.e. the `Library::_default` value).
