### PR TITLE
Statically determine if a cache adapter is enabled.

### DIFF
--- a/storage/Cache.php
+++ b/storage/Cache.php
@@ -290,6 +290,22 @@ class Cache extends \lithium\core\Adaptable {
 		$settings = static::config();
 		return (isset($settings[$name])) ? static::adapter($name)->clear() : false;
 	}
+
+	/**
+	 * Determines if the adapter specified in the named configuration is enabled.
+	 *
+	 * `Enabled` can mean various things, e.g. having a PECL memcached extension compiled
+	 * & loaded, as well as having the memcache server up & available.
+	 *
+	 * @param string $name The named configuration whose adapter will be checked.
+	 * @return boolean  True if adapter is enabled, false if not. This method will
+	 *         return null if no configuration under the given $name exists.
+	 */
+	public static function enabled($name) {
+		$class = static::_class(static::_config($name), static::$_adapters);
+		return $class::enabled();
+	}
+
 }
 
 ?>

--- a/tests/cases/storage/CacheTest.php
+++ b/tests/cases/storage/CacheTest.php
@@ -11,11 +11,13 @@ namespace lithium\tests\cases\storage;
 use SplFileInfo;
 use lithium\core\Libraries;
 use lithium\storage\Cache;
+use lithium\test\Mocker;
 
 class CacheTest extends \lithium\test\Unit {
 
 	public function setUp() {
 		Cache::reset();
+		Mocker::register();
 	}
 
 	public function tearDown() {
@@ -649,6 +651,32 @@ class CacheTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 		$this->assertFalse(file_exists("{$path}/key"));
 	}
+
+	public function testNotCreateCacheWhenTestingEnabled() {
+		$class = "lithium\storage\cache\Mock";
+		$class::config(array(
+			'default' => array(
+				'adapter' => 'Memory',
+			),
+		));
+
+		$class::enabled('default');
+		$chain = Mocker::chain($class);
+
+		$this->assertFalse($chain->called('adapter')->success());
+	}
+
+	public function testEnabledHasCorrectOutput() {
+		$class = "lithium\storage\cache\Mock";
+		$class::config(array(
+			'default' => array(
+				'adapter' => 'Memory',
+			),
+		));
+
+		$this->assertInternalType('bool', $class::enabled('default'));
+	}
+
 }
 
 ?>


### PR DESCRIPTION
In `Adaptable::enabled()` it first asks for an instance of the adapter, which might be fine with other adaptables but for caching this does not work correctly since you could get a fatal error.

```
Fatal error: Class 'Memcached' not found
```
