### PR TITLE
Update assertion methods to be more obvious.

### DIFF
--- a/test/Unit.php
+++ b/test/Unit.php
@@ -65,6 +65,7 @@ class Unit extends \lithium\core\Object {
 	protected static $_internalTypes = array(
 		'array' => 'is_array',
 		'bool' => 'is_bool',
+		'boolean' => 'is_bool',
 		'callable' => 'is_callable',
 		'double' => 'is_double',
 		'float' => 'is_float',
@@ -292,7 +293,7 @@ class Unit extends \lithium\core\Object {
 	 * @param mixed $result
 	 * @param string|boolean $message
 	 */
-	public function assertEqual($expected, $result, $message = false) {
+	public function assertEqual($expected, $result, $message = '{:message}') {
 		list($expected, $result) = $this->_normalizeLineEndings($expected, $result);
 		$data = ($expected != $result) ? $this->_compare('equal', $expected, $result) : null;
 		return $this->assert($expected == $result, $message, $data);
@@ -305,7 +306,7 @@ class Unit extends \lithium\core\Object {
 	 * @param mixed $result
 	 * @param string|boolean $message
 	 */
-	public function assertNotEqual($expected, $result, $message = false) {
+	public function assertNotEqual($expected, $result, $message = '{:message}') {
 		list($expected, $result) = $this->_normalizeLineEndings($expected, $result);
 		return $this->assert($result != $expected, $message, compact('expected', 'result'));
 	}
@@ -317,9 +318,20 @@ class Unit extends \lithium\core\Object {
 	 * @param mixed $result
 	 * @param string|boolean $message
 	 */
-	public function assertIdentical($expected, $result, $message = false) {
+	public function assertIdentical($expected, $result, $message = '{:message}') {
 		$data = ($expected !== $result) ? $this->_compare('identical', $expected, $result) : null;
 		return $this->assert($expected === $result, $message, $data);
+	}
+
+	/**
+	 * Checks that the actual result and the expected result are identical.
+	 *
+	 * @param mixed $expected
+	 * @param mixed $result
+	 * @param string|boolean $message
+	 */
+	public function assertNotIdentical($expected, $result, $message = '{:message}') {
+		return $this->assert($expected !== $result, $message, compact('expected', 'result'));
 	}
 
 	/**
@@ -339,10 +351,11 @@ class Unit extends \lithium\core\Object {
 	 *
 	 * @param mixed $result
 	 * @param string $message
+	 * @return boolean
 	 */
 	public function assertTrue($result, $message = '{:message}') {
 		$expected = true;
-		return $this->assert(!empty($result), $message, compact('expected', 'result'));
+		return $this->assert($result === $expected, $message, compact('expected', 'result'));
 	}
 
 	/**
@@ -364,10 +377,11 @@ class Unit extends \lithium\core\Object {
 	 *
 	 * @param mixed $result
 	 * @param string $message
+	 * @return boolean
 	 */
 	public function assertFalse($result, $message = '{:message}') {
 		$expected = false;
-		return $this->assert(empty($result), $message, compact('expected', 'result'));
+		return $this->assert($result === $expected, $message, compact('expected', 'result'));
 	}
 
 	/**
@@ -375,6 +389,7 @@ class Unit extends \lithium\core\Object {
 	 *
 	 * @param mixed $result
 	 * @param string $message
+	 * @return boolean
 	 */
 	public function assertNull($result, $message = '{:message}') {
 		$expected = null;
@@ -387,8 +402,9 @@ class Unit extends \lithium\core\Object {
 	 * @param mixed $expected
 	 * @param mixed $result
 	 * @param string $message
+	 * @return boolean
 	 */
-	public function assertNoPattern($expected, $result, $message = '{:message}') {
+	public function assertNotPattern($expected, $result, $message = '{:message}') {
 		list($expected, $result) = $this->_normalizeLineEndings($expected, $result);
 		$params = compact('expected', 'result');
 		return $this->assert(!preg_match($expected, $result), $message, $params);
@@ -400,6 +416,7 @@ class Unit extends \lithium\core\Object {
 	 * @param mixed $expected
 	 * @param mixed $result
 	 * @param string $message
+	 * @return boolean
 	 */
 	public function assertPattern($expected, $result, $message = '{:message}') {
 		list($expected, $result) = $this->_normalizeLineEndings($expected, $result);
@@ -1219,15 +1236,15 @@ class Unit extends \lithium\core\Object {
 	 * Will mark the test `true` if `$class` has an attribute `$attributeName`.
 	 *
 	 * {{{
-	 * $this->assertClassHasAttribute('name', '\ReflectionClass');
+	 * $this->assertClassHasAttribute('name', 'ReflectionClass');
 	 * }}}
 	 *
 	 * {{{
-	 * $this->assertClassHasAttribute('__construct', '\ReflectionClass');
+	 * $this->assertClassHasAttribute('__construct', 'ReflectionClass');
 	 * }}}
 	 *
 	 * @see    lithium\test\Unit::assertObjectHasAttribute()
-	 * @throws InvalidArgumentException When $object is not an object
+	 * @throws InvalidArgumentException When $class does not exist
 	 * @throws ReflectionException      If the given class does not exist
 	 * @param  string $attributeName    Attribute you wish to look for
 	 * @param  string $class            Class name
@@ -1249,15 +1266,15 @@ class Unit extends \lithium\core\Object {
 	 * Will mark the test `true` if `$class` has an attribute `$attributeName`.
 	 *
 	 * {{{
-	 * $this->assertClassNotHasAttribute('__construct', '\ReflectionClass');
+	 * $this->assertClassNotHasAttribute('__construct', 'ReflectionClass');
 	 * }}}
 	 *
 	 * {{{
-	 * $this->assertClassNotHasAttribute('name', '\ReflectionClass');
+	 * $this->assertClassNotHasAttribute('name', 'ReflectionClass');
 	 * }}}
 	 *
 	 * @see    lithium\test\Unit::assertObjectNotHasAttribute()
-	 * @throws InvalidArgumentException When $object is not an object
+	 * @throws InvalidArgumentException When $class does not exist
 	 * @throws ReflectionException      If the given class does not exist
 	 * @param  string $attributeName    Attribute you wish to look for
 	 * @param  string $class            Class name
@@ -1631,11 +1648,11 @@ class Unit extends \lithium\core\Object {
 	 * Will mark the test `true` if the file `$actual` does not exist.
 	 *
 	 * {{{
-	 * $this->assertFileExists(LITHIUM_APP_PATH . '/does/not/exist.txt');
+	 * $this->assertFileNotExists(LITHIUM_APP_PATH . '/does/not/exist.txt');
 	 * }}}
 	 *
 	 * {{{
-	 * $this->assertFileExists(LITHIUM_APP_PATH . '/readme.md');
+	 * $this->assertFileNotExists(LITHIUM_APP_PATH . '/readme.md');
 	 * }}}
 	 *
 	 * @param  string $actual   Path to the file you are asserting
@@ -1783,7 +1800,7 @@ class Unit extends \lithium\core\Object {
 	public function assertNotInstanceOf($expected, $actual, $message = '{:message}') {
 		return $this->assert(!is_a($actual, $expected), $message, array(
 			'expected' => $expected,
-			'result' => get_class($actual)
+			'result' => is_object($actual) ? get_class($actual) : gettype($actual),
 		));
 	}
 
@@ -1861,11 +1878,11 @@ class Unit extends \lithium\core\Object {
 	 * Will mark the test `true` if `$object` has an attribute `$attributeName`.
 	 *
 	 * {{{
-	 * $this->assertObjectHasAttribute('name', '\ReflectionClass');
+	 * $this->assertObjectHasAttribute('name', 'ReflectionClass');
 	 * }}}
 	 *
 	 * {{{
-	 * $this->assertObjectHasAttribute('__construct', '\ReflectionClass');
+	 * $this->assertObjectHasAttribute('__construct', 'ReflectionClass');
 	 * }}}
 	 *
 	 * @see    lithium\test\Unit::assertClassHasAttribute()
@@ -1890,11 +1907,11 @@ class Unit extends \lithium\core\Object {
 	 * Will mark the test `true` if `$object` has an attribute `$attributeName`.
 	 *
 	 * {{{
-	 * $this->assertObjectNotHasAttribute('__construct', '\ReflectionClass');
+	 * $this->assertObjectNotHasAttribute('__construct', 'ReflectionClass');
 	 * }}}
 	 *
 	 * {{{
-	 * $this->assertObjectNotHasAttribute('name', '\ReflectionClass');
+	 * $this->assertObjectNotHasAttribute('name', 'ReflectionClass');
 	 * }}}
 	 *
 	 * @see    lithium\test\Unit::assertClassHasNotAttribute()
@@ -1912,52 +1929,6 @@ class Unit extends \lithium\core\Object {
 		return $this->assert(!$object->hasProperty($attributeName), $message, array(
 			'expected' => $attributeName,
 			'result' => $object->getProperties()
-		));
-	}
-
-	/**
-	 * Will mark the test `true` if `$actual` matches $expected using `preg_match`.
-	 *
-	 * {{{
-	 * $this->assertRegExp('/^foo/', 'foobar');
-	 * }}}
-	 *
-	 * {{{
-	 * $this->assertRegExp('/^foobar/', 'bar');
-	 * }}}
-	 *
-	 * @param  string $expected Regex to match against $actual
-	 * @param  string $actual   String to be matched upon
-	 * @param  string $message  optional
-	 * @return bool
-	 */
-	public function assertRegExp($expected, $actual, $message = '{:message}') {
-		return $this->assert(preg_match($expected, $actual, $matches) === 1, $message, array(
-			'expected' => $expected,
-			'result' => $matches
-		));
-	}
-
-	/**
-	 * Will mark the test `true` if `$actual` does not match $expected using `preg_match`.
-	 *
-	 * {{{
-	 * $this->assertNotRegExp('/^foobar/', 'bar');
-	 * }}}
-	 *
-	 * {{{
-	 * $this->assertNotRegExp('/^foo/', 'foobar');
-	 * }}}
-	 *
-	 * @param  string $expected Regex to match against $actual
-	 * @param  string $actual   String to be matched upon
-	 * @param  string $message  optional
-	 * @return bool
-	 */
-	public function assertNotRegExp($expected, $actual, $message = '{:message}') {
-		return $this->assert(preg_match($expected, $actual, $matches) === 0, $message, array(
-			'expected' => $expected,
-			'result' => $matches
 		));
 	}
 

--- a/tests/cases/action/ControllerTest.php
+++ b/tests/cases/action/ControllerTest.php
@@ -9,7 +9,6 @@
 namespace lithium\tests\cases\action;
 
 use lithium\action\Request;
-use lithium\action\Response;
 use lithium\action\Controller;
 use lithium\tests\mocks\action\MockPostsController;
 use lithium\tests\mocks\action\MockControllerRequest;
@@ -39,7 +38,7 @@ class ControllerTest extends \lithium\test\Unit {
 		$postsController = new MockPostsController();
 		$result = $postsController->__invoke(null, array('action' => 'index', 'args' => array()));
 
-		$this->assertTrue($result instanceof Response);
+		$this->assertInstanceOf('lithium\action\Response', $result);
 		$this->assertEqual('List of posts', $result->body());
 		$this->assertEqual(array('Content-Type' => 'text/plain; charset=UTF-8'), $result->headers);
 
@@ -50,7 +49,7 @@ class ControllerTest extends \lithium\test\Unit {
 		$this->expectException('/Unhandled media type/');
 		$result = $postsController(null, array('action' => 'index', 'args' => array(true)));
 
-		$this->assertTrue($result instanceof Response);
+		$this->assertInstanceOf('lithium\action\Response', $result);
 		$this->assertEqual($result->body, '');
 
 		$headers = array('Content-Type' => 'text/html; charset=UTF-8');
@@ -62,7 +61,7 @@ class ControllerTest extends \lithium\test\Unit {
 		$postsController = new MockPostsController();
 		$result = $postsController(null, array('action' => 'view', 'args' => array('2')));
 
-		$this->assertTrue($result instanceof Response);
+		$this->assertInstanceOf('lithium\action\Response', $result);
 		$this->assertEqual($result->body, "Array\n(\n    [0] => This is a post\n)\n");
 
 		$headers = array('status' => 200, 'Content-Type' => 'text/plain; charset=UTF-8');

--- a/tests/cases/action/RequestTest.php
+++ b/tests/cases/action/RequestTest.php
@@ -156,7 +156,7 @@ class RequestTest extends \lithium\test\Unit {
 
 	public function testBase() {
 		$request = new Request(array('env' => array('PHP_SELF' => '/index.php')));
-		$this->assertFalse($request->env('base'));
+		$this->assertEmpty($request->env('base'));
 	}
 
 	public function testBaseWithDirectory() {
@@ -414,7 +414,7 @@ class RequestTest extends \lithium\test\Unit {
 
 	public function testMagicParamsAccess() {
 		$this->assertNull($this->request->action);
-		$this->assertFalse(isset($this->request->params['action']));
+		$this->assertArrayNotHasKey('action', $this->request->params);
 		$this->assertFalse(isset($this->request->action));
 
 		$expected = $this->request->params['action'] = 'index';
@@ -908,7 +908,7 @@ class RequestTest extends \lithium\test\Unit {
 				'CONTENT_TYPE' => 'application/json; charset=UTF-8',
 				'REQUEST_METHOD' => $method
 			)));
-			$this->assertFalse($request->data);
+			$this->assertEmpty($request->data);
 		}
 	}
 
@@ -1001,7 +1001,7 @@ class RequestTest extends \lithium\test\Unit {
 		);
 		$request = new Request(array('env' => array('HTTP_ACCEPT' => join(',', $chrome))));
 		$this->assertEqual('html', $request->accepts());
-		$this->assertTrue(array_search('text/plain', $request->accepts(true)), 4);
+		$this->assertNotEmpty(array_search('text/plain', $request->accepts(true)), 4);
 
 		$request = new Request(array('env' => array('HTTP_ACCEPT' => join(',', $safari))));
 		$this->assertEqual('html', $request->accepts());

--- a/tests/cases/analysis/InspectorTest.php
+++ b/tests/cases/analysis/InspectorTest.php
@@ -48,7 +48,7 @@ class InspectorTest extends \lithium\test\Unit {
 
 	public function testMethodInspection() {
 		$result = Inspector::methods($this, null);
-		$this->assertTrue($result[0] instanceof ReflectionMethod);
+		$this->assertInstanceOf('ReflectionMethod', $result[0]);
 
 		$result = Inspector::info('lithium\core\Object::_init()');
 		$expected = '_init';
@@ -165,7 +165,7 @@ class InspectorTest extends \lithium\test\Unit {
 		$this->assertEqual(array(__CLASS__ => __FILE__), $result);
 
 		$result = Inspector::classes(array('file' => __FILE__, 'group' => 'files'));
-		$this->assertEqual(1, count($result));
+		$this->assertCount(1, $result);
 		$this->assertEqual(__FILE__, key($result));
 
 		$result = Inspector::classes(array('file' => __FILE__, 'group' => 'foo'));
@@ -207,7 +207,7 @@ class InspectorTest extends \lithium\test\Unit {
 
 		$info = Inspector::info('\lithium\analysis\Inspector');
 		$result = str_replace('\\', '/', $info['file']);
-		$this->assertTrue(strpos($result, '/analysis/Inspector.php'));
+		$this->assertNotEmpty(strpos($result, '/analysis/Inspector.php'));
 		$this->assertEqual('lithium\analysis', $info['namespace']);
 		$this->assertEqual('Inspector', $info['shortName']);
 

--- a/tests/cases/analysis/LoggerTest.php
+++ b/tests/cases/analysis/LoggerTest.php
@@ -62,14 +62,14 @@ class LoggerTest extends \lithium\test\Unit {
 		$this->assertNull($result);
 
 		$result = Logger::config();
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 
 		$this->assertFalse(Logger::write('info', 'Test message.'));
 	}
 
 	public function testWrite() {
 		$result = Logger::write('info', 'value');
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 	}
 
 	public function testIntegrationWriteFile() {
@@ -82,14 +82,14 @@ class LoggerTest extends \lithium\test\Unit {
 		Logger::config($config);
 
 		$result = Logger::write('info', 'Message line 1');
-		$this->assertTrue(file_exists($base . '/info.log'));
+		$this->assertFileExists($base . '/info.log');
 
 		$expected = "Message line 1\n";
 		$result = file_get_contents($base . '/info.log');
 		$this->assertEqual($expected, $result);
 
 		$result = Logger::write('info', 'Message line 2');
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 
 		$expected = "Message line 1\nMessage line 2\n";
 		$result = file_get_contents($base . '/info.log');
@@ -114,12 +114,12 @@ class LoggerTest extends \lithium\test\Unit {
 			'format' => "{:message}\n"
 		)));
 
-		$this->assertFalse(file_exists($base . '/info.log'));
+		$this->assertFileNotExists($base . '/info.log');
 
-		$this->assertFalse(Logger::write('info', 'Message line 1'));
-		$this->assertFalse(file_exists($base . '/info.log'));
+		$this->assertEmpty(Logger::write('info', 'Message line 1'));
+		$this->assertFileNotExists($base . '/info.log');
 
-		$this->assertTrue(Logger::write(null, 'Message line 1', array('name' => 'default')));
+		$this->assertNotEmpty(Logger::write(null, 'Message line 1', array('name' => 'default')));
 
 		$expected = "Message line 1\n";
 		$result = file_get_contents($base . '/.log');
@@ -147,13 +147,13 @@ class LoggerTest extends \lithium\test\Unit {
 			),
 		));
 
-		$this->assertFalse(file_exists($base . '/info_default.log'));
+		$this->assertFileNotExists($base . '/info_default.log');
 
-		$this->assertTrue(Logger::write('info', 'Default Message line 1', array(
+		$this->assertNotEmpty(Logger::write('info', 'Default Message line 1', array(
 			'name' => 'default'
 		)));
 
-		$this->assertTrue(file_exists($base . '/info_default.log'));
+		$this->assertFileExists($base . '/info_default.log');
 
 		$expected = "Default Message line 1\n";
 		$result = file_get_contents($base . '/info_default.log');
@@ -182,13 +182,13 @@ class LoggerTest extends \lithium\test\Unit {
 			),
 		));
 
-		$this->assertFalse(file_exists($base . '/info_secondary.log'));
+		$this->assertFileNotExists($base . '/info_secondary.log');
 
-		$this->assertTrue(Logger::write('info', 'Secondary Message line 1', array(
+		$this->assertNotEmpty(Logger::write('info', 'Secondary Message line 1', array(
 			'name' => 'secondary'
 		)));
 
-		$this->assertTrue(file_exists($base . '/info_secondary.log'));
+		$this->assertFileExists($base . '/info_secondary.log');
 
 		$expected = "Secondary Message line 1\n";
 		$result = file_get_contents($base . '/info_secondary.log');

--- a/tests/cases/analysis/ParserTest.php
+++ b/tests/cases/analysis/ParserTest.php
@@ -54,7 +54,7 @@ class ParserTest extends \lithium\test\Unit {
 
 	public function testFullTokenization() {
 		$result = Parser::tokenize('$foo = function() {};');
-		$this->assertEqual(11, count($result));
+		$this->assertCount(11, $result);
 
 		$expected = array(
 			'id' => T_VARIABLE,
@@ -70,7 +70,7 @@ class ParserTest extends \lithium\test\Unit {
 		$code = '$defaults = array("id" => "foo", "name" => "bar", \'count\' => 5);';
 		$result = Parser::tokenize($code);
 
-		$this->assertEqual(27, count($result));
+		$this->assertCount(27, $result);
 		$this->assertEqual('T_VARIABLE', $result[0]['name']);
 		$this->assertEqual('$defaults', $result[0]['content']);
 	}

--- a/tests/cases/analysis/logger/adapter/CacheTest.php
+++ b/tests/cases/analysis/logger/adapter/CacheTest.php
@@ -58,8 +58,7 @@ class CacheTest extends \lithium\test\Unit {
 	 */
 	public function testConfiguration() {
 		$loggers = Logger::config();
-		$result = isset($loggers['cachelog']);
-		$this->assertTrue($result);
+		$this->assertArrayHasKey('cachelog', $loggers);
 	}
 
 	/**
@@ -69,7 +68,7 @@ class CacheTest extends \lithium\test\Unit {
 	public function testWrite() {
 		$message = "CacheLog test message...";
 		$result = Logger::write('info', $message, array('name' => 'cachelog'));
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 		$result = CacheStorage::read('cachelog', 'cachelog_testkey');
 		$this->assertEqual($message, $result);
 	}

--- a/tests/cases/analysis/logger/adapter/FirePhpTest.php
+++ b/tests/cases/analysis/logger/adapter/FirePhpTest.php
@@ -38,8 +38,7 @@ class FirePhpTest extends \lithium\test\Unit {
 	 */
 	public function testConfiguration() {
 		$loggers = Logger::config();
-		$result = isset($loggers['firephp']);
-		$this->assertTrue($result);
+		$this->assertArrayHasKey('firephp', $loggers);
 	}
 
 	/**
@@ -51,8 +50,8 @@ class FirePhpTest extends \lithium\test\Unit {
 	public function testWrite() {
 		$response = new Response();
 		$result = Logger::write('debug', 'FirePhp to the rescue!', array('name' => 'firephp'));
-		$this->assertTrue($result);
-		$this->assertFalse($response->headers());
+		$this->assertNotEmpty($result);
+		$this->assertEmpty($response->headers());
 
 		$host = 'meta.firephp.org';
 		$expected = array(
@@ -65,7 +64,7 @@ class FirePhpTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $response->headers());
 
 		$result = Logger::write('debug', 'Add this immediately.', array('name' => 'firephp'));
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 		$expected[] = 'X-Wf-1-1-1-2: 40|[{"Type":"LOG"},"Add this immediately."]|';
 		$this->assertEqual($expected, $response->headers());
 	}

--- a/tests/cases/analysis/logger/adapter/SyslogTest.php
+++ b/tests/cases/analysis/logger/adapter/SyslogTest.php
@@ -54,7 +54,7 @@ class SyslogTest extends \lithium\test\Unit {
 
 	public function testWrite() {
 		$result = Logger::write('info', 'SyslogTest message...', array('name' => 'syslog'));
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 	}
 }
 

--- a/tests/cases/console/CommandTest.php
+++ b/tests/cases/console/CommandTest.php
@@ -9,7 +9,6 @@
 namespace lithium\tests\cases\console;
 
 use lithium\console\Request;
-use lithium\console\Response;
 use lithium\tests\mocks\console\MockCommand;
 
 class CommandTest extends \lithium\test\Unit {
@@ -31,7 +30,7 @@ class CommandTest extends \lithium\test\Unit {
 			'case' => 'lithium.tests.cases.console.CommandTest'
 		);
 		$command = new MockCommand(array('request' => $this->request));
-		$this->assertTrue(!empty($command->case));
+		$this->assertNotEmpty($command->case);
 	}
 
 	public function testInvoke() {
@@ -39,7 +38,7 @@ class CommandTest extends \lithium\test\Unit {
 		$response = $command('testRun');
 
 		$result = $response;
-		$this->assertTrue($result instanceof Response);
+		$this->assertInstanceOf('lithium\console\Response', $result);
 
 		$expected = 'testRun';
 		$result = $response->testAction;
@@ -152,7 +151,7 @@ class CommandTest extends \lithium\test\Unit {
 		$command = new MockCommand(array('request' => $this->request));
 		$return = $command->__invoke('_help');
 
-		$this->assertTrue($return instanceOf \lithium\tests\mocks\console\MockResponse);
+		$this->assertInstanceOf('lithium\tests\mocks\console\MockResponse', $return);
 
 		$expected = "DESCRIPTION.*This is the Mock Command";
 		$result = $command->response->output;

--- a/tests/cases/console/DispatcherTest.php
+++ b/tests/cases/console/DispatcherTest.php
@@ -109,7 +109,7 @@ class DispatcherTest extends \lithium\test\Unit {
 				'sample-task-with-optional-args'
 			)
 		)));
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 
 		$result = Dispatcher::run(new Request(array(
 			'args' => array(
@@ -117,7 +117,7 @@ class DispatcherTest extends \lithium\test\Unit {
 				'sample_task_with_optional_args'
 			)
 		)));
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 	}
 
 	public function testEnvironmentIsSet() {

--- a/tests/cases/console/RequestTest.php
+++ b/tests/cases/console/RequestTest.php
@@ -45,7 +45,7 @@ class RequestTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 
 		$result = $request->env();
-		$this->assertTrue(!empty($result));
+		$this->assertNotEmpty($result);
 
 		$expected = getcwd();
 		$result = $result['working'];
@@ -134,7 +134,7 @@ class RequestTest extends \lithium\test\Unit {
 
 		$stream = fopen($this->streams['input'], 'w+');
 		$request = new Request(array('input' => $stream));
-		$this->assertTrue(is_resource($request->input));
+		$this->assertInternalType('resource', $request->input);
 		$this->assertEqual($stream, $request->input);
 
 		$this->assertEqual(2, fwrite($request->input, 'ok'));
@@ -179,7 +179,7 @@ class RequestTest extends \lithium\test\Unit {
 	public function testTemporaryFileStructureExists() {
 		$resources = Libraries::get(true, 'resources');
 		$template = $resources . '/tmp/cache/templates/';
-		$this->assert(is_dir($template));
+		$this->assertFileExists($template);
 	}
 }
 

--- a/tests/cases/console/ResponseTest.php
+++ b/tests/cases/console/ResponseTest.php
@@ -32,8 +32,8 @@ class ResponseTest extends \lithium\test\Unit {
 
 	public function testConstructWithoutConfig() {
 		$response = new Response();
-		$this->assertTrue(is_resource($response->output));
-		$this->assertTrue(is_resource($response->error));
+		$this->assertInternalType('resource', $response->output);
+		$this->assertInternalType('resource', $response->error);
 	}
 
 	public function testConstructWithConfigOutput() {
@@ -44,7 +44,7 @@ class ResponseTest extends \lithium\test\Unit {
 		$response = new Response(array(
 			'output' => $stream
 		));
-		$this->assertTrue(is_resource($response->output));
+		$this->assertInternalType('resource', $response->output);
 		$this->assertEqual($stream, $response->output);
 
 	}
@@ -55,7 +55,7 @@ class ResponseTest extends \lithium\test\Unit {
 
 		$stream = fopen($this->streams['error'], 'w');
 		$response = new Response(array('error' => $stream));
-		$this->assertTrue(is_resource($response->error));
+		$this->assertInternalType('resource', $response->error);
 		$this->assertEqual($stream, $response->error);
 	}
 
@@ -64,7 +64,7 @@ class ResponseTest extends \lithium\test\Unit {
 		$this->skipIf(!is_writable($base), "Path `{$base}` is not writable.");
 
 		$response = new Response(array('output' => fopen($this->streams['output'], 'w+')));
-		$this->assertTrue(is_resource($response->output));
+		$this->assertInternalType('resource', $response->output);
 
 
 		$this->assertEqual(2, $response->output('ok'));
@@ -76,7 +76,7 @@ class ResponseTest extends \lithium\test\Unit {
 		$this->skipIf(!is_writable($base), "Path `{$base}` is not writable.");
 
 		$response = new Response(array('error' => fopen($this->streams['error'], 'w+')));
-		$this->assertTrue(is_resource($response->error));
+		$this->assertInternalType('resource', $response->error);
 		$this->assertEqual(2, $response->error('ok'));
 		$this->assertEqual('ok', file_get_contents($this->streams['error']));
 	}

--- a/tests/cases/console/command/CreateTest.php
+++ b/tests/cases/console/command/CreateTest.php
@@ -90,10 +90,10 @@ class CreateTest extends \lithium\test\Unit {
 			'class' => 'PostTest',
 			'methods' => "\tpublic function testCreate() {\n\n\t}\n"
 		));
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 
 		$result = $this->_testPath . '/create_test/tests/cases/models/PostTest.php';
-		$this->assertTrue(file_exists($result));
+		$this->assertFileExists($result);
 
 		$this->_cleanUp();
 	}
@@ -105,7 +105,7 @@ class CreateTest extends \lithium\test\Unit {
 		$this->assertFalse($result);
 
 		$result = $create->response->output;
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 	}
 
 	public function testRunNotSaved() {
@@ -138,7 +138,7 @@ class CreateTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 
 		$result = $this->_testPath . '/create_test/models/Posts.php';
-		$this->assertTrue(file_exists($result));
+		$this->assertFileExists($result);
 	}
 
 	public function testRunWithTestModelCommand() {
@@ -156,7 +156,7 @@ class CreateTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 
 		$result = $this->_testPath . '/create_test/tests/cases/models/PostsTest.php';
-		$this->assertTrue(file_exists($result));
+		$this->assertFileExists($result);
 	}
 
 	public function testRunWithTestControllerCommand() {
@@ -174,7 +174,7 @@ class CreateTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 
 		$result = $this->_testPath . '/create_test/tests/cases/controllers/PostsControllerTest.php';
-		$this->assertTrue(file_exists($result));
+		$this->assertFileExists($result);
 	}
 
 	public function testRunWithTestOtherCommand() {
@@ -191,7 +191,7 @@ class CreateTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 
 		$result = $this->_testPath . '/create_test/tests/cases/something/PostsTest.php';
-		$this->assertTrue(file_exists($result));
+		$this->assertFileExists($result);
 	}
 
 	public function testRunAll() {
@@ -204,16 +204,16 @@ class CreateTest extends \lithium\test\Unit {
 		$create->run('Posts');
 
 		$result = $this->_testPath . '/create_test/models/Posts.php';
-		$this->assertTrue(file_exists($result));
+		$this->assertFileExists($result);
 
 		$result = $this->_testPath . '/create_test/controllers/PostsController.php';
-		$this->assertTrue(file_exists($result));
+		$this->assertFileExists($result);
 
 		$result = $this->_testPath . '/create_test/tests/cases/models/PostsTest.php';
-		$this->assertTrue(file_exists($result));
+		$this->assertFileExists($result);
 
 		$result = $this->_testPath . '/create_test/tests/cases/controllers/PostsControllerTest.php';
-		$this->assertTrue(file_exists($result));
+		$this->assertFileExists($result);
 	}
 }
 

--- a/tests/cases/console/command/LibraryTest.php
+++ b/tests/cases/console/command/LibraryTest.php
@@ -61,7 +61,7 @@ class LibraryTest extends \lithium\test\Unit {
 
 	public function testConfigServer() {
 		$result = $this->library->config('server', 'lab.lithify.me');
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 
 		$expected = array('servers' => array('lab.lithify.me' => true));
 		$result = json_decode(file_get_contents($this->testConf), true);
@@ -151,7 +151,7 @@ class LibraryTest extends \lithium\test\Unit {
 
 	protected function _assertFileContents($filepath, $expected) {
 		$content = file_get_contents($filepath);
-		$this->assertTrue(strpos($content, $expected));
+		$this->assertContains($expected, $content);
 	}
 
 	public function testArchive() {
@@ -182,18 +182,16 @@ class LibraryTest extends \lithium\test\Unit {
 		);
 		$this->assertTrue($result);
 
-		$this->assertTrue(file_exists($this->_testPath . '/new'));
+		$this->assertFileExists($this->_testPath . '/new');
 
 		$expected = "new created in {$this->_testPath} from ";
 		$expected .= "{$this->_testPath}/library_test.phar.gz\n";
 		$result = $this->library->response->output;
 		$this->assertEqual($expected, $result);
 
-		$result = file_exists($this->_testPath . '/new/.htaccess');
-		$this->assertTrue($result);
+		$this->assertFileExists($this->_testPath . '/new/.htaccess');
 
-		$result = file_exists($this->_testPath . '/new/.DS_Store');
-		$this->assertFalse($result);
+		$this->assertFileNotExists($this->_testPath . '/new/.DS_Store');
 
 		Phar::unlinkArchive($this->_testPath . '/library_test.phar.gz');
 	}
@@ -232,7 +230,7 @@ class LibraryTest extends \lithium\test\Unit {
 		$result = $app->extract();
 		$this->assertTrue($result);
 
-		$this->assertTrue(file_exists($this->_testPath . '/new'));
+		$this->assertFileExists($this->_testPath . '/new');
 
 		$path = realpath($this->_testPath);
 		$tplPath = realpath(LITHIUM_LIBRARY_PATH . '/lithium/console/command/create/template');
@@ -272,8 +270,7 @@ class LibraryTest extends \lithium\test\Unit {
 		$result = $this->library->formulate($path);
 		$this->assertTrue($result);
 
-		$result = file_exists($path . '/config/library_test_plugin.json');
-		$this->assertTrue($result);
+		$this->assertFileExists($path . '/config/library_test_plugin.json');
 
 		$this->_cleanUp();
 	}
@@ -297,8 +294,7 @@ class LibraryTest extends \lithium\test\Unit {
 		$result = $this->library->formulate($path);
 		$this->assertTrue($result);
 
-		$result = file_exists($path . '/config/library_test_plugin.json');
-		$this->assertTrue($result);
+		$this->assertFileExists($path . '/config/library_test_plugin.json');
 	}
 
 	public function testNoFormulate() {
@@ -306,8 +302,7 @@ class LibraryTest extends \lithium\test\Unit {
 		$result = $this->library->formulate($path);
 		$this->assertFalse($result);
 
-		$result = file_exists($path . '/config/library_test_no_plugin.json');
-		$this->assertFalse($result);
+		$this->assertFileNotExists($path . '/config/library_test_no_plugin.json');
 
 		$expected = '/Formula for library_test_no_plugin not created/';
 		$result = $this->library->response->error;
@@ -327,8 +322,7 @@ class LibraryTest extends \lithium\test\Unit {
 		$result = $this->library->formulate($path);
 		$this->assertFalse($result);
 
-		$result = file_exists($path . '/config/library_test_plugin.json');
-		$this->assertFalse($result);
+		$this->assertFileNotExists($path . '/config/library_test_plugin.json');
 
 		$expected = '/Formula for library_test_no_plugin not created/';
 		$result = $this->library->response->error;
@@ -342,7 +336,7 @@ class LibraryTest extends \lithium\test\Unit {
 		$this->library->push();
 		$expected = 'please supply a name';
 		$result = $this->library->response->output;
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 	}
 
 	public function testPush() {
@@ -363,7 +357,7 @@ class LibraryTest extends \lithium\test\Unit {
 				)
 			))
 		);
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 
 		$result = $this->library->archive(
 			$this->_testPath . '/library_test_plugin',
@@ -376,20 +370,18 @@ class LibraryTest extends \lithium\test\Unit {
 		$result = $this->library->response->output;
 		$this->assertEqual($expected, $result);
 
-		$result = file_exists($this->_testPath . '/library_test_plugin.phar.gz');
-		$this->assertTrue($result);
+		$this->assertFileExists($this->_testPath . '/library_test_plugin.phar.gz');
 		$this->library->response->output = null;
 
 		$result = $this->library->push('library_test_plugin');
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 
 		$expected = "library_test_plugin added to {$this->library->server}.\n";
 		$expected .= "See http://{$this->library->server}/lab/plugins/view/{$result->id}\n";
 		$result = $this->library->response->output;
 		$this->assertEqual($expected, $result);
 
-		$result = is_dir($this->_testPath . '/library_test_plugin');
-		$this->assertTrue($result);
+		$this->assertFileExists($this->_testPath . '/library_test_plugin');
 
 		$this->_cleanUp('tests/library_test_plugin');
 		rmdir($this->_testPath . '/library_test_plugin');
@@ -405,11 +397,9 @@ class LibraryTest extends \lithium\test\Unit {
 		$result = $this->library->install('library_test_plugin');
 		$this->assertTrue($result);
 
-		$result = file_exists($this->_testPath . '/library_test_plugin.phar.gz');
-		$this->assertTrue($result);
+		$this->assertFileExists($this->_testPath . '/library_test_plugin.phar.gz');
 
-		$result = is_dir($this->_testPath . '/library_test_plugin');
-		$this->assertTrue($result);
+		$this->assertFileExists($this->_testPath . '/library_test_plugin');
 
 		Phar::unlinkArchive($this->_testPath . '/library_test_plugin.phar');
 		Phar::unlinkArchive($this->_testPath . '/library_test_plugin.phar.gz');
@@ -445,8 +435,7 @@ class LibraryTest extends \lithium\test\Unit {
 		$result = $this->library->response->output;
 		$this->assertEqual($expected, $result);
 
-		$result = is_dir($this->_testPath . '/li3_lab');
-		$this->assertFalse($result);
+		$this->assertFileNotExists($this->_testPath . '/li3_lab');
 		$this->_cleanUp();
 	}
 
@@ -461,8 +450,7 @@ class LibraryTest extends \lithium\test\Unit {
 		$result = $this->library->install('li3_docs');
 		$this->assertTrue($result);
 
-		$result = is_dir($this->_testPath . '/li3_docs');
-		$this->assertTrue($result);
+		$this->assertFileExists($this->_testPath . '/li3_docs');
 		$this->_cleanUp();
 	}
 
@@ -599,7 +587,7 @@ test;
 				)
 			))
 		);
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 
 		$result = $this->library->archive(
 			$this->_testPath . '/library_test_plugin',
@@ -607,22 +595,20 @@ test;
 		);
 		$this->assertTrue($result);
 
-		$result = file_exists($this->_testPath . '/library_test_plugin.phar.gz');
-		$this->assertTrue($result);
+		$this->assertFileExists($this->_testPath . '/library_test_plugin.phar.gz');
 
 		$this->library->response->output = null;
 		$this->library->username = 'gwoo';
 		$this->library->password = 'password';
 		$result = $this->library->push('library_test_plugin');
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 
 		$expected = "library_test_plugin added to {$this->library->server}.\n";
 		$expected .= "See http://{$this->library->server}/lab/plugins/view/{$result->id}\n";
 		$result = $this->library->response->output;
 		$this->assertEqual($expected, $result);
 
-		$result = file_exists($this->_testPath . '/library_test_plugin');
-		$this->assertTrue($result);
+		$this->assertFileExists($this->_testPath . '/library_test_plugin');
 
 		$this->library->response->error = null;
 		$this->library->response->output = null;
@@ -635,8 +621,7 @@ test;
 		$result = $this->library->response->error;
 		$this->assertEqual($expected, $result);
 
-		$result = file_exists($this->_testPath . '/library_test_plugin');
-		$this->assertTrue($result);
+		$this->assertFileExists($this->_testPath . '/library_test_plugin');
 
 		Phar::unlinkArchive($this->_testPath . '/library_test_plugin.phar');
 		Phar::unlinkArchive($this->_testPath . '/library_test_plugin.phar.gz');
@@ -665,7 +650,7 @@ test;
 				'summary' => 'something'
 			))
 		);
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 
 		$result = $this->library->archive(
 			$this->_testPath . '/library_test_plugin',
@@ -678,8 +663,7 @@ test;
 		$result = $this->library->response->output;
 		$this->assertEqual($expected, $result);
 
-		$result = file_exists($this->_testPath . '/library_test_plugin.phar.gz');
-		$this->assertTrue($result);
+		$this->assertFileExists($this->_testPath . '/library_test_plugin.phar.gz');
 		$this->library->response->output = null;
 
 		$result = $this->library->push('library_test_plugin');
@@ -689,8 +673,7 @@ test;
 		$result = $this->library->response->error;
 		$this->assertPattern($expected, $result);
 
-		$result = is_dir($this->_testPath . '/library_test_plugin');
-		$this->assertTrue($result);
+		$this->assertFileExists($this->_testPath . '/library_test_plugin');
 
 		Phar::unlinkArchive($this->_testPath . '/library_test_plugin.phar');
 		Phar::unlinkArchive($this->_testPath . '/library_test_plugin.phar.gz');

--- a/tests/cases/console/command/RouteTest.php
+++ b/tests/cases/console/command/RouteTest.php
@@ -98,17 +98,17 @@ class RouteTest extends \lithium\test\Unit {
 	 * routes are connected to the router.
 	 */
 	public function testRouteLoading() {
-		$this->assertFalse(Router::get());
+		$this->assertEmpty(Router::get());
 
 		$command = new Route(array('routes' => $this->_config['routes']));
-		$this->assertEqual(4, count(Router::get()));
+		$this->assertCount(4, Router::get());
 
 		Router::reset();
 
 		$request = new Request();
 		$request->params['env'] = 'production';
 		$command = new Route(compact('request') + array('routes' => $this->_config['routes']));
-		$this->assertEqual(2, count(Router::get()));
+		$this->assertCount(2, Router::get());
 	}
 
 	/**

--- a/tests/cases/console/command/TestTest.php
+++ b/tests/cases/console/command/TestTest.php
@@ -183,8 +183,8 @@ class TestTest extends \lithium\test\Unit {
 		$result = $command->response->output;
 		$result = json_decode($result, true);
 
-		$this->assertTrue(isset($result['count']));
-		$this->assertTrue(isset($result['stats']));
+		$this->assertArrayHasKey('count', $result);
+		$this->assertArrayHasKey('stats', $result);
 	}
 
 	public function testPathWithCustomDirectoryName() {

--- a/tests/cases/console/command/g11n/ExtractTest.php
+++ b/tests/cases/console/command/g11n/ExtractTest.php
@@ -112,8 +112,7 @@ EOD;
 		$this->assertPattern($expected, $result);
 
 		$file = "{$this->_path}/destination/message_default.pot";
-		$result = file_exists($file);
-		$this->assertTrue($result);
+		$this->assertFileExists($file);
 
 		$result = file_get_contents($file);
 		$expected = '/msgid "Apples are green\."/';
@@ -123,7 +122,7 @@ EOD;
 		$this->assertPattern($expected, $result);
 
 		$result = $this->command->response->error;
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 	}
 }
 

--- a/tests/cases/core/AdaptableTest.php
+++ b/tests/cases/core/AdaptableTest.php
@@ -13,8 +13,6 @@ use lithium\core\Adaptable;
 use lithium\storage\cache\adapter\Memory;
 use lithium\tests\mocks\core\MockAdapter;
 use lithium\tests\mocks\core\MockStrategy;
-use lithium\tests\mocks\storage\cache\strategy\MockSerializer;
-use lithium\tests\mocks\storage\cache\strategy\MockConfigurizer;
 use lithium\test\Mocker;
 
 class AdaptableTest extends \lithium\test\Unit {
@@ -25,7 +23,7 @@ class AdaptableTest extends \lithium\test\Unit {
 	}
 
 	public function testConfig() {
-		$this->assertFalse($this->adaptable->config());
+		$this->assertEmpty($this->adaptable->config());
 
 		$items = array(array(
 			'adapter' => 'some\adapter',
@@ -60,7 +58,7 @@ class AdaptableTest extends \lithium\test\Unit {
 
 		$result = $this->adaptable->reset();
 		$this->assertNull($result);
-		$this->assertFalse($this->adaptable->config());
+		$this->assertEmpty($this->adaptable->config());
 	}
 
 	public function testNonExistentConfig() {
@@ -114,9 +112,10 @@ class AdaptableTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 
 		$result = $strategy::strategies('default');
-		$this->assertTrue($result instanceof SplDoublyLinkedList);
-		$this->assertEqual(count($result), 1);
-		$this->assertTrue($result->top() instanceof MockSerializer);
+		$this->assertInstanceOf('SplDoublyLinkedList', $result);
+		$this->assertCount(1, $result);
+		$obj = $result->top();
+		$this->assertInstanceOf('lithium\tests\mocks\storage\cache\strategy\MockSerializer', $obj);
 	}
 
 	public function testInvalidStrategy() {
@@ -133,14 +132,15 @@ class AdaptableTest extends \lithium\test\Unit {
 		$this->expectException($message);
 
 		$result = $strategy::strategies('default');
-		$this->assertTrue($result instanceof SplDoublyLinkedList);
+		$this->assertInstanceOf('SplDoublyLinkedList', $result);
 	}
 
 	public function testStrategyConstructionSettings() {
+		$mockConfigurizer = 'lithium\tests\mocks\storage\cache\strategy\MockConfigurizer';
 		$strategy = new MockStrategy();
 		$items = array('default' => array(
 			'strategies' => array(
-				'lithium\tests\mocks\storage\cache\strategy\MockConfigurizer' => array(
+				$mockConfigurizer => array(
 					'key1' => 'value1', 'key2' => 'value2'
 				)
 			),
@@ -153,9 +153,9 @@ class AdaptableTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 
 		$result = $strategy::strategies('default');
-		$this->assertTrue($result instanceof SplDoublyLinkedList);
+		$this->assertInstanceOf('SplDoublyLinkedList', $result);
 		$this->assertEqual(count($result), 1);
-		$this->assertTrue($result->top() instanceof MockConfigurizer);
+		$this->assertInstanceOf($mockConfigurizer, $result->top());
 	}
 
 	public function testNonExistentStrategyConfiguration() {

--- a/tests/cases/core/EnvironmentTest.php
+++ b/tests/cases/core/EnvironmentTest.php
@@ -229,7 +229,7 @@ class EnvironmentTest extends \lithium\test\Unit {
 		$this->assertEqual(Environment::get(true), Environment::get('development'));
 
 		Environment::set('production');
-		$this->assertFalse(Environment::get(true));
+		$this->assertEmpty(Environment::get(true));
 	}
 }
 

--- a/tests/cases/core/ErrorHandlerTest.php
+++ b/tests/cases/core/ErrorHandlerTest.php
@@ -43,14 +43,14 @@ class ErrorHandlerTest extends \lithium\test\Unit {
 
 		ErrorHandler::handle(new Exception('Test!'));
 
-		$this->assertEqual(1, count($this->errors));
+		$this->assertCount(1, $this->errors);
 		$result = end($this->errors);
 		$expected = 'Test!';
 		$this->assertEqual($expected, $result['message']);
 
 		$this->expectException('/Test/');
 		trigger_error('Test warning!', E_USER_WARNING);
-		$this->assertEqual(1, count($this->errors));
+		$this->assertCount(1, $this->errors);
 	}
 
 	public function testExceptionSubclassCatching() {
@@ -63,7 +63,7 @@ class ErrorHandlerTest extends \lithium\test\Unit {
 		)));
 		ErrorHandler::handle(new UnexpectedValueException('Test subclass'));
 
-		$this->assertEqual(1, count($this->errors));
+		$this->assertCount(1, $this->errors);
 		$result = end($this->errors);
 		$expected = 'Test subclass';
 		$this->assertEqual($expected, $result['message']);
@@ -81,19 +81,19 @@ class ErrorHandlerTest extends \lithium\test\Unit {
 		)));
 
 		file_get_contents(false);
-		$this->assertEqual(1, count($this->errors));
+		$this->assertCount(1, $this->errors);
 
 		$result = end($this->errors);
 		$this->assertPattern('/Filename cannot be empty/', $result['message']);
 
 		trigger_error('Test warning', E_USER_WARNING);
-		$this->assertEqual(2, count($this->errors));
+		$this->assertCount(2, $this->errors);
 
 		$result = end($this->errors);
 		$this->assertEqual('Test warning', $result['message']);
 
 		trigger_error('Test notice', E_USER_NOTICE);
-		$this->assertEqual(2, count($this->errors));
+		$this->assertCount(2, $this->errors);
 	}
 
 	public function testApply() {
@@ -135,17 +135,17 @@ class ErrorHandlerTest extends \lithium\test\Unit {
 
 		$defaultChecks = 4;
 		$this->assertEqual($defaultChecks, count($checks));
-		$this->assertTrue($checks['type'] instanceof Closure);
+		$this->assertInstanceOf('Closure', $checks['type']);
 
 		$checks = MockErrorHandler::checks(array('foo' => 'bar'));
-		$this->assertEqual(1, count($checks));
+		$this->assertCount(1, $checks);
 		$this->assertFalse(isset($checks['type']));
 
 		MockErrorHandler::reset();
 
 		$checks = MockErrorHandler::checks();
 		$this->assertEqual($defaultChecks, count($checks));
-		$this->assertTrue($checks['type'] instanceof Closure);
+		$this->assertInstanceOf('Closure', $checks['type']);
 	}
 
 	public function testErrorTrapping() {
@@ -158,9 +158,9 @@ class ErrorHandlerTest extends \lithium\test\Unit {
 		));
 		ErrorHandler::run(array('trapErrors' => true));
 
-		$this->assertEqual(0, count($this->errors));
+		$this->assertCount(0, $this->errors);
 		list($foo, $bar) = array('baz');
-		$this->assertEqual(1, count($this->errors));
+		$this->assertCount(1, $this->errors);
 	}
 
 	public function testRenderedOutput() {

--- a/tests/cases/core/LibrariesTest.php
+++ b/tests/cases/core/LibrariesTest.php
@@ -12,7 +12,6 @@ use stdClass;
 use SplFileInfo;
 use lithium\util\Inflector;
 use lithium\core\Libraries;
-use lithium\template\view\adapter\Simple;
 
 class LibrariesTest extends \lithium\test\Unit {
 
@@ -35,13 +34,13 @@ class LibrariesTest extends \lithium\test\Unit {
 		$invalidDS = $ds == '/' ? '\\' : '/';
 
 		$result = Libraries::path('\lithium\core\Libraries');
-		$this->assertTrue(strpos($result, "${ds}lithium${ds}core${ds}Libraries.php"));
-		$this->assertTrue(file_exists($result));
+		$this->assertNotEmpty(strpos($result, "${ds}lithium${ds}core${ds}Libraries.php"));
+		$this->assertFileExists($result);
 		$this->assertFalse(strpos($result, $invalidDS));
 
 		$result = Libraries::path('lithium\core\Libraries');
-		$this->assertTrue(strpos($result, "${ds}lithium${ds}core${ds}Libraries.php"));
-		$this->assertTrue(file_exists($result));
+		$this->assertNotEmpty(strpos($result, "${ds}lithium${ds}core${ds}Libraries.php"));
+		$this->assertFileExists($result);
 		$this->assertFalse(strpos($result, $invalidDS));
 	}
 
@@ -143,11 +142,11 @@ class LibrariesTest extends \lithium\test\Unit {
 		$this->assertNull(Libraries::get('foo'));
 
 		$configs = Libraries::get(); // => ['lithium' => ['path' => ...], 'myapp' => [...], ...]
-		$this->assertTrue(isset($configs['lithium']));
+		$this->assertArrayHasKey('lithium', $configs);
 		$this->assertEqual($expected, $configs['lithium']);
 
 		if ($this->hasApp) {
-			$this->assertTrue(isset($configs['app']));
+			$this->assertArrayHasKey('app', $configs);
 		}
 
 		$configs = Libraries::get(array('lithium')); // => ['lithium' => ['path' => '...', ...]]
@@ -158,11 +157,11 @@ class LibrariesTest extends \lithium\test\Unit {
 		$this->assertEqual(array('lithium' => 'lithium\\'), $prefixes);
 
 		$allPre = Libraries::get(null, 'prefix'); // => ['my' => 'my\\', 'lithium' => 'lithium\\']
-		$this->assertTrue($allPre);
+		$this->assertNotEmpty($allPre);
 		$this->assertEqual(array_keys(Libraries::get()), array_keys($allPre));
 
 		foreach ($allPre as $prefix) {
-			$this->assertTrue(is_string($prefix) || is_bool($prefix));
+			$this->assertInternalType('string', $prefix) || is_bool($prefix);
 		}
 
 		$library = Libraries::get('lithium\core\Libraries'); // 'lithium'
@@ -186,18 +185,18 @@ class LibrariesTest extends \lithium\test\Unit {
 	 */
 	public function testLibraryAddRemove() {
 		$lithium = Libraries::get('lithium');
-		$this->assertFalse(empty($lithium));
+		$this->assertNotEmpty($lithium);
 
 		$app = Libraries::get(true);
-		$this->assertFalse(empty($app));
+		$this->assertNotEmpty($app);
 
 		Libraries::remove(array('lithium', 'app'));
 
 		$result = Libraries::get('lithium');
-		$this->assertTrue(empty($result));
+		$this->assertEmpty($result);
 
 		$result = Libraries::get('app');
-		$this->assertTrue(empty($result));
+		$this->assertEmpty($result);
 
 		$result = Libraries::add('lithium', array('bootstrap' => false) + $lithium);
 		$this->assertEqual($lithium, $result);
@@ -255,7 +254,7 @@ class LibrariesTest extends \lithium\test\Unit {
 	 */
 	public function testExcludeNonClassFiles() {
 		$result = Libraries::find('lithium');
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 
 		$result = Libraries::find('lithium', array('namespaces' => true));
 
@@ -266,15 +265,15 @@ class LibrariesTest extends \lithium\test\Unit {
 		$this->assertFalse(in_array('lithium\LICENSE.txt', $result));
 		$this->assertFalse(in_array('lithium\readme.wiki', $result));
 
-		$this->assertFalse(Libraries::find('lithium'));
+		$this->assertEmpty(Libraries::find('lithium'));
 		$result = Libraries::find('lithium', array('path' => '/test/filter/reporter/template'));
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 
 		$result = Libraries::find('lithium', array(
 			'path' => '/test/filter/reporter/template',
 			'namespaces' => true
 		));
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 	}
 
 	/**
@@ -289,7 +288,7 @@ class LibrariesTest extends \lithium\test\Unit {
 	 * Tests path caching by calling `path()` twice.
 	 */
 	public function testPathCaching() {
-		$this->assertFalse(Libraries::cache(false));
+		$this->assertEmpty(Libraries::cache(false));
 		$path = Libraries::path(__CLASS__);
 		$this->assertEqual(__FILE__, realpath($path));
 
@@ -357,7 +356,7 @@ class LibrariesTest extends \lithium\test\Unit {
 		$this->assertTrue(in_array('lithium\action\Dispatcher', $classes));
 
 		$this->assertFalse(in_array('lithium\tests\integration\data\SourceTest', $classes));
-		$this->assertFalse(preg_grep('/\w+Test$/', $classes));
+		$this->assertEmpty(preg_grep('/\w+Test$/', $classes));
 
 		$expected = Libraries::find('lithium', array(
 			'filter' => '/\w+Test$/', 'recursive' => true
@@ -387,7 +386,7 @@ class LibrariesTest extends \lithium\test\Unit {
 
 	public function testServiceLocateInstantiation() {
 		$result = Libraries::instance('adapter.template.view', 'Simple');
-		$this->assertTrue($result instanceof Simple);
+		$this->assertInstanceOf('lithium\template\view\adapter\Simple', $result);
 		$this->expectException("Class `Foo` of type `adapter.template.view` not found.");
 		$result = Libraries::instance('adapter.template.view', 'Foo');
 	}
@@ -496,7 +495,7 @@ class LibrariesTest extends \lithium\test\Unit {
 				}
 			}
 		));
-		$this->assertEqual(1, count($result));
+		$this->assertCount(1, $result);
 		$this->assertIdentical(__FILE__, $result[0]->getRealPath());
 	}
 
@@ -513,7 +512,7 @@ class LibrariesTest extends \lithium\test\Unit {
 				}
 			}
 		));
-		$this->assertEqual(1, count($result));
+		$this->assertCount(1, $result);
 		$this->assertIdentical(__FILE__, $result[0]->getRealPath());
 	}
 
@@ -529,9 +528,9 @@ class LibrariesTest extends \lithium\test\Unit {
 			}
 		));
 		$this->assertTrue(count($result) > 3);
-		$this->assertTrue(array_search('controller.txt.php', $result) !== false);
-		$this->assertTrue(array_search('model.txt.php', $result) !== false);
-		$this->assertTrue(array_search('plugin.phar.gz', $result) !== false);
+		$this->assertNotIdentical(array_search('controller.txt.php', $result), false);
+		$this->assertNotIdentical(array_search('model.txt.php', $result), false);
+		$this->assertNotIdentical(array_search('plugin.phar.gz', $result), false);
 	}
 
 	public function testLocateWithDotSyntax() {

--- a/tests/cases/core/ObjectTest.php
+++ b/tests/cases/core/ObjectTest.php
@@ -221,11 +221,11 @@ class ObjectTest extends \lithium\test\Unit {
 			return false;
 		});
 
-		$this->assertIdentical(false, $obj->method2());
+		$this->assertFalse($obj->method2());
 
 		$obj->applyFilter('method2', false);
 
-		$this->assertTrue($obj->method2() !== false);
+		$this->assertNotIdentical($obj->method2(), false);
 	}
 
 	public function testResetMultipleFilters() {
@@ -235,13 +235,13 @@ class ObjectTest extends \lithium\test\Unit {
 			return false;
 		});
 
-		$this->assertIdentical(false, $obj->method2());
-		$this->assertIdentical(false, $obj->manual(array()));
+		$this->assertFalse($obj->method2());
+		$this->assertFalse($obj->manual(array()));
 
 		$obj->applyFilter('method2', false);
 
-		$this->assertTrue($obj->method2() !== false);
-		$this->assertIdentical(false, $obj->manual(array()));
+		$this->assertNotIdentical($obj->method2(), false);
+		$this->assertFalse($obj->manual(array()));
 	}
 
 	public function testResetClass() {
@@ -251,13 +251,13 @@ class ObjectTest extends \lithium\test\Unit {
 			return false;
 		});
 
-		$this->assertIdentical(false, $obj->method2());
-		$this->assertIdentical(false, $obj->manual(array()));
+		$this->assertFalse($obj->method2());
+		$this->assertFalse($obj->manual(array()));
 
 		$obj->applyFilter(false);
 
-		$this->assertTrue($obj->method2() !== false);
-		$this->assertTrue($obj->manual(array()) !== false);
+		$this->assertNotIdentical($obj->method2(), false);
+		$this->assertNotIdentical($obj->manual(array()), false);
 	}
 
 	public function testRespondsTo() {

--- a/tests/cases/core/StaticObjectTest.php
+++ b/tests/cases/core/StaticObjectTest.php
@@ -170,11 +170,11 @@ class StaticObjectTest extends \lithium\test\Unit {
 			return false;
 		});
 
-		$this->assertIdentical(false, $class::method2());
+		$this->assertFalse($class::method2());
 
 		$class::applyFilter('method2', false);
 
-		$this->assertTrue($class::method2() !== false);
+		$this->assertNotIdentical($class::method2(), false);
 	}
 
 	public function testResetMultipleFilters() {
@@ -184,13 +184,13 @@ class StaticObjectTest extends \lithium\test\Unit {
 			return false;
 		});
 
-		$this->assertIdentical(false, $class::method2());
-		$this->assertIdentical(false, $class::manual(array()));
+		$this->assertFalse($class::method2());
+		$this->assertFalse($class::manual(array()));
 
 		$class::applyFilter('method2', false);
 
-		$this->assertTrue($class::method2() !== false);
-		$this->assertIdentical(false, $class::manual(array()));
+		$this->assertNotIdentical($class::method2(), false);
+		$this->assertFalse($class::manual(array()));
 	}
 
 	public function testResetClass() {
@@ -200,13 +200,13 @@ class StaticObjectTest extends \lithium\test\Unit {
 			return false;
 		});
 
-		$this->assertIdentical(false, $class::method2());
-		$this->assertIdentical(false, $class::manual(array()));
+		$this->assertFalse($class::method2());
+		$this->assertFalse($class::manual(array()));
 
 		$class::applyFilter(false);
 
-		$this->assertTrue($class::method2() !== false);
-		$this->assertTrue($class::manual(array()) !== false);
+		$this->assertNotIdentical($class::method2(), false);
+		$this->assertNotIdentical($class::manual(array()), false);
 	}
 
 	public function testRespondsTo() {

--- a/tests/cases/data/ConnectionsTest.php
+++ b/tests/cases/data/ConnectionsTest.php
@@ -10,8 +10,6 @@ namespace lithium\tests\cases\data;
 
 use Exception;
 use lithium\data\Connections;
-use lithium\data\source\Http;
-use lithium\data\source\Mock;
 use lithium\data\source\database\adapter\MySql;
 use lithium\data\source\database\adapter\PostgreSql;
 
@@ -50,13 +48,13 @@ class ConnectionsTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 
 		$result = Connections::get('conn-test');
-		$this->assertTrue($result instanceof Mock);
+		$this->assertInstanceOf('lithium\data\source\Mock', $result);
 
 		$result = Connections::add('conn-test-2', $this->config);
 		$this->assertEqual($expected, $result);
 
 		$result = Connections::get('conn-test-2');
-		$this->assertTrue($result instanceof Mock);
+		$this->assertInstanceOf('lithium\data\source\Mock', $result);
 	}
 
 	public function testConnectionGetAndReset() {
@@ -81,9 +79,9 @@ class ConnectionsTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, Connections::get('conn-test', array('config' => true)));
 
 		$this->assertNull(Connections::reset());
-		$this->assertFalse(Connections::get());
+		$this->assertEmpty(Connections::get());
 
-		$this->assertTrue(is_array(Connections::get()));
+		$this->assertInternalType('array', Connections::get());
 	}
 
 	public function testConnectionAutoInstantiation() {
@@ -91,10 +89,10 @@ class ConnectionsTest extends \lithium\test\Unit {
 		Connections::add('conn-test-2', $this->config);
 
 		$result = Connections::get('conn-test');
-		$this->assertTrue($result instanceof Mock);
+		$this->assertInstanceOf('lithium\data\source\Mock', $result);
 
 		$result = Connections::get('conn-test');
-		$this->assertTrue($result instanceof Mock);
+		$this->assertInstanceOf('lithium\data\source\Mock', $result);
 
 		$this->assertNull(Connections::get('conn-test-2', array('autoCreate' => false)));
 	}
@@ -115,7 +113,7 @@ class ConnectionsTest extends \lithium\test\Unit {
 
 		Connections::add('stream-test', $config);
 		$result = Connections::get('stream-test');
-		$this->assertTrue($result instanceof Http);
+		$this->assertInstanceOf('lithium\data\source\Http', $result);
 		Connections::config(array('stream-test' => false));
 	}
 
@@ -137,7 +135,7 @@ class ConnectionsTest extends \lithium\test\Unit {
 
 	public function testGetNullAdapter() {
 		Connections::reset();
-		$this->assertTrue(Connections::get(false) instanceof Mock);
+		$this->assertInstanceOf('lithium\data\source\Mock', Connections::get(false));
 	}
 
 	protected function _canConnect($host, $port) {

--- a/tests/cases/data/EntityTest.php
+++ b/tests/cases/data/EntityTest.php
@@ -47,14 +47,14 @@ class EntityTest extends \lithium\test\Unit {
 		$this->assertEqual('foo', $entity->test_field);
 		$this->assertEqual(array('test_me' => 'bar'), $entity->test_relationship);
 
-		$this->assertTrue(isset($entity->test_field));
+		$this->assertFalse(isset($entity->field));
 		$this->assertTrue(isset($entity->test_relationship));
 
-		$this->assertFalse(empty($entity->test_field));
-		$this->assertFalse(empty($entity->test_relationship));
+		$this->assertNotEmpty($entity->test_field);
+		$this->assertNotEmpty($entity->test_relationship);
 
-		$this->assertTrue(empty($entity->test_invisible_field));
-		$this->assertTrue(empty($entity->test_invisible_relationship));
+		$this->assertEmpty($entity->test_invisible_field);
+		$this->assertEmpty($entity->test_invisible_relationship);
 	}
 
 	public function testIncrement() {
@@ -152,7 +152,7 @@ class EntityTest extends \lithium\test\Unit {
 		$this->assertEqual(array('foo' => true, 'baz' => true, 'ble' => true), $entity->modified());
 
 		$this->assertTrue($entity->ble->modified('foo'));
-		$this->assertFalse($entity->ble->modified('iak'));
+		$this->assertEmpty($entity->ble->modified('iak'));
 		$this->assertEqual($entity->ble->modified(), array('foo' => true, 'baz' => true));
 
 		$data = array('foo' => 'bar', 'baz' => 'dib'); //it's the default data array in the test

--- a/tests/cases/data/ModelTest.php
+++ b/tests/cases/data/ModelTest.php
@@ -11,10 +11,7 @@ namespace lithium\tests\cases\data;
 use stdClass;
 use lithium\util\Inflector;
 use lithium\data\Model;
-use lithium\data\Entity;
 use lithium\data\Schema;
-use lithium\data\model\Query;
-use lithium\data\entity\Record;
 use lithium\tests\mocks\data\MockTag;
 use lithium\tests\mocks\data\MockPost;
 use lithium\tests\mocks\data\MockComment;
@@ -93,7 +90,7 @@ class ModelTest extends \lithium\test\Unit {
 		$this->assertEqual('post', MockPost::meta('source'));
 
 		MockPost::config(array('meta' => array('source' => false)));
-		$this->assertIdentical(false, MockPost::meta('source'));
+		$this->assertFalse(MockPost::meta('source'));
 
 		MockPost::config(array('meta' => array('source' => null)));
 		$this->assertIdentical('mock_posts', MockPost::meta('source'));
@@ -145,7 +142,7 @@ class ModelTest extends \lithium\test\Unit {
 	public function testInstanceMethods() {
 		MockPost::instanceMethods(array());
 		$methods = MockPost::instanceMethods();
-		$this->assertTrue(empty($methods));
+		$this->assertEmpty($methods);
 
 		MockPost::instanceMethods(array(
 			'first' => array(
@@ -156,14 +153,14 @@ class ModelTest extends \lithium\test\Unit {
 		));
 
 		$methods = MockPost::instanceMethods();
-		$this->assertEqual(2, count($methods));
+		$this->assertCount(2, $methods);
 
 		MockPost::instanceMethods(array(
 			'third' => function($entity) {}
 		));
 
 		$methods = MockPost::instanceMethods();
-		$this->assertEqual(3, count($methods));
+		$this->assertCount(3, $methods);
 	}
 
 	public function testMetaInformation() {
@@ -207,7 +204,7 @@ class ModelTest extends \lithium\test\Unit {
 
 	public function testSchemaLoading() {
 		$result = MockPost::schema();
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 		$this->assertEqual($result->fields(), MockPost::schema()->fields());
 
 		MockPost::config(array('schema' => $this->_altSchema));
@@ -220,8 +217,8 @@ class ModelTest extends \lithium\test\Unit {
 	}
 
 	public function testFieldIntrospection() {
-		$this->assertTrue(MockComment::hasField('comment_id'));
-		$this->assertFalse(MockComment::hasField('foo'));
+		$this->assertNotEmpty(MockComment::hasField('comment_id'));
+		$this->assertEmpty(MockComment::hasField('foo'));
 		$this->assertEqual('comment_id', MockComment::hasField(array('comment_id')));
 	}
 
@@ -251,8 +248,8 @@ class ModelTest extends \lithium\test\Unit {
 		$result = MockComment::relations('belongsTo');
 		$this->assertEqual($expected, $result);
 
-		$this->assertFalse(MockComment::relations('hasMany'));
-		$this->assertFalse(MockPost::relations('belongsTo'));
+		$this->assertEmpty(MockComment::relations('hasMany'));
+		$this->assertEmpty(MockPost::relations('belongsTo'));
 
 		$expected = array(
 			'name' => 'MockPost',
@@ -308,7 +305,7 @@ class ModelTest extends \lithium\test\Unit {
 
 	public function testSimpleFind() {
 		$result = MockPost::find('all');
-		$this->assertTrue($result['query'] instanceof Query);
+		$this->assertInstanceOf('lithium\data\model\Query', $result['query']);
 	}
 
 	public function testMagicFinders() {
@@ -321,7 +318,7 @@ class ModelTest extends \lithium\test\Unit {
 		$this->assertEqual('read', $result['query']->type());
 
 		$result = MockPost::findAllByFoo(13, array('order' => array('created_at' => 'desc')));
-		$this->assertFalse($result['query']->data());
+		$this->assertEmpty($result['query']->data());
 		$this->assertEqual(array('foo' => 13), $result['query']->conditions());
 		$this->assertEqual(array('created_at' => 'desc'), $result['query']->order());
 
@@ -336,7 +333,7 @@ class ModelTest extends \lithium\test\Unit {
 	 */
 	public function testSimpleFindFirst() {
 		$result = MockComment::first();
-		$this->assertTrue($result instanceof Record);
+		$this->assertInstanceOf('lithium\data\entity\Record', $result);
 
 		$expected = 'First comment';
 		$this->assertEqual($expected, $result->text);
@@ -344,8 +341,8 @@ class ModelTest extends \lithium\test\Unit {
 
 	public function testSimpleFindList() {
 		$result = MockComment::find('list');
-		$this->assertTrue(!empty($result));
-		$this->assertTrue(is_array($result));
+		$this->assertNotEmpty($result);
+		$this->assertInternalType('array', $result);
 	}
 
 	public function testFilteredFind() {
@@ -431,9 +428,9 @@ class ModelTest extends \lithium\test\Unit {
 		$post = MockPostForValidates::create();
 
 		$result = $post->validates();
-		$this->assertTrue($result === false);
+		$this->assertFalse($result);
 		$result = $post->errors();
-		$this->assertTrue(!empty($result));
+		$this->assertNotEmpty($result);
 
 		$expected = array(
 			'title' => array('please enter a title'),
@@ -447,9 +444,9 @@ class ModelTest extends \lithium\test\Unit {
 		$post = MockPostForValidates::create(array('title' => 'new post'));
 
 		$result = $post->validates();
-		$this->assertTrue($result === false);
+		$this->assertFalse($result);
 		$result = $post->errors();
-		$this->assertTrue(!empty($result));
+		$this->assertNotEmpty($result);
 
 		$expected = array(
 			'email' => array('email is empty', 'email is not valid')
@@ -462,10 +459,10 @@ class ModelTest extends \lithium\test\Unit {
 		$post = MockPostForValidates::create(array('title' => 'new post', 'email' => 'something'));
 
 		$result = $post->validates();
-		$this->assertIdentical(false, $result);
+		$this->assertFalse($result);
 
 		$result = $post->errors();
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 
 		$expected = array('email' => array('email is not valid'));
 		$result = $post->errors();
@@ -478,9 +475,9 @@ class ModelTest extends \lithium\test\Unit {
 		));
 
 		$result = $post->validates();
-		$this->assertTrue($result === true);
+		$this->assertTrue($result);
 		$result = $post->errors();
-		$this->assertTrue(empty($result));
+		$this->assertEmpty($result);
 	}
 
 	public function testCustomValidationCriteria() {
@@ -495,7 +492,7 @@ class ModelTest extends \lithium\test\Unit {
 		));
 
 		$result = $post->validates(array('rules' => $validates));
-		$this->assertTrue($result === true);
+		$this->assertTrue($result);
 		$this->assertIdentical(array(), $post->errors());
 	}
 
@@ -503,8 +500,8 @@ class ModelTest extends \lithium\test\Unit {
 		$post = MockPostForValidates::create();
 		$events = 'customEvent';
 
-		$this->assertIdentical(false, $post->validates(compact('events')));
-		$this->assertTrue($post->errors());
+		$this->assertFalse($post->validates(compact('events')));
+		$this->assertNotEmpty($post->errors());
 
 		$expected = array(
 			'title' => array('please enter a title'),
@@ -525,9 +522,9 @@ class ModelTest extends \lithium\test\Unit {
 
 		$events = 'customEvent';
 		$result = $post->validates(compact('events'));
-		$this->assertTrue($result === true);
+		$this->assertTrue($result);
 		$result = $post->errors();
-		$this->assertTrue(empty($result));
+		$this->assertEmpty($result);
 	}
 
 	public function testValidatesCustomEventsFalse() {
@@ -536,9 +533,9 @@ class ModelTest extends \lithium\test\Unit {
 		$events = array('customEvent','anotherCustomEvent');
 
 		$result = $post->validates(compact('events'));
-		$this->assertTrue($result === false);
+		$this->assertFalse($result);
 		$result = $post->errors();
-		$this->assertTrue(!empty($result));
+		$this->assertNotEmpty($result);
 
 		$expected = array(
 			'title' => array('please enter a title'),
@@ -561,9 +558,9 @@ class ModelTest extends \lithium\test\Unit {
 		$events = array('customEvent','anotherCustomEvent');
 
 		$result = $post->validates(compact('events'));
-		$this->assertTrue($result === false);
+		$this->assertFalse($result);
 		$result = $post->errors();
-		$this->assertTrue(!empty($result));
+		$this->assertNotEmpty($result);
 
 		$expected = array(
 			'email' => array('email is not in 2nd list')
@@ -580,9 +577,9 @@ class ModelTest extends \lithium\test\Unit {
 		$events = array('customEvent','anotherCustomEvent');
 
 		$result = $post->validates(compact('events'));
-		$this->assertTrue($result === true);
+		$this->assertTrue($result);
 		$result = $post->errors();
-		$this->assertTrue(empty($result));
+		$this->assertEmpty($result);
 	}
 
 	public function testDefaultValuesFromSchema() {
@@ -634,7 +631,7 @@ class ModelTest extends \lithium\test\Unit {
 		$this->assertEqual($this->_altSchema->fields(), MockPost::schema()->fields());
 
 		$post = MockPost::create(array('title' => 'New post'));
-		$this->assertTrue($post instanceof Entity);
+		$this->assertInstanceOf('lithium\data\Entity', $post);
 		$this->assertEqual('New post', $post->title);
 	}
 
@@ -680,7 +677,7 @@ class ModelTest extends \lithium\test\Unit {
 				'title' => 'A title must be present'
 			)
 		));
-		$this->assertIdentical(false, $result);
+		$this->assertFalse($result);
 	}
 
 	public function testSaveFailedWithValidationByModelDefinition() {
@@ -688,9 +685,9 @@ class ModelTest extends \lithium\test\Unit {
 		$post = MockPostForValidates::create();
 
 		$result = $post->save();
-		$this->assertTrue($result === false);
+		$this->assertFalse($result);
 		$result = $post->errors();
-		$this->assertTrue(!empty($result));
+		$this->assertNotEmpty($result);
 
 		$expected = array(
 			'title' => array('please enter a title'),
@@ -705,9 +702,9 @@ class ModelTest extends \lithium\test\Unit {
 		$events = array('customEvent','anotherCustomEvent');
 
 		$result = $post->save(null,compact('events'));
-		$this->assertTrue($result === false);
+		$this->assertFalse($result);
 		$result = $post->errors();
-		$this->assertTrue(!empty($result));
+		$this->assertNotEmpty($result);
 
 		$expected = array(
 			'title' => array('please enter a title'),
@@ -841,7 +838,7 @@ class ModelTest extends \lithium\test\Unit {
 
 		$this->assertIdentical('mock_posts', MockPost::meta('source'));
 		$this->assertIdentical('name', MockPost::meta('title'));
-		$this->assertIdentical(null, MockPost::meta('unexisting'));
+		$this->assertEmpty(MockPost::meta('unexisting'));
 
 		$config = array(
 			'schema' => new Schema(array(
@@ -869,7 +866,7 @@ class ModelTest extends \lithium\test\Unit {
 		MockPost::config($config);
 		$this->assertIdentical('cool_posts', MockPost::meta('source'));
 		$this->assertIdentical('label1', MockPost::meta('title'));
-		$this->assertFalse('label2' === MockPost::meta('title'));
+		$this->assertNotIdentical('label2', MockPost::meta('title'));
 		$this->assertIdentical('label1', MockPost::meta('title'));
 		$meta = MockPost::meta();
 		$this->assertIdentical('label1', $meta['title']);
@@ -912,7 +909,7 @@ class ModelTest extends \lithium\test\Unit {
 	public function testRespondsToInstanceMethod() {
 		$this->assertFalse(MockPost::respondsTo('foo_Bar_Baz'));
 		MockPost::instanceMethods(array(
-		    'foo_Bar_Baz' => function($entity) {}
+			'foo_Bar_Baz' => function($entity) {}
 		));
 		$this->assertTrue(MockPost::respondsTo('foo_Bar_Baz'));
 	}

--- a/tests/cases/data/SourceTest.php
+++ b/tests/cases/data/SourceTest.php
@@ -8,7 +8,6 @@
 
 namespace lithium\tests\cases\data;
 
-use lithium\data\Entity;
 use lithium\tests\mocks\data\MockSource;
 
 class SourceTest extends \lithium\test\Unit {
@@ -45,7 +44,7 @@ class SourceTest extends \lithium\test\Unit {
 	public function testItem() {
 		$source = new MockSource();
 		$entity = $source->item('Foo', array('foo' => 'bar'));
-		$this->assertTrue($entity instanceof Entity);
+		$this->assertInstanceOf('lithium\data\Entity', $entity);
 		$this->assertEqual('Foo', $entity->model());
 		$this->assertEqual(array('foo' => 'bar'), $entity->data());
 	}

--- a/tests/cases/data/collection/DocumentSetTest.php
+++ b/tests/cases/data/collection/DocumentSetTest.php
@@ -46,7 +46,7 @@ class DocumentSetTest extends \lithium\test\Unit {
 		));
 
 		foreach ($array as $value) {
-			$this->assertTrue(is_int($value));
+			$this->assertInternalType('int', $value);
 		}
 	}
 
@@ -80,10 +80,10 @@ class DocumentSetTest extends \lithium\test\Unit {
 		)));
 
 		foreach ($array as $document) {
-			$this->assertTrue($document->_id instanceof MongoId);
-			$this->assertTrue(is_string($document->body));
-			$this->assertTrue(is_object($document->foo));
-			$this->assertTrue(is_string($document->foo->bar));
+			$this->assertInstanceOf('MongoId', $document->_id);
+			$this->assertInternalType('string', $document->body);
+			$this->assertInternalType('object', $document->foo);
+			$this->assertInternalType('string', $document->foo->bar);
 		}
 
 		$array = new DocumentSet(compact('model', 'schema') + array(
@@ -106,10 +106,10 @@ class DocumentSetTest extends \lithium\test\Unit {
 		)));
 
 		foreach ($array as $document) {
-			$this->assertTrue($document->_id instanceof MongoId);
-			$this->assertTrue(is_string($document->body));
-			$this->assertTrue(is_object($document->foo));
-			$this->assertTrue(is_int($document->foo->bar));
+			$this->assertInstanceOf('MongoId', $document->_id);
+			$this->assertInternalType('string', $document->body);
+			$this->assertInternalType('object', $document->foo);
+			$this->assertInternalType('int', $document->foo->bar);
 		}
 
 	}
@@ -170,10 +170,10 @@ class DocumentSetTest extends \lithium\test\Unit {
 			'data' => array($first, $second, $third)
 		));
 
-		$this->assertTrue(is_object($doc[0]));
-		$this->assertTrue(is_object($doc[1]));
-		$this->assertTrue(is_object($doc[2]));
-		$this->assertEqual(3, count($doc));
+		$this->assertInternalType('object', $doc[0]);
+		$this->assertInternalType('object', $doc[1]);
+		$this->assertInternalType('object', $doc[2]);
+		$this->assertCount(3, $doc);
 	}
 
 	public function testOffsetSet() {
@@ -192,8 +192,8 @@ class DocumentSetTest extends \lithium\test\Unit {
 		$model = $this->_model;
 
 		$result = $doc->rewind();
-		$this->assertTrue($result instanceof Document);
-		$this->assertTrue(is_object($result['_id']));
+		$this->assertInstanceOf('lithium\data\entity\Document', $result);
+		$this->assertInternalType('object', $result['_id']);
 
 		$expected = array('_id' => '4c8f86167675abfabdbf0300', 'title' => 'bar');
 		$this->assertEqual($expected, $result->data());

--- a/tests/cases/data/collection/MultiKeyRecordSetTest.php
+++ b/tests/cases/data/collection/MultiKeyRecordSetTest.php
@@ -80,7 +80,7 @@ class MultiKeyRecordSetTest extends \lithium\test\Unit {
 
 	public function testInit() {
 		$recordSet = new MockMultiKeyRecordSet();
-		$this->assertTrue($recordSet instanceof MultiKeyRecordSet);
+		$this->assertInstanceOf('lithium\data\collection\MultiKeyRecordSet', $recordSet);
 
 		$recordSet = new MockMultiKeyRecordSet(array(
 			'model'  => $this->_model,
@@ -99,14 +99,14 @@ class MultiKeyRecordSetTest extends \lithium\test\Unit {
 		$this->assertTrue($this->_recordSet->offsetExists(3));
 		$this->assertTrue($this->_recordSet->offsetExists(4));
 
-		$this->assertTrue(isset($this->_recordSet[3]));
+		$this->assertArrayHasKey(3, $this->_recordSet);
 
 		$this->assertFalse($this->_objectRecordSet->offsetExists(0));
 		$this->assertTrue($this->_objectRecordSet->offsetExists(1));
 		$this->assertTrue($this->_objectRecordSet->offsetExists(2));
 		$this->assertTrue($this->_objectRecordSet->offsetExists(3));
 		$this->assertTrue($this->_objectRecordSet->offsetExists(4));
-		$this->assertTrue(isset($this->_objectRecordSet[3]));
+		$this->assertArrayHasKey(3, $this->_objectRecordSet);
 
 		$data = array(array(
 				'client_id' => 1,
@@ -123,26 +123,26 @@ class MultiKeyRecordSetTest extends \lithium\test\Unit {
 		));
 
 		$payments = new MockMultiKeyRecordSet(array('data' => $data, 'model' => $this->_model2));
-		$this->assertTrue(isset($payments[array('client_id' => 1,'invoice_id' => 4)]));
-		$this->assertTrue(isset($payments[array('invoice_id' => 4, 'client_id' => 1)]));
-		$this->assertFalse(isset($payments[0]));
-		$this->assertFalse(isset($payments[true]));
-		$this->assertFalse(isset($payments[false]));
-		$this->assertFalse(isset($payments[null]));
-		$this->assertFalse(isset($payments['string']));
+		$this->assertArrayHasKey(array('client_id' => 1,'invoice_id' => 4), $payments);
+		$this->assertArrayHasKey(array('invoice_id' => 4, 'client_id' => 1), $payments);
+		$this->assertArrayNotHasKey(0, $payments);
+		$this->assertArrayNotHasKey(true, $payments);
+		$this->assertArrayNotHasKey(false, $payments);
+		$this->assertArrayNotHasKey(null, $payments);
+		$this->assertArrayNotHasKey('string', $payments);
 
 		$records = new MockMultiKeyRecordSet();
 		$records[0] = array('title' => 'Record0');
 		$records[1] = array('title' => 'Record1');
-		$this->assertTrue(isset($records[true]));
-		$this->assertTrue(isset($records[null]));
-		$this->assertTrue(isset($records[false]));
-		$this->assertTrue(isset($records[array()]));
-		$this->assertTrue(isset($records[0]));
-		$this->assertTrue(isset($records['0']));
-		$this->assertTrue(isset($records[1]));
-		$this->assertTrue(isset($records['1']));
-		$this->assertFalse(isset($records[2]));
+		$this->assertArrayHasKey(true, $records);
+		$this->assertArrayHasKey(null, $records);
+		$this->assertArrayHasKey(false, $records);
+		$this->assertArrayHasKey(array(), $records);
+		$this->assertArrayHasKey(0, $records);
+		$this->assertArrayHasKey('0', $records);
+		$this->assertArrayHasKey(1, $records);
+		$this->assertArrayHasKey('1', $records);
+		$this->assertArrayNotHasKey(2, $records);
 	}
 
 	public function testOffsetGet() {
@@ -236,14 +236,14 @@ class MultiKeyRecordSetTest extends \lithium\test\Unit {
 	}
 
 	public function testOffsetSet() {
-		$this->assertEqual(0, count($this->_recordSet->get('_data')));
+		$this->assertCount(0, $this->_recordSet->get('_data'));
 		$this->_recordSet[5] = $expected = array('id' => 5, 'data' => 'data5');
 		$this->assertEqual($expected, $this->_recordSet[5]->to('array'));
-		$this->assertEqual(5, count($this->_recordSet->get('_data')));
+		$this->assertCount(5, $this->_recordSet->get('_data'));
 
 		$this->_recordSet[] = $expected = array('id' => 6, 'data' => 'data6');
 		$this->assertEqual($expected, $this->_recordSet[6]->to('array'));
-		$this->assertEqual(6, count($this->_recordSet->get('_data')));
+		$this->assertCount(6, $this->_recordSet->get('_data'));
 
 		$this->_objectRecordSet[5] = $expected = new MockPostObject(array(
 			'id' => 5, 'data' => 'data5'
@@ -593,7 +593,7 @@ class MultiKeyRecordSetTest extends \lithium\test\Unit {
 			)
 		);
 		$posts = new MockMultiKeyRecordSet(array('data' => $expected));
-		$this->assertEqual(3, count($posts->get('_data')));
+		$this->assertCount(3, $posts->get('_data'));
 
 		$this->assertEqual($expected['post1'], $posts->first());
 		$this->assertEqual($expected['post1'], $posts->current());
@@ -610,7 +610,7 @@ class MultiKeyRecordSetTest extends \lithium\test\Unit {
 
 		$posts = new MockMultiKeyRecordSet();
 		$posts->set($expected);
-		$this->assertEqual(3, count($posts->get('_data')));
+		$this->assertCount(3, $posts->get('_data'));
 
 		$this->assertEqual($expected['post1'], $posts->first());
 		$this->assertEqual($expected['post1'], $posts->current());
@@ -768,7 +768,7 @@ class MultiKeyRecordSetTest extends \lithium\test\Unit {
 			}
 		}
 
-		$this->assertEqual(3, count($recordSet));
+		$this->assertCount(3, $recordSet);
 
 		$expected = array(
 			2 => array('id' => 2, 'data' => 'data2'),
@@ -813,7 +813,7 @@ class MultiKeyRecordSetTest extends \lithium\test\Unit {
 		));
 
 		$payments = new MockMultiKeyRecordSet(array('data' => $data, 'model' => $this->_model2));
-		$this->assertEqual(3, count($payments->get('_data')));
+		$this->assertCount(3, $payments->get('_data'));
 
 		$index = array('client_id' => 1, 'invoice_id' => 4);
 		$this->assertEqual($data[0], $payments[$index]->data());
@@ -869,27 +869,27 @@ class MultiKeyRecordSetTest extends \lithium\test\Unit {
 		$payments = new MockMultiKeyRecordSet(array(
 			'result' => $result, 'model' => $this->_model2
 		));
-		$this->assertEqual(0, count($payments->get('_data')));
+		$this->assertCount(0, $payments->get('_data'));
 
 		$result = $payments[array('client_id' => 1, 'invoice_id' => 4)]->to('array');
 		$this->assertEqual($records[0], $result);
 
 		$result = $payments[array('client_id' => 2, 'invoice_id' => 6)]->to('array');
 		$this->assertEqual($records[2], $result);
-		$this->assertEqual(3, count($payments->get('_data')));
+		$this->assertCount(3, $payments->get('_data'));
 
 		$result = $payments[array('client_id' => 2, 'invoice_id' => 5)]->to('array');
 		$this->assertEqual($records[1], $result);
-		$this->assertEqual(3, count($payments->get('_data')));
+		$this->assertCount(3, $payments->get('_data'));
 
 		$this->assertNull($payments[array('client_id' => 3, 'invoice_id' => 3)]);
 		$this->assertNull($payments[array('client_id' => 2)]);
 		$this->assertNull($payments[array('invoice_id' => 6)]);
 
-		$this->assertEqual(4, count($payments->get('_data')));
+		$this->assertCount(4, $payments->get('_data'));
 
 		$this->assertTrue($payments->reset());
-		$this->assertEqual(0, count($payments->get('_data')));
+		$this->assertCount(0, $payments->get('_data'));
 
 		$this->assertEqual($records, $payments->to('array'));
 

--- a/tests/cases/data/collection/RecordSetTest.php
+++ b/tests/cases/data/collection/RecordSetTest.php
@@ -79,7 +79,7 @@ class RecordSetTest extends \lithium\test\Unit {
 
 	public function testInit() {
 		$recordSet = new MockRecordSet();
-		$this->assertTrue($recordSet instanceof RecordSet);
+		$this->assertInstanceOf('lithium\data\collection\RecordSet', $recordSet);
 
 		$recordSet = new MockRecordSet(array(
 			'model'  => $this->_model,
@@ -98,14 +98,14 @@ class RecordSetTest extends \lithium\test\Unit {
 		$this->assertTrue($this->_recordSet->offsetExists(3));
 		$this->assertTrue($this->_recordSet->offsetExists(4));
 
-		$this->assertTrue(isset($this->_recordSet[3]));
+		$this->assertArrayHasKey(3, $this->_recordSet);
 
 		$this->assertFalse($this->_objectRecordSet->offsetExists(0));
 		$this->assertTrue($this->_objectRecordSet->offsetExists(1));
 		$this->assertTrue($this->_objectRecordSet->offsetExists(2));
 		$this->assertTrue($this->_objectRecordSet->offsetExists(3));
 		$this->assertTrue($this->_objectRecordSet->offsetExists(4));
-		$this->assertTrue(isset($this->_objectRecordSet[3]));
+		$this->assertArrayHasKey(3, $this->_objectRecordSet);
 	}
 
 	public function testOffsetGet() {
@@ -199,14 +199,14 @@ class RecordSetTest extends \lithium\test\Unit {
 	}
 
 	public function testOffsetSet() {
-		$this->assertEqual(0, count($this->_recordSet->get('_data')));
+		$this->assertCount(0, $this->_recordSet->get('_data'));
 		$this->_recordSet[5] = $expected = array('id' => 5, 'data' => 'data5');
 		$this->assertEqual($expected, $this->_recordSet[5]->to('array'));
-		$this->assertEqual(5, count($this->_recordSet->get('_data')));
+		$this->assertCount(5, $this->_recordSet->get('_data'));
 
 		$this->_recordSet[] = $expected = array('id' => 6, 'data' => 'data6');
 		$this->assertEqual($expected, $this->_recordSet[6]->to('array'));
-		$this->assertEqual(6, count($this->_recordSet->get('_data')));
+		$this->assertCount(6, $this->_recordSet->get('_data'));
 
 		$this->_objectRecordSet[5] = $expected = new MockPostObject(array(
 			'id' => 5, 'data' => 'data5'
@@ -522,7 +522,7 @@ class RecordSetTest extends \lithium\test\Unit {
 			)
 		);
 		$posts = new MockRecordSet(array('data' => $expected));
-		$this->assertEqual(3, count($posts->get('_data')));
+		$this->assertCount(3, $posts->get('_data'));
 
 		$this->assertEqual($expected['post1'], $posts->first());
 		$this->assertEqual($expected['post1'], $posts->current());
@@ -539,7 +539,7 @@ class RecordSetTest extends \lithium\test\Unit {
 
 		$posts = new MockRecordSet();
 		$posts->set($expected);
-		$this->assertEqual(3, count($posts->get('_data')));
+		$this->assertCount(3, $posts->get('_data'));
 
 		$this->assertEqual($expected['post1'], $posts->first());
 		$this->assertEqual($expected['post1'], $posts->current());
@@ -693,7 +693,7 @@ class RecordSetTest extends \lithium\test\Unit {
 			}
 		}
 
-		$this->assertEqual(3, count($recordSet));
+		$this->assertCount(3, $recordSet);
 
 		$expected = array(
 			2 => array('id' => 2, 'data' => 'data2'),

--- a/tests/cases/data/entity/DocumentTest.php
+++ b/tests/cases/data/entity/DocumentTest.php
@@ -46,7 +46,7 @@ class DocumentTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 
 		$result = $set->next();
-		$this->assertTrue(empty($result));
+		$this->assertEmpty($result);
 
 		$expected = array('_id' => 1, 'name' => 'One', 'content' => 'Lorem ipsum one');
 		$result = $set->rewind()->data();
@@ -194,8 +194,10 @@ class DocumentTest extends \lithium\test\Unit {
 		$doc->forceArray = 'foo';
 		$result = $doc->export();
 
-		$this->assertTrue($result['update']['forceArray'] instanceof DocumentSet);
-		$this->assertTrue($result['update']['array'] instanceof DocumentSet);
+		$obj = $result['update']['forceArray'];
+		$this->assertInstanceOf('lithium\data\collection\DocumentSet', $obj);
+		$obj = $result['update']['array'];
+		$this->assertInstanceOf('lithium\data\collection\DocumentSet', $obj);
 		$this->assertIdentical(array('foo'), $result['update']['forceArray']->data());
 
 		$doc->forceArray = false;
@@ -226,7 +228,7 @@ class DocumentTest extends \lithium\test\Unit {
 		$this->assertEqual('Crystal Reports', $doc->profile->dislikes);
 
 		$doc->{'profile.foo.bar'} = 'baz';
-		$this->assertTrue($doc->profile->foo instanceof Document);
+		$this->assertInstanceOf('lithium\data\entity\Document', $doc->profile->foo);
 		$this->assertEqual(array('bar' => 'baz'), $doc->profile->foo->data());
 
 		$post = new Document(array('model' => $this->_model, 'data' => array(
@@ -243,7 +245,7 @@ class DocumentTest extends \lithium\test\Unit {
 	public function testNoItems() {
 		$doc = new Document(array('model' => $this->_model, 'data' => array()));
 		$result = $doc->_id;
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 	}
 
 	public function testWithData() {
@@ -301,7 +303,7 @@ class DocumentTest extends \lithium\test\Unit {
 		)));
 
 		$this->assertEqual('father', $doc->type);
-		$this->assertTrue($doc->children instanceof DocumentSet);
+		$this->assertInstanceOf('lithium\data\collection\DocumentSet', $doc->children);
 
 		$expected = array('_id' => 124, 'type' => 'child', 'children' => null);
 		$result = $doc->children[124]->data();
@@ -321,8 +323,8 @@ class DocumentTest extends \lithium\test\Unit {
 
 		$this->assertEqual('father', $doc->name);
 
-		$this->assertTrue(is_object($doc->child), 'children is not an object');
-		$this->assertTrue($doc->child instanceof Document, 'Child is not of the type Document');
+		$this->assertInternalType('object', $doc->child, 'children is not an object');
+		$this->assertInstanceOf('lithium\data\entity\Document', $doc->child);
 		$this->skipIf(!$doc->child instanceof Document, 'Child is not of the type Document');
 
 		$expected = 124;
@@ -340,8 +342,8 @@ class DocumentTest extends \lithium\test\Unit {
 		$doc->arr1 = array('something' => 'else');
 		$doc->arr2 = array('some' => 'noses', 'have' => 'it');
 
-		$this->assertTrue($doc->arr1 instanceof Document);
-		$this->assertTrue($doc->arr2 instanceof Document);
+		$this->assertInstanceOf('lithium\data\entity\Document', $doc->arr1);
+		$this->assertInstanceOf('lithium\data\entity\Document', $doc->arr2);
 	}
 
 	public function testRewindNoData() {
@@ -403,8 +405,8 @@ class DocumentTest extends \lithium\test\Unit {
 		$this->assertEqual(12, $doc->_id);
 		$this->assertEqual('bird', $doc->name);
 
-		$this->assertTrue(is_object($doc->arr), 'arr is not an object');
-		$this->assertTrue($doc->arr instanceof Document, 'arr is not of the type Document');
+		$this->assertInternalType('object', $doc->arr, 'arr is not an object');
+		$this->assertInstanceOf('lithium\data\entity\Document', $doc->arr);
 		$this->skipIf(!$doc->arr instanceof Document, 'arr is not of the type Document');
 
 		$this->assertEqual(33, $doc->arr->_id);
@@ -420,7 +422,7 @@ class DocumentTest extends \lithium\test\Unit {
 		$this->assertEqual(12, $doc->_id);
 		$this->assertEqual('Joe', $doc->name);
 
-		$this->assertTrue($doc->sons instanceof DocumentSet, 'arr is not an array');
+		$this->assertInstanceOf('lithium\data\collection\DocumentSet', $doc->sons);
 		$this->assertEqual(array('Moe', 'Greg'), $doc->sons->data());
 	}
 
@@ -667,7 +669,7 @@ class DocumentTest extends \lithium\test\Unit {
 
 		$this->assertTrue(isset($doc->top));
 		$this->assertTrue(isset($doc->second->level));
-		$this->assertTrue($doc->second instanceof Document);
+		$this->assertInstanceOf('lithium\data\entity\Document', $doc->second);
 
 		$this->assertEqual('level', $doc->top);
 		$this->assertEqual('of data', $doc->second->level);
@@ -749,8 +751,8 @@ class DocumentTest extends \lithium\test\Unit {
 		$expected = array('foo' => 'bar', 'baz' => 'dib', 'nested.more' => 'data');
 		$this->assertFalse($newData['exists']);
 		$this->assertEqual(array('foo' => 'bar', 'baz' => 'dib'), $newData['data']);
-		$this->assertEqual(3, count($newData['update']));
-		$this->assertTrue($newData['update']['nested'] instanceof Document);
+		$this->assertCount(3, $newData['update']);
+		$this->assertInstanceOf('lithium\data\entity\Document', $newData['update']['nested']);
 
 		$result = $newData['update']['nested']->export();
 		$this->assertFalse($result['exists']);
@@ -841,7 +843,7 @@ class DocumentTest extends \lithium\test\Unit {
 		$doc = new Document(array('schema' => new Schema(array('fields' => array(
 			'foo' => array('type' => 'string', 'default' => 'bar')
 		)))));
-		$this->assertFalse($doc->data());
+		$this->assertEmpty($doc->data());
 
 		$this->assertEqual('bar', $doc->foo);
 		$this->assertEqual(array('foo' => 'bar'), $doc->data());

--- a/tests/cases/data/entity/RecordTest.php
+++ b/tests/cases/data/entity/RecordTest.php
@@ -49,8 +49,7 @@ class RecordTest extends \lithium\test\Unit {
 		$this->assertTrue(isset($this->record->body));
 
 		$this->assertNull($this->record->foo);
-		$this->assertFalse(isset($this->record->foo));
-	}
+		$this->assertFalse(isset($this->record->foo));	}
 
 	/**
 	 * Tests that a record can be exported to a given series of formats.
@@ -97,7 +96,7 @@ class RecordTest extends \lithium\test\Unit {
 	 * Test the ability to set multiple field's values, and that they can be read back.
 	 */
 	public function testSetData() {
-		$this->assertFalse($this->record->data());
+		$this->assertEmpty($this->record->data());
 		$expected = array('id' => 1, 'name' => 'Joe Bloggs', 'address' => 'The Park');
 		$this->record->set($expected);
 		$this->assertEqual($expected, $this->record->data());

--- a/tests/cases/data/model/QueryTest.php
+++ b/tests/cases/data/model/QueryTest.php
@@ -48,7 +48,7 @@ class QueryTest extends \lithium\test\Unit {
 	 */
 	public function testObjectConstruction() {
 		$query = new Query();
-		$this->assertFalse($query->conditions());
+		$this->assertEmpty($query->conditions());
 
 		$query = new Query(array('conditions' => 'foo', 'limit' => '10'));
 		$this->assertEqual(array('foo'), $query->conditions());
@@ -199,7 +199,7 @@ class QueryTest extends \lithium\test\Unit {
 		$result = $queryRecord->title;
 		$this->assertEqual($expected, $result);
 
-		$this->assertTrue($record === $query->entity());
+		$this->assertIdentical($record, $query->entity());
 	}
 
 	public function testComment() {
@@ -295,7 +295,7 @@ class QueryTest extends \lithium\test\Unit {
 		$ds = new MockDatabase();
 		$export = $query->export($ds);
 
-		$this->assertTrue(is_array($export));
+		$this->assertInternalType('array', $export);
 		$this->skipIf(!is_array($export), 'Query::export() does not return an array');
 
 		$expected = array(
@@ -374,14 +374,14 @@ class QueryTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $joins);
 
 		$this->assertEqual('bar', $joins[0]['foo']);
-		$this->assertFalse(isset($joins[0]['bar']));
+		$this->assertArrayNotHasKey('bar', $joins[0]);
 
 		$this->assertEqual('baz', $joins[1]['bar']);
-		$this->assertFalse(isset($joins[1]['foo']));
+		$this->assertArrayNotHasKey('foo', $joins[1]);
 
 		$query->joins('zim', array('dib' => 'gir'));
 		$joins = $query->joins();
-		$this->assertEqual(3, count($joins));
+		$this->assertCount(3, $joins);
 
 		$this->assertEqual('gir', $joins['zim']['dib']);
 
@@ -407,9 +407,8 @@ class QueryTest extends \lithium\test\Unit {
 			'fieldName' => 'mock_query_comments',
 			'alias' => 'MockQueryComment'
 		));
-		$keyExists = isset($export['relationships']);
-		$this->assertTrue($keyExists);
-		$this->skipIf(!$keyExists);
+		$this->assertArrayHasKey('relationships', $export);
+		$this->skipIf(!isset($export['relationships']));
 		$this->assertEqual($expected, $export['relationships']);
 
 		$query = new Query(compact('model') + array(

--- a/tests/cases/data/source/DatabaseTest.php
+++ b/tests/cases/data/source/DatabaseTest.php
@@ -10,7 +10,6 @@ namespace lithium\tests\cases\data\source;
 
 use lithium\data\model\Query;
 use lithium\data\entity\Record;
-use lithium\data\collection\RecordSet;
 use lithium\tests\mocks\data\model\MockDatabase;
 use lithium\tests\mocks\data\model\MockDatabasePost;
 use lithium\tests\mocks\data\model\MockDatabaseComment;
@@ -446,7 +445,7 @@ class DatabaseTest extends \lithium\test\Unit {
 		$result = $this->db->read('SELECT * from mock_database_posts AS MockDatabasePost;', array(
 			'return' => 'resource'
 		));
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 
 		$expected = "SELECT * from mock_database_posts AS MockDatabasePost;";
 		$this->assertEqual($expected, $this->db->sql);
@@ -473,7 +472,7 @@ class DatabaseTest extends \lithium\test\Unit {
 	public function testReadWithQueryObjectRecordSet() {
 		$query = new Query(array('type' => 'read', 'model' => $this->_model));
 		$result = $this->db->read($query);
-		$this->assertTrue($result instanceof RecordSet);
+		$this->assertInstanceOf('lithium\data\collection\RecordSet', $result);
 
 		$expected = "SELECT * FROM {mock_database_posts} AS {MockDatabasePost};";
 		$result = $this->db->sql;
@@ -483,7 +482,7 @@ class DatabaseTest extends \lithium\test\Unit {
 	public function testReadWithQueryObjectArray() {
 		$query = new Query(array('type' => 'read', 'model' => $this->_model));
 		$result = $this->db->read($query, array('return' => 'array'));
-		$this->assertTrue(is_array($result));
+		$this->assertInternalType('array', $result);
 
 		$expected = "SELECT * FROM {mock_database_posts} AS {MockDatabasePost};";
 		$result = $this->db->sql;
@@ -911,15 +910,15 @@ class DatabaseTest extends \lithium\test\Unit {
 
 	public function testRawConditions() {
 		$query = new Query(array('type' => 'read', 'model' => $this->_model, 'conditions' => null));
-		$this->assertFalse($this->db->conditions(5, $query));
-		$this->assertFalse($this->db->conditions(null, $query));
+		$this->assertEmpty($this->db->conditions(5, $query));
+		$this->assertEmpty($this->db->conditions(null, $query));
 		$this->assertEqual("WHERE CUSTOM", $this->db->conditions("CUSTOM", $query));
 	}
 
 	public function testRawHaving() {
 		$query = new Query(array('type' => 'read', 'model' => $this->_model, 'having' => null));
-		$this->assertFalse($this->db->having(5, $query));
-		$this->assertFalse($this->db->having(null, $query));
+		$this->assertEmpty($this->db->having(5, $query));
+		$this->assertEmpty($this->db->having(null, $query));
 		$this->assertEqual("HAVING CUSTOM", $this->db->having("CUSTOM", $query));
 	}
 
@@ -1004,7 +1003,7 @@ class DatabaseTest extends \lithium\test\Unit {
 			'limit' => 1
 		);
 		$result = $this->db->read(new Query($options), $options);
-		$this->assertFalse($result instanceof RecordSet);
+		$this->assertNotInstanceOf('lithium\data\collection\RecordSet', $result);
 	}
 
 	public function testGroup() {

--- a/tests/cases/data/source/HttpTest.php
+++ b/tests/cases/data/source/HttpTest.php
@@ -41,11 +41,11 @@ class HttpTest extends \lithium\test\Unit {
 
 	public function testAllMethodsNoConnection() {
 		$http = new Http(array('socket' => false));
-		$this->assertTrue($http->connect());
-		$this->assertTrue($http->disconnect());
-		$this->assertFalse($http->get());
-		$this->assertFalse($http->post());
-		$this->assertFalse($http->put());
+		$this->assertNotEmpty($http->connect());
+		$this->assertNotEmpty($http->disconnect());
+		$this->assertEmpty($http->get());
+		$this->assertEmpty($http->post());
+		$this->assertEmpty($http->put());
 	}
 
 	public function testConnect() {

--- a/tests/cases/data/source/MongoDbTest.php
+++ b/tests/cases/data/source/MongoDbTest.php
@@ -18,7 +18,6 @@ use lithium\data\model\Query;
 use lithium\data\entity\Document;
 use lithium\tests\mocks\data\MockPost;
 use lithium\tests\mocks\data\MockComment;
-use lithium\data\collection\DocumentSet;
 use lithium\tests\mocks\core\MockCallable;
 use lithium\tests\mocks\data\source\MockMongoSource;
 use lithium\tests\mocks\data\source\MockMongoConnection;
@@ -124,11 +123,11 @@ class MongoDbTest extends \lithium\test\Unit {
 
 		$query = array_pop($this->db->connection->queries);
 
-		$this->assertFalse($this->db->connection->queries);
+		$this->assertEmpty($this->db->connection->queries);
 		$this->assertEqual('insert', $query['type']);
 		$this->assertEqual('posts', $query['collection']);
 		$this->assertEqual(array('title', '_id'), array_keys($query['data']));
-		$this->assertTrue($query['data']['_id'] instanceof MongoId);
+		$this->assertInstanceOf('MongoId', $query['data']['_id']);
 	}
 
 	public function testConditions() {
@@ -139,24 +138,24 @@ class MongoDbTest extends \lithium\test\Unit {
 		$conditions = new MongoCode($function);
 		$result = $this->db->conditions($conditions, null);
 
-		$this->assertTrue(is_array($result));
+		$this->assertInternalType('array', $result);
 		$this->assertTrue(isset($result['$where']));
 		$this->assertEqual($conditions, $result['$where']);
 
 		$conditions = $function;
 		$result = $this->db->conditions($conditions, null);
-		$this->assertTrue(is_array($result));
+		$this->assertInternalType('array', $result);
 		$this->assertTrue(isset($result['$where']));
 		$this->assertEqual($conditions, $result['$where']);
 
 		$conditions = array('key' => 'value', 'anotherkey' => 'some other value');
 		$result = $this->db->conditions($conditions, null);
-		$this->assertTrue(is_array($result));
+		$this->assertInternalType('array', $result);
 		$this->assertEqual($conditions, $result);
 
 		$conditions = array('key' => array('one', 'two', 'three'));
 		$result = $this->db->conditions($conditions, null);
-		$this->assertTrue(is_array($result));
+		$this->assertInternalType('array', $result);
 		$this->assertTrue(isset($result['key']));
 		$this->assertTrue(isset($result['key']['$in']));
 		$this->assertEqual($conditions['key'], $result['key']['$in']);
@@ -246,13 +245,13 @@ class MongoDbTest extends \lithium\test\Unit {
 		$data = array('title' => 'Test Post');
 		$options = array('safe' => false, 'fsync' => false);
 		$this->query->data($data);
-		$this->assertIdentical(true, $this->db->create($this->query));
+		$this->assertTrue($this->db->create($this->query));
 		$this->assertEqual(compact('data', 'options'), end($this->db->connection->queries));
 
 		$this->db->connection->resultSets = array(array(array('_id' => new MongoId()) + $data));
 		$result = $this->db->read($this->query);
 
-		$this->assertTrue($result instanceof DocumentSet);
+		$this->assertInstanceOf('lithium\data\collection\DocumentSet', $result);
 		$this->assertEqual(1, $result->count());
 		$this->assertEqual('Test Post', $result->first()->title);
 		$this->db->connection = $connection;
@@ -273,13 +272,13 @@ class MongoDbTest extends \lithium\test\Unit {
 		$this->db->connection->resultSets = array(array());
 		$this->query->conditions(array('title' => 'Nonexistent Post'));
 		$result = $this->db->read($this->query);
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 		$this->assertEqual(0, $result->count());
 
 		$this->db->connection->resultSets = array(array($data));
 		$this->query->conditions($data);
 		$result = $this->db->read($this->query);
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 		$this->assertEqual(1, $result->count());
 		$this->db->connection = $connection;
 	}
@@ -401,7 +400,7 @@ class MongoDbTest extends \lithium\test\Unit {
 		$model = $this->_model;
 		$data = array('title' => 'New Item');
 		$result = $this->db->item($model, $data);
-		$this->assertTrue($result instanceof Document);
+		$this->assertInstanceOf('lithium\data\entity\Document', $result);
 
 		$expected = $data;
 		$result = $result->to('array');
@@ -421,7 +420,7 @@ class MongoDbTest extends \lithium\test\Unit {
 	}
 
 	public function testArbitraryMethodCalls() {
-		$this->assertTrue(is_array($this->db->listDBs()));
+		$this->assertInternalType('array', $this->db->listDBs());
 	}
 
 	public function testDocumentSorting() {
@@ -516,7 +515,7 @@ class MongoDbTest extends \lithium\test\Unit {
 		$data = $result['data'];
 
 		$this->assertEqual('A post', $data['title']);
-		$this->assertTrue($data['_id'] instanceof MongoId);
+		$this->assertInstanceOf('MongoId', $data['_id']);
 
 		$post->sync();
 		$post->title = 'An updated post';
@@ -670,28 +669,28 @@ class MongoDbTest extends \lithium\test\Unit {
 		$result = $this->db->conditions($conditions, $query);
 
 		$this->assertEqual(array_keys($conditions), array_keys($result));
-		$this->assertTrue($result['_id'] instanceof MongoId);
+		$this->assertInstanceOf('MongoId', $result['_id']);
 		$this->assertEqual($conditions['_id'], (string) $result['_id']);
 
 		$conditions = array('_id' => array(
 			"4c8f86167675abfabdbe0300", "4c8f86167675abfabdbf0300", "4c8f86167675abfabdc00300"
 		));
 		$result = $this->db->conditions($conditions, $query);
-		$this->assertEqual(3, count($result['_id']['$in']));
+		$this->assertCount(3, $result['_id']['$in']);
 
 		foreach (array(0, 1, 2) as $i) {
-			$this->assertTrue($result['_id']['$in'][$i] instanceof MongoId);
+			$this->assertInstanceOf('MongoId', $result['_id']['$in'][$i]);
 		}
 
 		$conditions = array('voters' => array('$all' => array(
 			"4c8f86167675abfabdbf0300", "4c8f86167675abfabdc00300"
 		)));
 		$result = $this->db->conditions($conditions, $query);
-		$this->assertEqual(2, count($result['voters']['$all']));
+		$this->assertCount(2, $result['voters']['$all']);
 		$result = $result['voters']['$all'];
 
 		foreach (array(0, 1) as $i) {
-			$this->assertTrue($result[$i] instanceof MongoId);
+			$this->assertInstanceOf('MongoId', $result[$i]);
 			$this->assertEqual($conditions['voters']['$all'][$i], (string) $result[$i]);
 		}
 
@@ -701,11 +700,11 @@ class MongoDbTest extends \lithium\test\Unit {
 		));
 		$result = $this->db->conditions($conditions, $query);
 		$this->assertEqual(array('$or'), array_keys($result));
-		$this->assertEqual(2, count($result['$or']));
+		$this->assertCount(2, $result['$or']);
 
 
 		foreach (array('_id', 'guid') as $i => $key) {
-			$this->assertTrue($result['$or'][$i][$key] instanceof MongoId);
+			$this->assertInstanceOf('MongoId', $result['$or'][$i][$key]);
 			$this->assertEqual($conditions['$or'][$i][$key], (string) $result['$or'][$i][$key]);
 		}
 	}
@@ -745,7 +744,7 @@ class MongoDbTest extends \lithium\test\Unit {
 		$result = $query->export($this->db);
 		$expected = array('_id', 'created', 'list', 'updated');
 		$this->assertEqual($expected, array_keys($result['data']['update']));
-		$this->assertTrue($result['data']['update']['updated'] instanceof MongoDate);
+		$this->assertInstanceOf('MongoDate', $result['data']['update']['updated']);
 	}
 
 	/**
@@ -855,13 +854,13 @@ class MongoDbTest extends \lithium\test\Unit {
 		$data = array('filename' => 'lithium', 'file' => 'some_datas');
 
 		$model::config(array('meta' => array('source' => $source, 'locked' => false)));
-		$this->assertIdentical(true, $model::create()->save($data));
+		$this->assertTrue($model::create()->save($data));
 		$this->assertIdentical('fs', $this->db->connection->gridFsPrefix);
 		$this->db->connection->gridFsPrefix = null;
 
 		$model::config(array('meta' => array('source' => $source, 'locked' => false)));
 		$this->db->connection->results = array(new MockResult(array('data' => $data)));
-		$this->assertTrue($model::find('all'));
+		$this->assertNotEmpty($model::find('all'));
 		$this->assertIdentical('fs', $this->db->connection->gridFsPrefix);
 		$this->db->connection->gridFsPrefix = null;
 
@@ -882,11 +881,11 @@ class MongoDbTest extends \lithium\test\Unit {
 		$model::$connection = $db;
 
 		$model::config(array('meta' => array('source' => 'fs.files', 'locked' => false)));
-		$this->assertIdentical(false, $model::create()->save($data));
+		$this->assertFalse($model::create()->save($data));
 		$this->assertIdentical(null, $db->connection->gridFsPrefix);
 
 		$model::config(array('meta' => array('source' => 'custom.files', 'locked' => false)));
-		$this->assertIdentical(true, $model::create()->save($data));
+		$this->assertTrue($model::create()->save($data));
 		$this->assertIdentical('custom', $db->connection->gridFsPrefix);
 	}
 
@@ -905,12 +904,12 @@ class MongoDbTest extends \lithium\test\Unit {
 
 		$model::config(array('meta' => array('source' => 'fs.files', 'locked' => false)));
 		$db->connection->results = array($result);
-		$this->assertTrue($model::find('all'));
+		$this->assertNotEmpty($model::find('all'));
 		$this->assertIdentical(null, $db->connection->gridFsPrefix);
 
 		$model::config(array('meta' => array('source' => 'custom.files', 'locked' => false)));
 		$db->connection->results = array($result);
-		$this->assertTrue($model::find('all'));
+		$this->assertNotEmpty($model::find('all'));
 		$this->assertIdentical('custom', $db->connection->gridFsPrefix);
 	}
 

--- a/tests/cases/data/source/database/adapter/MySqlTest.php
+++ b/tests/cases/data/source/database/adapter/MySqlTest.php
@@ -92,12 +92,12 @@ class MySqlTest extends \lithium\test\Unit {
 	public function testValueByIntrospect() {
 		$expected = "'string'";
 		$result = $this->db->value("string");
-		$this->assertTrue(is_string($result));
+		$this->assertInternalType('string', $result);
 		$this->assertEqual($expected, $result);
 
 		$expected = "'\'this string is escaped\''";
 		$result = $this->db->value("'this string is escaped'");
-		$this->assertTrue(is_string($result));
+		$this->assertInternalType('string', $result);
 		$this->assertEqual($expected, $result);
 
 		$this->assertIdentical(1, $this->db->value(true));
@@ -138,11 +138,11 @@ class MySqlTest extends \lithium\test\Unit {
 			'name' => 'Test',
 			'return' => 'array'
 		));
-		$this->assertEqual(1, count($result));
+		$this->assertCount(1, $result);
 		$expected = array('id', 'name', 'active', 'created', 'modified');
 		$this->assertEqual($expected, array_keys($result[0]));
 
-		$this->assertTrue(is_numeric($result[0]['id']));
+		$this->assertInternalType('numeric', $result[0]['id']);
 		unset($result[0]['id']);
 
 		$expected = array('name' => 'Test', 'active' => '1', 'created' => null, 'modified' => null);
@@ -175,8 +175,8 @@ class MySqlTest extends \lithium\test\Unit {
 
 	public function testEntityQuerying() {
 		$sources = $this->db->sources();
-		$this->assertTrue(is_array($sources));
-		$this->assertFalse(empty($sources));
+		$this->assertInternalType('array', $sources);
+		$this->assertNotEmpty($sources);
 	}
 
 	public function testQueryOrdering() {
@@ -189,19 +189,19 @@ class MySqlTest extends \lithium\test\Unit {
 				'created' => date('Y-m-d H:i:s')
 			)
 		));
-		$this->assertIdentical(true, $this->db->create($insert));
+		$this->assertTrue($this->db->create($insert));
 
 		$insert->data(array(
 			'name' => 'Bar',
 			'created' => date('Y-m-d H:i:s', strtotime('-5 minutes'))
 		));
-		$this->assertIdentical(true, $this->db->create($insert));
+		$this->assertTrue($this->db->create($insert));
 
 		$insert->data(array(
 			'name' => 'Baz',
 			'created' => date('Y-m-d H:i:s', strtotime('-10 minutes'))
 		));
-		$this->assertIdentical(true, $this->db->create($insert));
+		$this->assertTrue($this->db->create($insert));
 
 		$read = new Query(array(
 			'type' => 'read',

--- a/tests/cases/data/source/database/adapter/PostgreSqlTest.php
+++ b/tests/cases/data/source/database/adapter/PostgreSqlTest.php
@@ -105,12 +105,12 @@ class PostgreSqlTest extends \lithium\test\Unit {
 	public function testValueByIntrospect() {
 		$expected = "'string'";
 		$result = $this->db->value("string");
-		$this->assertTrue(is_string($result));
+		$this->assertInternalType('string', $result);
 		$this->assertEqual($expected, $result);
 
 		$expected = "'''this string is escaped'''";
 		$result = $this->db->value("'this string is escaped'");
-		$this->assertTrue(is_string($result));
+		$this->assertInternalType('string', $result);
 		$this->assertEqual($expected, $result);
 
 		$this->assertIdentical("'t'", $this->db->value(true));
@@ -151,11 +151,11 @@ class PostgreSqlTest extends \lithium\test\Unit {
 			'name' => 'Test',
 			'return' => 'array'
 		));
-		$this->assertEqual(1, count($result));
+		$this->assertCount(1, $result);
 		$expected = array('id', 'name', 'active', 'created', 'modified');
 		$this->assertEqual($expected, array_keys($result[0]));
 
-		$this->assertTrue(is_numeric($result[0]['id']));
+		$this->assertInternalType('numeric', $result[0]['id']);
 		unset($result[0]['id']);
 
 		$expected = array(
@@ -193,8 +193,8 @@ class PostgreSqlTest extends \lithium\test\Unit {
 
 	public function testEntityQuerying() {
 		$sources = $this->db->sources();
-		$this->assertTrue(is_array($sources));
-		$this->assertFalse(empty($sources));
+		$this->assertInternalType('array', $sources);
+		$this->assertNotEmpty($sources);
 	}
 
 	public function testQueryOrdering() {
@@ -207,19 +207,19 @@ class PostgreSqlTest extends \lithium\test\Unit {
 				'created' => date('Y-m-d H:i:s')
 			)
 		));
-		$this->assertIdentical(true, $this->db->create($insert));
+		$this->assertTrue($this->db->create($insert));
 
 		$insert->data(array(
 			'name' => 'Bar',
 			'created' => date('Y-m-d H:i:s', strtotime('-5 minutes'))
 		));
-		$this->assertIdentical(true, $this->db->create($insert));
+		$this->asserTrue($this->db->create($insert));
 
 		$insert->data(array(
 			'name' => 'Baz',
 			'created' => date('Y-m-d H:i:s', strtotime('-10 minutes'))
 		));
-		$this->assertIdentical(true, $this->db->create($insert));
+		$this->assertTrue($this->db->create($insert));
 
 		$read = new Query(array(
 			'type' => 'read',

--- a/tests/cases/data/source/database/adapter/Sqlite3Test.php
+++ b/tests/cases/data/source/database/adapter/Sqlite3Test.php
@@ -192,7 +192,7 @@ class Sqlite3Test extends \lithium\test\Unit {
 			$this->assertEqual($cpt, $employee->id);
 		}
 		$this->assertEqual(8, $cpt);
-		$this->assertEqual(8, count($employees));
+		$this->assertCount(8, $employees);
 
 		Employees::reset();
 		Companies::reset();
@@ -227,7 +227,7 @@ class Sqlite3Test extends \lithium\test\Unit {
 			$this->assertEqual($cpt, $employee->id);
 		}
 		$this->assertEqual(8, $cpt);
-		$this->assertEqual(8, count($employees));
+		$this->assertCount(8, $employees);
 
 		$this->_cleanUp();
 		Connections::get('test')->read('DROP TABLE employees;');

--- a/tests/cases/data/source/database/adapter/pdo/ResultTest.php
+++ b/tests/cases/data/source/database/adapter/pdo/ResultTest.php
@@ -73,7 +73,7 @@ class ResultTest extends \lithium\test\Unit {
 
 		$resource = new PDOStatement;
 		$result = new Result(compact('resource'));
-		$this->assertTrue($result->resource() instanceof PDOStatement);
+		$this->assertInstanceOf('PDOStatement', $result->resource());
 	}
 
 	public function testNext() {

--- a/tests/cases/data/source/http/adapter/CouchDbTest.php
+++ b/tests/cases/data/source/http/adapter/CouchDbTest.php
@@ -44,11 +44,11 @@ class CouchDbTest extends \lithium\test\Unit {
 	}
 
 	public function testAllMethodsNoConnection() {
-		$this->assertTrue($this->db->connect());
-		$this->assertTrue($this->db->disconnect());
-		$this->assertFalse($this->db->get());
-		$this->assertFalse($this->db->post());
-		$this->assertFalse($this->db->put());
+		$this->assertNotEmpty($this->db->connect());
+		$this->assertNotEmpty($this->db->disconnect());
+		$this->assertEmpty($this->db->get());
+		$this->assertEmpty($this->db->post());
+		$this->assertEmpty($this->db->put());
 	}
 
 	public function testConnect() {
@@ -73,7 +73,7 @@ class CouchDbTest extends \lithium\test\Unit {
 
 	public function testDescribe() {
 		$couchdb = new CouchDb($this->_testConfig);
-		$this->assertTrue(is_object($couchdb->describe('companies')));
+		$this->assertInternalType('object', $couchdb->describe('companies'));
 	}
 
 	public function testItem() {
@@ -122,7 +122,7 @@ class CouchDbTest extends \lithium\test\Unit {
 		$couchdb = new CouchDb($this->_testConfig);
 
 		$result = $couchdb->read($this->query);
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 		$this->assertEqual(array('total_rows' => 3, 'offset' => 0), $result->stats());
 
 		$expected = '/lithium-test/_all_docs';
@@ -139,7 +139,7 @@ class CouchDbTest extends \lithium\test\Unit {
 
 		$this->query->conditions(array('id' => 12345));
 		$result = $couchdb->read($this->query);
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 
 		$expected = '/lithium-test/12345';
 		$result = $couchdb->last->request->path;
@@ -151,7 +151,7 @@ class CouchDbTest extends \lithium\test\Unit {
 
 		$this->query->conditions(array('id' => 12345, 'path' => '/lithium-test/12345'));
 		$result = $couchdb->read($this->query);
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 	}
 
 	public function testReadWithViewConditions() {

--- a/tests/cases/data/source/mongo_db/ExporterTest.php
+++ b/tests/cases/data/source/mongo_db/ExporterTest.php
@@ -133,13 +133,13 @@ class ExporterTest extends \lithium\test\Unit {
 			))),
 			'deeply' => new Document(array('exists' => true, 'data' => array('nested' => 'object')))
 		)));
-		$this->assertFalse(Exporter::get('update', $doc->export()));
+		$this->assertEmpty(Exporter::get('update', $doc->export()));
 	}
 
 	public function testUpdateFromResourceLoading() {
 		$resource = new MockResult();
 		$doc = new DocumentSet(array('model' => $this->_model, 'result' => $resource));
-		$this->assertFalse(Exporter::get('update', $doc->export()));
+		$this->assertEmpty(Exporter::get('update', $doc->export()));
 		$this->assertEqual('dib', $doc['6c8f86167675abfabdbf0302']->title);
 
 		$doc['6c8f86167675abfabdbf0302']->title = 'bob';
@@ -151,8 +151,8 @@ class ExporterTest extends \lithium\test\Unit {
 		$this->assertEqual('bill', $doc['4c8f86167675abfabdbf0300']->title);
 
 		$expected = Exporter::get('update', $doc->export());
-		$this->assertTrue(Exporter::get('update', $doc->export()));
-		$this->assertEqual(2, count($expected['update']));
+		$this->assertNotEmpty(Exporter::get('update', $doc->export()));
+		$this->assertCount(2, $expected['update']);
 	}
 
 	public function testUpdateWithSubObjects() {
@@ -285,7 +285,7 @@ class ExporterTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, Exporter::get('update', $doc->export()));
 		$doc->sync();
 
-		$this->assertFalse(Exporter::get('update', $doc->export()));
+		$this->assertEmpty(Exporter::get('update', $doc->export()));
 		$doc->append2->foo = 'baz';
 		$doc->append2->bar = 'dib';
 		$doc->deeply->nested = true;
@@ -334,15 +334,15 @@ class ExporterTest extends \lithium\test\Unit {
 		$schema = new Schema(array('fields' => $this->_schema));
 		$result = $schema->cast(null, null, $data, $options);
 		$this->assertEqual(array_keys($data), array_keys($result->data()));
-		$this->assertTrue($result->_id instanceof MongoId);
+		$this->assertInstanceOf('MongoId', $result->_id);
 		$this->assertEqual('4c8f86167675abfabd970300', (string) $result->_id);
 
-		$this->assertTrue($result->comments instanceof DocumentSet);
-		$this->assertEqual(3, count($result['comments']));
+		$this->assertInstanceOf('lithium\data\collection\DocumentSet', $result->comments);
+		$this->assertCount(3, $result['comments']);
 
-		$this->assertTrue($result->comments[0] instanceof MongoId);
-		$this->assertTrue($result->comments[1] instanceof MongoId);
-		$this->assertTrue($result->comments[2] instanceof MongoId);
+		$this->assertInstanceOf('MongoId', $result->comments[0]);
+		$this->assertInstanceOf('MongoId', $result->comments[1]);
+		$this->assertInstanceOf('MongoId', $result->comments[2]);
 		$this->assertEqual('4c8f86167675abfabdbe0300', (string) $result->comments[0]);
 		$this->assertEqual('4c8f86167675abfabdbf0300', (string) $result->comments[1]);
 		$this->assertEqual('4c8f86167675abfabdc00300', (string) $result->comments[2]);
@@ -350,13 +350,13 @@ class ExporterTest extends \lithium\test\Unit {
 		$this->assertEqual($data['comments'], $result->comments->data());
 		$this->assertEqual(array('test'), $result->tags->data());
 		$this->assertEqual(array('4c8f86167675abfabdb00300'), $result->authors->data());
-		$this->assertTrue($result->authors[0] instanceof MongoId);
+		$this->assertInstanceOf('MongoId', $result->authors[0]);
 
-		$this->assertTrue($result->modified instanceof MongoDate);
-		$this->assertTrue($result->created instanceof MongoDate);
-		$this->assertTrue($result->created->sec > 0);
+		$this->assertInstanceOf('MongoDate', $result->modified);
+		$this->assertInstanceOf('MongoDate', $result->created);
+		$this->assertGreaterThan($result->created->sec, 0);
 
-		$this->assertTrue($result->empty_array instanceof DocumentSet);
+		$this->assertInstanceOf('lithium\data\collection\DocumentSet', $result->empty_array);
 
 		$this->assertEqual($time, $result->modified->sec);
 		$this->assertEqual($time, $result->created->sec);
@@ -391,23 +391,23 @@ class ExporterTest extends \lithium\test\Unit {
 		$result = $schema->cast(null, null, $data, $options);
 
 		$this->assertEqual(array_keys($data), array_keys($result->data()));
-		$this->assertTrue($result->_id instanceof MongoId);
+		$this->assertInstanceOf('MongoId', $result->_id);
 		$this->assertEqual('4c8f86167675abfabd970300', (string) $result->_id);
 
-		$this->assertTrue($result->accounts instanceof DocumentSet);
-		$this->assertEqual(2, count($result->accounts));
+		$this->assertInstanceOf('lithium\data\collection\DocumentSet', $result->accounts);
+		$this->assertCount(2, $result->accounts);
 
 		$id1 = '4fb6e2dd3e91581fe6e75736';
 		$id2 = '4fb6e2df3e91581fe6e75737';
-		$this->assertTrue($result->accounts[$id1]['_id'] instanceof MongoId);
+		$this->assertInstanceOf('MongoId', $result->accounts[$id1]['_id']);
 		$this->assertEqual($id1, (string) $result->accounts[$id1]['_id']);
-		$this->assertTrue($result->accounts[$id2]['_id'] instanceof MongoId);
+		$this->assertInstanceOf('MongoId', $result->accounts[$id2]['_id']);
 		$this->assertEqual($id2, (string) $result->accounts[$id2]['_id']);
 
-		$this->assertTrue($result->accounts[$id1]['created'] instanceof MongoDate);
-		$this->assertTrue($result->accounts[$id1]['created']->sec > 0);
-		$this->assertTrue($result->accounts[$id2]['created'] instanceof MongoDate);
-		$this->assertTrue($result->accounts[$id2]['created']->sec > 0);
+		$this->assertInstanceOf('MongoDate', $result->accounts[$id1]['created']);
+		$this->assertGreaterThan($result->accounts[$id1]['created']->sec, 0);
+		$this->assertInstanceOf('MongoDate', $result->accounts[$id2]['created']);
+		$this->assertGreaterThan($result->accounts[$id2]['created']->sec, 0);
 	}
 
 	public function testWithArraySchema() {
@@ -580,11 +580,11 @@ class ExporterTest extends \lithium\test\Unit {
 			'similar_text.magazines' => array('type' => 'MongoId', 'array' => true)
 		)));
 		$result = $schema->cast(null, null, $data, $options);
-		$this->assertTrue($result['similar_text']['articles'][0] instanceof MongoId);
-		$this->assertTrue($result['similar_text']['books'][0] instanceof MongoId);
-		$this->assertTrue($result['similar_text']['books'][1] instanceof MongoId);
-		$this->assertTrue($result['similar_text']['magazines'][0] instanceof MongoId);
-		$this->assertTrue($result['similar_text']['magazines'][1] instanceof MongoId);
+		$this->assertInstanceOf('MongoId', $result['similar_text']['articles'][0]);
+		$this->assertInstanceOf('MongoId', $result['similar_text']['books'][0]);
+		$this->assertInstanceOf('MongoId', $result['similar_text']['books'][1]);
+		$this->assertInstanceOf('MongoId', $result['similar_text']['magazines'][0]);
+		$this->assertInstanceOf('MongoId', $result['similar_text']['magazines'][1]);
 	}
 
 	/**
@@ -604,12 +604,12 @@ class ExporterTest extends \lithium\test\Unit {
 		$doc->list[] = new MongoId();
 		$result = Exporter::get('update', $doc->export());
 
-		$this->assertEqual(1, count($result));
-		$this->assertEqual(1, count($result['update']));
-		$this->assertEqual(5, count($result['update']['list']));
+		$this->assertCount(1, $result);
+		$this->assertCount(1, $result['update']);
+		$this->assertCount(5, $result['update']['list']);
 
 		for ($i = 0; $i < 5; $i++) {
-			$this->assertTrue($result['update']['list'][$i] instanceof MongoId);
+			$this->assertInstanceOf('MongoId', $result['update']['list'][$i]);
 		}
 
 		$doc = new Document(array('exists' => true, 'data' => array(
@@ -618,12 +618,12 @@ class ExporterTest extends \lithium\test\Unit {
 		$doc->list = array(new MongoId(), new MongoId(), new MongoId());
 		$result = Exporter::get('update', $doc->export());
 
-		$this->assertEqual(1, count($result));
-		$this->assertEqual(1, count($result['update']));
-		$this->assertEqual(3, count($result['update']['list']));
+		$this->assertCount(1, $result);
+		$this->assertCount(1, $result['update']);
+		$this->assertCount(3, $result['update']['list']);
 
 		for ($i = 0; $i < 3; $i++) {
-			$this->assertTrue($result['update']['list'][$i] instanceof MongoId);
+			$this->assertInstanceOf('MongoId', $result['update']['list'][$i]);
 		}
 	}
 
@@ -720,8 +720,10 @@ class ExporterTest extends \lithium\test\Unit {
 		$model = $this->_model;
 
 		$array = new DocumentSet(compact('model', 'schema', 'data'));
-		$this->assertTrue($array['4c8f86167675abfabd970300']->accounts instanceof DocumentSet);
-		$this->assertTrue($array['4c8f86167675abfabd970301']->accounts instanceof DocumentSet);
+		$obj = $array['4c8f86167675abfabd970300']->accounts;
+		$this->assertInstanceOf('lithium\data\collection\DocumentSet', $obj);
+		$obj = $array['4c8f86167675abfabd970301']->accounts;
+		$this->assertInstanceOf('lithium\data\collection\DocumentSet', $obj);
 
 		$result = Exporter::get('create', $array->export());
 		$this->assertTrue(isset($result['create'][0]));
@@ -766,8 +768,7 @@ class ExporterTest extends \lithium\test\Unit {
 		$model = $this->_model;
 
 		$document = new Document(compact('model', 'schema', 'data'));
-		$this->assertTrue($document->accounts instanceof DocumentSet);
-		$this->assertTrue($document->accounts instanceof DocumentSet);
+		$this->assertInstanceOf('lithium\data\collection\DocumentSet', $document->accounts);
 
 		$export = $document->export();
 		$result = Exporter::get('create', $document->export());
@@ -795,7 +796,7 @@ class ExporterTest extends \lithium\test\Unit {
 		$model = $this->_model;
 
 		$document = new Document(compact('model', 'schema', 'data'));
-		$this->assertTrue($document->accounts[0] instanceof Document);
+		$this->assertInstanceOf('lithium\data\entity\Document', $document->accounts[0]);
 	}
 }
 

--- a/tests/cases/data/source/mongo_db/SchemaTest.php
+++ b/tests/cases/data/source/mongo_db/SchemaTest.php
@@ -35,8 +35,8 @@ class SchemaTest extends \lithium\test\Unit {
 		));
 
 		$this->assertEqual(array('users'), array_keys($result->data()));
-		$this->assertEqual(1, count($result->users));
-		$this->assertTrue($result->users[0] instanceof MongoId);
+		$this->assertCount(1, $result->users);
+		$this->assertInstanceOf('MongoId', $result->users[0]);
 	}
 
 	public function testCastingEmptyValues() {

--- a/tests/cases/g11n/MessageTest.php
+++ b/tests/cases/g11n/MessageTest.php
@@ -291,7 +291,7 @@ class MessageTest extends \lithium\test\Unit {
 		$data = array('catalog' => 'Katalog');
 		Catalog::write('runtime', 'message', 'de', $data, array('scope' => 'foo'));
 
-		$this->assertFalse(Message::cache());
+		$this->assertEmpty(Message::cache());
 
 		$result = Message::translate('catalog', array('locale' => 'de', 'scope' => 'foo'));
 		$this->assertEqual('Katalog', $result);
@@ -300,7 +300,7 @@ class MessageTest extends \lithium\test\Unit {
 		$this->assertEqual('Katalog', $cache['foo']['de']['catalog']);
 
 		Message::cache(false);
-		$this->assertFalse(Message::cache());
+		$this->assertEmpty(Message::cache());
 
 		Message::cache(array('foo' => array('de' => array('catalog' => '<Katalog>'))));
 		$result = Message::translate('catalog', array('locale' => 'de', 'scope' => 'foo'));

--- a/tests/cases/g11n/catalog/adapter/CodeTest.php
+++ b/tests/cases/g11n/catalog/adapter/CodeTest.php
@@ -238,7 +238,7 @@ EOD;
 		$this->adapter = new Code(array('path' => $this->_path, 'scope' => 'li3_bot'));
 
 		$results = $this->adapter->read('messageTemplate', 'root', null);
-		$this->assertFalse($results);
+		$this->assertEmpty($results);
 
 		$results = $this->adapter->read('messageTemplate', 'root', 'li3_bot');
 		$expected = array('singular' => 'simple 1');
@@ -248,7 +248,7 @@ EOD;
 
 	public function testNoReadSupportForOtherCategories() {
 		$result = $this->adapter->read('message', 'de', null);
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 	}
 }
 

--- a/tests/cases/g11n/catalog/adapter/GettextTest.php
+++ b/tests/cases/g11n/catalog/adapter/GettextTest.php
@@ -54,7 +54,7 @@ class GettextTest extends \lithium\test\Unit {
 
 	public function testReadNonExistent() {
 		$result = $this->adapter->read('messageTemplate', 'root', null);
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 	}
 
 	public function testReadUnreadable() {
@@ -229,7 +229,7 @@ EOD;
 		file_put_contents($file, $data);
 
 		$result = $this->adapter->read('message', 'de', null);
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 	}
 
 	public function testReadAndWritePoWithFlagsAndComments() {
@@ -478,7 +478,7 @@ EOD;
 			)
 		);
 		$this->adapter->write('message', 'de', null, $data);
-		$this->assertTrue(file_exists("{$this->_path}/de/LC_MESSAGES/default.po"));
+		$this->assertFileExists("{$this->_path}/de/LC_MESSAGES/default.po");
 	}
 
 	public function testWriteMessageTemplateCompilesPot() {
@@ -493,7 +493,7 @@ EOD;
 			)
 		);
 		$this->adapter->write('messageTemplate', 'root', null, $data);
-		$this->assertTrue(file_exists("{$this->_path}/message_default.pot"));
+		$this->assertFileExists("{$this->_path}/message_default.pot");
 	}
 
 	public function testWriteReadPo() {
@@ -798,7 +798,7 @@ EOD;
 		file_put_contents($file, $data);
 
 		$result = $this->adapter->read('message', 'de', null);
-		$this->assertTrue(is_callable($result['pluralRule']['translated']));
+		$this->assertInternalType('callable', $result['pluralRule']['translated']);
 		$this->assertEqual(true, $result['pluralRule']['translated'](3));
 		$this->assertEqual(0, $result['pluralRule']['translated'](1));
 	}

--- a/tests/cases/g11n/catalog/adapter/MemoryTest.php
+++ b/tests/cases/g11n/catalog/adapter/MemoryTest.php
@@ -42,7 +42,7 @@ class MemoryTest extends \lithium\test\Unit {
 
 	public function testReadNonExistent() {
 		$result = $this->adapter->read('messageTemplate', 'root', null);
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 	}
 }
 

--- a/tests/cases/g11n/catalog/adapter/PhpTest.php
+++ b/tests/cases/g11n/catalog/adapter/PhpTest.php
@@ -128,7 +128,7 @@ EOD;
 		file_put_contents("{$this->_path}/fr/message/li3_docs.php", $data);
 
 		$result = $this->adapter->read('message', 'fr', null);
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 
 		$result = $this->adapter->read('message', 'fr', 'li3_docs');
 		$expected = array(
@@ -193,7 +193,7 @@ EOD;
 		);
 		$this->assertEqual($expected, $result['politics']);
 
-		$this->assertTrue(is_callable($result['plural']['translated']));
+		$this->assertInternalType('callable', $result['plural']['translated']);
 
 		$expected = 123;
 		$result = $result['plural']['translated']();

--- a/tests/cases/net/SocketTest.php
+++ b/tests/cases/net/SocketTest.php
@@ -10,7 +10,6 @@ namespace lithium\tests\cases\net;
 
 use lithium\tests\mocks\net\http\MockSocket;
 use lithium\net\http\Request;
-use lithium\net\http\Response;
 
 class SocketTest extends \lithium\test\Unit {
 
@@ -25,8 +24,8 @@ class SocketTest extends \lithium\test\Unit {
 		$socket = new MockSocket();
 		$message = new Request();
 		$response = $socket->send($message, array('response' => 'lithium\net\http\Response'));
-		$this->assertTrue($response instanceof Response);
-		$this->assertTrue($socket->data instanceof Request);
+		$this->assertInstanceOf('lithium\net\http\Response', $response);
+		$this->assertInstanceOf('lithium\net\http\Request', $socket->data);
 	}
 }
 

--- a/tests/cases/net/http/MediaTest.php
+++ b/tests/cases/net/http/MediaTest.php
@@ -216,7 +216,7 @@ class MediaTest extends \lithium\test\Unit {
 		$this->assertPattern('%^foo/media_test/css/debug\.css\?type=test&\d+$%', $result);
 
 		$file = Media::path('css/debug.css', 'bar', array('library' => 'media_test'));
-		$this->assertTrue(file_exists($file));
+		$this->assertFileExists($file);
 
 		$result = Media::asset('this.file.should.not.exist', 'css', array('check' => true));
 		$this->assertFalse($result);
@@ -630,7 +630,7 @@ class MediaTest extends \lithium\test\Unit {
 		}
 
 		Libraries::add('media_test', array('path' => "{$resources}/media_test"));
-		$this->assertTrue(is_dir(Media::webroot('media_test')));
+		$this->assertFileExists(Media::webroot('media_test'));
 		Libraries::remove('media_test');
 		rmdir($webroot);
 	}

--- a/tests/cases/net/http/MessageTest.php
+++ b/tests/cases/net/http/MessageTest.php
@@ -28,7 +28,7 @@ class MessageTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 
 		$result = $this->message->headers('Host', false);
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 	}
 
 	public function testHeaderKeyValue() {

--- a/tests/cases/net/http/ResponseTest.php
+++ b/tests/cases/net/http/ResponseTest.php
@@ -409,7 +409,7 @@ class ResponseTest extends \lithium\test\Unit {
 		$body = "\n<html>...</html>\n";
 		$message = "\r\n\r\n{$body}";
 		$response = new Response(compact('message'));
-		$this->assertFalse($response->headers());
+		$this->assertEmpty($response->headers());
 		$this->assertEqual(trim($body), $response->body());
 	}
 

--- a/tests/cases/net/http/RouterTest.php
+++ b/tests/cases/net/http/RouterTest.php
@@ -9,7 +9,6 @@
 namespace lithium\tests\cases\net\http;
 
 use lithium\action\Request;
-use lithium\net\http\Route;
 use lithium\net\http\Router;
 use lithium\action\Response;
 
@@ -50,7 +49,7 @@ class RouterTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result->export());
 
 		$result = Router::connect('/{:controller}/{:action}', array('action' => 'view'));
-		$this->assertTrue($result instanceof Route);
+		$this->assertInstanceOf('lithium\net\http\Route', $result);
 		$expected = array(
 			'template' => '/{:controller}/{:action}',
 			'pattern' => '@^(?:/(?P<controller>[^\\/]+))(?:/(?P<action>[^\\/]+)?)?$@u',
@@ -452,7 +451,7 @@ class RouterTest extends \lithium\test\Unit {
 		$this->assertEqual(array('controller'), $request->persist);
 
 		$request = Router::process(new Request(array('url' => '/remove/foo/bar')));
-		$this->assertFalse($request->params);
+		$this->assertEmpty($request->params);
 	}
 
 	/**
@@ -539,7 +538,7 @@ class RouterTest extends \lithium\test\Unit {
 		});
 
 		$result = Router::process(new Request(array('url' => '/users/login')));
-		$this->assertTrue($result instanceof Response);
+		$this->assertInstanceOf('lithium\action\Response', $result);
 
 		$headers = array('Location' => '/login');
 		$this->assertEqual($headers, $result->headers);
@@ -616,7 +615,7 @@ class RouterTest extends \lithium\test\Unit {
 			'REQUEST_METHOD' => 'POST'
 		)));
 		$params = Router::process($request)->params;
-		$this->assertFalse($params);
+		$this->assertEmpty($params);
 	}
 
 	/**
@@ -720,7 +719,7 @@ class RouterTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, Router::process($request)->params);
 
 		$request = new Request(array('url' => '/en/admin/foo/bar/5'));
-		$this->assertFalse(Router::process($request)->params);
+		$this->assertEmpty(Router::process($request)->params);
 
 		$result = Router::match(array('Foo::bar', 'id' => 5));
 		$this->assertEqual('/foo/bar/5', $result);

--- a/tests/cases/net/http/ServiceTest.php
+++ b/tests/cases/net/http/ServiceTest.php
@@ -29,10 +29,10 @@ class ServiceTest extends \lithium\test\Unit {
 
 	public function testAllMethodsNoConnection() {
 		$http = new Service(array('init' => false));
-		$this->assertFalse($http->get());
-		$this->assertFalse($http->post());
-		$this->assertFalse($http->put());
-		$this->assertFalse($http->delete());
+		$this->assertEmpty($http->get());
+		$this->assertEmpty($http->post());
+		$this->assertEmpty($http->put());
+		$this->assertEmpty($http->delete());
 	}
 
 	public function testRequestPath() {

--- a/tests/cases/net/socket/ContextTest.php
+++ b/tests/cases/net/socket/ContextTest.php
@@ -30,7 +30,7 @@ class ContextTest extends \lithium\test\Unit {
 
 	public function testConstruct() {
 		$subject = new Context(array('timeout' => 300) + $this->_testConfig);
-		$this->assertTrue(300, $subject->timeout());
+		$this->assertEqual(300, $subject->timeout());
 		unset($subject);
 	}
 
@@ -49,7 +49,7 @@ class ContextTest extends \lithium\test\Unit {
 
 	public function testOpen() {
 		$stream = new Context($this->_testConfig);
-		$this->assertTrue(is_resource($stream->open()));
+		$this->assertInternalType('resource', $stream->open());
 	}
 
 	public function testClose() {
@@ -69,48 +69,48 @@ class ContextTest extends \lithium\test\Unit {
 
 	public function testMessageInConfig() {
 		$socket = new Context(array('message' => new Request($this->_testConfig)));
-		$this->assertTrue(is_resource($socket->open()));
+		$this->assertInternalType('resource', $socket->open());
 	}
 
 	public function testWriteAndRead() {
 		$stream = new Context($this->_testConfig);
-		$this->assertTrue(is_resource($stream->open()));
-		$this->assertTrue(is_resource($stream->resource()));
+		$this->assertInternalType('resource', $stream->open());
+		$this->assertInternalType('resource', $stream->resource());
 		$this->assertEqual(1, $stream->write());
 		$this->assertPattern("/^HTTP/", (string) $stream->read());
 	}
 
 	public function testSendWithNull() {
 		$stream = new Context($this->_testConfig);
-		$this->assertTrue(is_resource($stream->open()));
+		$this->assertInternalType('resource', $stream->open());
 		$result = $stream->send(
 			new Request($this->_testConfig),
 			array('response' => 'lithium\net\http\Response')
 		);
-		$this->assertTrue($result instanceof Response);
+		$this->assertInstanceOf('lithium\net\http\Response', $result);
 		$this->assertPattern("/^HTTP/", (string) $result);
 		$this->assertTrue($stream->eof());
 	}
 
 	public function testSendWithArray() {
 		$stream = new Context($this->_testConfig);
-		$this->assertTrue(is_resource($stream->open()));
+		$this->assertInternalType('resource', $stream->open());
 		$result = $stream->send($this->_testConfig,
 			array('response' => 'lithium\net\http\Response')
 		);
-		$this->assertTrue($result instanceof Response);
+		$this->assertInstanceOf('lithium\net\http\Response', $result);
 		$this->assertPattern("/^HTTP/", (string) $result);
 		$this->assertTrue($stream->eof());
 	}
 
 	public function testSendWithObject() {
 		$stream = new Context($this->_testConfig);
-		$this->assertTrue(is_resource($stream->open()));
+		$this->assertInternalType('resource', $stream->open());
 		$result = $stream->send(
 			new Request($this->_testConfig),
 			array('response' => 'lithium\net\http\Response')
 		);
-		$this->assertTrue($result instanceof Response);
+		$this->assertInstanceOf('lithium\net\http\Response', $result);
 		$this->assertPattern("/^HTTP/", (string) $result);
 		$this->assertTrue($stream->eof());
 	}

--- a/tests/cases/net/socket/CurlTest.php
+++ b/tests/cases/net/socket/CurlTest.php
@@ -8,7 +8,6 @@
 
 namespace lithium\tests\cases\net\socket;
 
-use lithium\net\http\Response;
 use lithium\net\http\Request;
 use lithium\net\socket\Curl;
 
@@ -46,7 +45,7 @@ class CurlTest extends \lithium\test\Unit {
 		$this->assertFalse($stream->open());
 		$this->assertTrue($stream->close());
 		$this->assertFalse($stream->timeout(2));
-		$this->assertFalse($stream->encoding('UTF-8'));
+		$this->assertEmpty($stream->encoding('UTF-8'));
 		$this->assertFalse($stream->write(null));
 		$this->assertFalse($stream->read());
 	}
@@ -54,22 +53,22 @@ class CurlTest extends \lithium\test\Unit {
 	public function testOpen() {
 		$stream = new Curl($this->_testConfig);
 		$result = $stream->open();
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 
 		$result = $stream->resource();
-		$this->assertTrue(is_resource($result));
+		$this->assertInternalType('resource', $result);
 	}
 
 	public function testClose() {
 		$stream = new Curl($this->_testConfig);
 		$result = $stream->open();
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 
 		$result = $stream->close();
 		$this->assertTrue($result);
 
 		$result = $stream->resource();
-		$this->assertFalse(is_resource($result));
+		$this->assertNotInternalType('resource', $result);
 	}
 
 	public function testTimeout() {
@@ -77,7 +76,7 @@ class CurlTest extends \lithium\test\Unit {
 		$result = $stream->open();
 		$stream->timeout(10);
 		$result = $stream->resource();
-		$this->assertTrue(is_resource($result));
+		$this->assertInternalType('resource', $result);
 	}
 
 	public function testEncoding() {
@@ -85,51 +84,51 @@ class CurlTest extends \lithium\test\Unit {
 		$result = $stream->open();
 		$stream->encoding('UTF-8');
 		$result = $stream->resource();
-		$this->assertTrue(is_resource($result));
+		$this->assertInternalType('resource', $result);
 
 		$stream = new Curl($this->_testConfig + array('encoding' => 'UTF-8'));
 		$result = $stream->open();
 		$result = $stream->resource();
-		$this->assertTrue(is_resource($result));
+		$this->assertInternalType('resource', $result);
 	}
 
 	public function testWriteAndRead() {
 		$stream = new Curl($this->_testConfig);
-		$this->assertTrue(is_resource($stream->open()));
-		$this->assertTrue(is_resource($stream->resource()));
+		$this->assertInternalType('resource', $stream->open());
+		$this->assertInternalType('resource', $stream->resource());
 		$this->assertEqual(1, $stream->write());
 		$this->assertPattern("/^HTTP/", (string) $stream->read());
 	}
 
 	public function testSendWithNull() {
 		$stream = new Curl($this->_testConfig);
-		$this->assertTrue(is_resource($stream->open()));
+		$this->assertInternalType('resource', $stream->open());
 		$result = $stream->send(
 			new Request($this->_testConfig),
 			array('response' => 'lithium\net\http\Response')
 		);
-		$this->assertTrue($result instanceof Response);
+		$this->assertInstanceOf('lithium\net\http\Response', $result);
 		$this->assertPattern("/^HTTP/", (string) $result);
 	}
 
 	public function testSendWithArray() {
 		$stream = new Curl($this->_testConfig);
-		$this->assertTrue(is_resource($stream->open()));
+		$this->assertInternalType('resource', $stream->open());
 		$result = $stream->send($this->_testConfig,
 			array('response' => 'lithium\net\http\Response')
 		);
-		$this->assertTrue($result instanceof Response);
+		$this->assertInstanceOf('lithium\net\http\Response', $result);
 		$this->assertPattern("/^HTTP/", (string) $result);
 	}
 
 	public function testSendWithObject() {
 		$stream = new Curl($this->_testConfig);
-		$this->assertTrue(is_resource($stream->open()));
+		$this->assertInternalType('resource', $stream->open());
 		$result = $stream->send(
 			new Request($this->_testConfig),
 			array('response' => 'lithium\net\http\Response')
 		);
-		$this->assertTrue($result instanceof Response);
+		$this->assertInstanceOf('lithium\net\http\Response', $result);
 		$this->assertPattern("/^HTTP/", (string) $result);
 	}
 
@@ -156,12 +155,12 @@ class CurlTest extends \lithium\test\Unit {
 	public function testSendPostThenGet() {
 		$postConfig = array('method' => 'POST', 'body' => '{"body"}');
 		$stream = new Curl($this->_testConfig);
-		$this->assertTrue(is_resource($stream->open()));
+		$this->assertInternalType('resource', $stream->open());
 		$this->assertTrue($stream->write(new Request($postConfig + $this->_testConfig)));
 		$this->assertTrue(isset($stream->options[CURLOPT_POST]));
 		$this->assertTrue($stream->close());
 
-		$this->assertTrue(is_resource($stream->open()));
+		$this->assertInternalType('resource', $stream->open());
 		$this->assertTrue($stream->write(new Request($this->_testConfig)));
 		$this->assertFalse(isset($stream->options[CURLOPT_POST]));
 		$this->assertTrue($stream->close());
@@ -170,7 +169,7 @@ class CurlTest extends \lithium\test\Unit {
 	public function testSendPutThenGet() {
 		$postConfig = array('method' => 'PUT', 'body' => '{"body"}');
 		$stream = new Curl($this->_testConfig);
-		$this->assertTrue(is_resource($stream->open()));
+		$this->assertInternalType('resource', $stream->open());
 		$this->assertTrue($stream->write(new Request($postConfig + $this->_testConfig)));
 		$this->assertTrue(isset($stream->options[CURLOPT_CUSTOMREQUEST]));
 		$this->assertEqual($stream->options[CURLOPT_CUSTOMREQUEST],'PUT');
@@ -178,7 +177,7 @@ class CurlTest extends \lithium\test\Unit {
 		$this->assertEqual($stream->options[CURLOPT_POSTFIELDS],$postConfig['body']);
 		$this->assertTrue($stream->close());
 
-		$this->assertTrue(is_resource($stream->open()));
+		$this->assertInternalType('resource', $stream->open());
 		$this->assertTrue($stream->write(new Request($this->_testConfig)));
 		$this->assertFalse(isset($stream->options[CURLOPT_CUSTOMREQUEST]));
 		$this->assertTrue($stream->close());

--- a/tests/cases/net/socket/StreamTest.php
+++ b/tests/cases/net/socket/StreamTest.php
@@ -43,22 +43,22 @@ class StreamTest extends \lithium\test\Unit {
 	public function testOpen() {
 		$stream = new Stream($this->_testConfig);
 		$result = $stream->open();
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 
 		$result = $stream->resource();
-		$this->assertTrue(is_resource($result));
+		$this->assertInternalType('resource', $result);
 	}
 
 	public function testClose() {
 		$stream = new Stream($this->_testConfig);
 		$result = $stream->open();
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 
 		$result = $stream->close();
 		$this->assertTrue($result);
 
 		$result = $stream->resource();
-		$this->assertFalse(is_resource($result));
+		$this->assertNotInternalType('resource', $result);
 	}
 
 	public function testTimeout() {
@@ -66,7 +66,7 @@ class StreamTest extends \lithium\test\Unit {
 		$result = $stream->open();
 		$stream->timeout(10);
 		$result = $stream->resource();
-		$this->assertTrue(is_resource($result));
+		$this->assertInternalType('resource', $result);
 	}
 
 	public function testEncoding() {
@@ -74,18 +74,18 @@ class StreamTest extends \lithium\test\Unit {
 		$result = $stream->open();
 		$stream->encoding('UTF-8');
 		$result = $stream->resource();
-		$this->assertTrue(is_resource($result));
+		$this->assertInternalType('resource', $result);
 
 		$stream = new Stream($this->_testConfig + array('encoding' => 'UTF-8'));
 		$result = $stream->open();
 		$result = $stream->resource();
-		$this->assertTrue(is_resource($result));
+		$this->assertInternalType('resource', $result);
 	}
 
 	public function testWriteAndRead() {
 		$stream = new Stream($this->_testConfig);
-		$this->assertTrue(is_resource($stream->open()));
-		$this->assertTrue(is_resource($stream->resource()));
+		$this->assertInternalType('resource', $stream->open());
+		$this->assertInternalType('resource', $stream->resource());
 
 		$result = $stream->write();
 		$this->assertEqual(83, $result);
@@ -94,35 +94,35 @@ class StreamTest extends \lithium\test\Unit {
 
 	public function testSendWithNull() {
 		$stream = new Stream($this->_testConfig);
-		$this->assertTrue(is_resource($stream->open()));
+		$this->assertInternalType('resource', $stream->open());
 		$result = $stream->send(
 			new Request($this->_testConfig),
 			array('response' => 'lithium\net\http\Response')
 		);
-		$this->assertTrue($result instanceof Response);
+		$this->assertInstanceOf('lithium\net\http\Response', $result);
 		$this->assertPattern("/^HTTP/", (string) $result);
 		$this->assertTrue($stream->eof());
 	}
 
 	public function testSendWithArray() {
 		$stream = new Stream($this->_testConfig);
-		$this->assertTrue(is_resource($stream->open()));
+		$this->assertInternalType('resource', $stream->open());
 		$result = $stream->send($this->_testConfig,
 			array('response' => 'lithium\net\http\Response')
 		);
-		$this->assertTrue($result instanceof Response);
+		$this->assertInstanceOf('lithium\net\http\Response', $result);
 		$this->assertPattern("/^HTTP/", (string) $result);
 		$this->assertTrue($stream->eof());
 	}
 
 	public function testSendWithObject() {
 		$stream = new Stream($this->_testConfig);
-		$this->assertTrue(is_resource($stream->open()));
+		$this->assertInternalType('resource', $stream->open());
 		$result = $stream->send(
 			new Request($this->_testConfig),
 			array('response' => 'lithium\net\http\Response')
 		);
-		$this->assertTrue($result instanceof Response);
+		$this->assertInstanceOf('lithium\net\http\Response', $result);
 		$this->assertPattern("/^HTTP/", (string) $result);
 		$this->assertTrue($stream->eof());
 	}

--- a/tests/cases/security/AuthTest.php
+++ b/tests/cases/security/AuthTest.php
@@ -60,7 +60,7 @@ class AuthTest extends \lithium\test\Unit {
 		$this->assertFalse(Auth::check('test'));
 		$user = array('id' => 13, 'user' => 'bob');
 
-		$this->assertTrue(Auth::set('test', $user));
+		$this->assertNotEmpty(Auth::set('test', $user));
 
 		$result = Auth::check('test');
 		$this->assertEqual($user, $result);

--- a/tests/cases/security/auth/adapter/FormTest.php
+++ b/tests/cases/security/auth/adapter/FormTest.php
@@ -395,7 +395,7 @@ class FormTest extends \lithium\test\Unit {
 		));
 
 		$request = (object) array('data' => array('name' => 'Foo', 'password' => 'bar'));
-		$this->assertTrue($subject->check($request));
+		$this->assertNotEmpty($subject->check($request));
 	}
 }
 

--- a/tests/cases/security/auth/adapter/HttpTest.php
+++ b/tests/cases/security/auth/adapter/HttpTest.php
@@ -24,7 +24,7 @@ class HttpTest extends \lithium\test\Unit {
 	public function testCheckBasicIsFalse() {
 		$http = new MockHttp(array('method' => 'basic', 'users' => array('gwoo' => 'li3')));
 		$result = $http->check($this->request);
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 
 		$expected = array('WWW-Authenticate: Basic realm="' . basename(LITHIUM_APP_PATH) . '"');
 		$result = $http->headers;
@@ -37,7 +37,7 @@ class HttpTest extends \lithium\test\Unit {
 		));
 		$http = new MockHttp(array('method' => 'basic', 'users' => array('gwoo' => 'li3')));
 		$result = $http->check($request);
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 
 		$expected = array();
 		$result = $http->headers;
@@ -63,7 +63,7 @@ class HttpTest extends \lithium\test\Unit {
 		$request = new Request(array('env' => array('PHP_AUTH_DIGEST' => $digest)));
 		$http = new MockHttp(array('realm' => 'app', 'users' => array('gwoo' => 'li3')));
 		$result = $http->check($request);
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 
 		$expected = array();
 		$result = $http->headers;

--- a/tests/cases/storage/CacheTest.php
+++ b/tests/cases/storage/CacheTest.php
@@ -35,7 +35,7 @@ class CacheTest extends \lithium\test\Unit {
 
 	public function testBasicCacheConfig() {
 		$result = Cache::config();
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 
 		$config = array('default' => array('adapter' => '\some\adapter', 'filters' => array()));
 		$result = Cache::config($config);
@@ -221,7 +221,7 @@ class CacheTest extends \lithium\test\Unit {
 
 		Cache::write('default', 'some_key', 'some value', '+1 minute');
 		$result = Cache::read('default', 'some_key', compact('conditions'));
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 
 		$this->assertFalse(Cache::read('non_existing', 'key_value', compact('conditions')));
 	}
@@ -386,7 +386,7 @@ class CacheTest extends \lithium\test\Unit {
 		$this->assertFalse($result);
 
 		$result = Cache::read('default', 'key_value', compact('conditions'));
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 
 		$result = Cache::write('default', 'keyed', 'some data', '+1 minute', compact('conditions'));
 		$this->assertTrue($result);
@@ -415,7 +415,7 @@ class CacheTest extends \lithium\test\Unit {
 
 		$result = Cache::delete('default', 'to delete');
 		$this->assertTrue($result);
-		$this->assertFalse(Cache::read('default', 'to delete'));
+		$this->assertEmpty(Cache::read('default', 'to delete'));
 	}
 
 	public function testCacheWriteAndDeleteWithConditions() {
@@ -466,7 +466,7 @@ class CacheTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$result = Cache::read('default', 'to delete');
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 
 	}
 
@@ -500,7 +500,7 @@ class CacheTest extends \lithium\test\Unit {
 		$this->assertNull($result);
 
 		$result = Cache::config();
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 	}
 
 	public function testIncrement() {
@@ -519,7 +519,7 @@ class CacheTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$result = Cache::increment('default', 'increment');
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 
 		$result = Cache::read('default', 'increment');
 		$this->assertEqual(6, $result);
@@ -541,7 +541,7 @@ class CacheTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$result = Cache::decrement('default', 'decrement');
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 
 		$result = Cache::read('default', 'decrement');
 		$this->assertEqual(4, $result);
@@ -559,7 +559,7 @@ class CacheTest extends \lithium\test\Unit {
 
 	public function testIntegrationFileAdapterCacheConfig() {
 		$result = Cache::config();
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 		$config = array('default' => array('adapter' => 'File', 'filters' => array()));
 
 		Cache::config($config);
@@ -578,7 +578,7 @@ class CacheTest extends \lithium\test\Unit {
 		Cache::config($config);
 
 		$result = Cache::write('default', 'key', 'value', '+1 minute');
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 
 		$time = time() + 60;
 		$result = file_get_contents("{$path}/key");
@@ -587,7 +587,7 @@ class CacheTest extends \lithium\test\Unit {
 
 		$result = unlink("{$path}/key");
 		$this->assertTrue($result);
-		$this->assertFalse(file_exists("{$path}/key"));
+		$this->assertFileNotExists("{$path}/key");
 	}
 
 	public function testIntegrationFileAdapterWithStrategies() {
@@ -604,7 +604,7 @@ class CacheTest extends \lithium\test\Unit {
 
 		$data = array('some' => 'data');
 		$result = Cache::write('default', 'key', $data, '+1 minute');
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 
 		$time = time() + 60;
 		$result = file_get_contents("{$path}/key");
@@ -617,7 +617,7 @@ class CacheTest extends \lithium\test\Unit {
 
 		$result = unlink("{$path}/key");
 		$this->assertTrue($result);
-		$this->assertFalse(file_exists("{$path}/key"));
+		$this->assertFileNotExists("{$path}/key");
 	}
 
 	public function testIntegrationFileAdapterMultipleStrategies() {
@@ -634,7 +634,7 @@ class CacheTest extends \lithium\test\Unit {
 
 		$data = array('some' => 'data');
 		$result = Cache::write('default', 'key', $data, '+1 minute');
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 
 		$time = time() + 60;
 		$result = file_get_contents("{$path}/key");
@@ -647,7 +647,7 @@ class CacheTest extends \lithium\test\Unit {
 
 		$result = unlink("{$path}/key");
 		$this->assertTrue($result);
-		$this->assertFalse(file_exists("{$path}/key"));
+		$this->assertFileNotExists("{$path}/key");
 	}
 }
 

--- a/tests/cases/storage/SessionTest.php
+++ b/tests/cases/storage/SessionTest.php
@@ -56,7 +56,7 @@ class SessionTest extends \lithium\test\Unit {
 
 		Session::reset();
 		$this->assertNull(Session::read('key'));
-		$this->assertIdentical(false, Session::write('key', 'value'));
+		$this->assertFalse(Session::write('key', 'value'));
 	}
 
 	public function testNamedConfigurationReadWrite() {
@@ -78,7 +78,7 @@ class SessionTest extends \lithium\test\Unit {
 		$this->assertEqual($result, 'value');
 
 		$result = Session::read('key', array('name' => 'store2'));
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 	}
 
 	public function testSessionConfigReset() {
@@ -86,9 +86,9 @@ class SessionTest extends \lithium\test\Unit {
 		$this->assertEqual(Session::read('key'), 'value');
 
 		Session::reset();
-		$this->assertFalse(Session::config());
+		$this->assertEmpty(Session::config());
 
-		$this->assertFalse(Session::read('key'));
+		$this->assertEmpty(Session::read('key'));
 		$this->assertFalse(Session::write('key', 'value'));
 	}
 
@@ -182,7 +182,7 @@ class SessionTest extends \lithium\test\Unit {
 		));
 		$this->assertTrue(Session::write('key', 'value'));
 		$this->assertEqual(Session::read('key'), 'value');
-		$this->assertFalse(Session::read('key', array('fail' => true)));
+		$this->assertEmpty(Session::read('key', array('fail' => true)));
 	}
 
 	public function testSessionState() {
@@ -295,7 +295,7 @@ class SessionTest extends \lithium\test\Unit {
 		$encrypted = Session::read('test', array('strategies' => false));
 
 		$this->assertNotEqual($value, $encrypted);
-		$this->assertTrue(is_string($encrypted));
+		$this->assertInternalType('string', $encrypted);
 
 		$result = Session::read('test');
 		$this->assertEqual($value, $result);

--- a/tests/cases/storage/cache/adapter/ApcTest.php
+++ b/tests/cases/storage/cache/adapter/ApcTest.php
@@ -42,7 +42,7 @@ class ApcTest extends \lithium\test\Unit {
 		$expiry = '+5 seconds';
 
 		$closure = $this->Apc->write($key, $data, $expiry);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'data', 'expiry');
 		$result = $closure($this->Apc, $params, null);
@@ -60,7 +60,7 @@ class ApcTest extends \lithium\test\Unit {
 		$expiry = '+1 minute';
 
 		$closure = $this->Apc->write($key, $data, $expiry);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'data', 'expiry');
 		$result = $closure($this->Apc, $params, null);
@@ -80,7 +80,7 @@ class ApcTest extends \lithium\test\Unit {
 		$data = 'value';
 
 		$closure = $apc->write($key, $data);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'data');
 		$result = $closure($apc, $params, null);
@@ -104,7 +104,7 @@ class ApcTest extends \lithium\test\Unit {
 		$data = null;
 
 		$closure = $this->Apc->write($key, $data, $expiry);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'data', 'expiry');
 		$result = $closure($this->Apc, $params, null);
@@ -126,7 +126,7 @@ class ApcTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->Apc->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->Apc, $params, null);
@@ -143,7 +143,7 @@ class ApcTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->Apc->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->Apc, $params, null);
@@ -165,7 +165,7 @@ class ApcTest extends \lithium\test\Unit {
 		$data = null;
 
 		$closure = $this->Apc->write($key, $data, $expiry);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'data', 'expiry');
 		$result = $closure($this->Apc, $params, null);
@@ -186,7 +186,7 @@ class ApcTest extends \lithium\test\Unit {
 	public function testReadKeyThatDoesNotExist() {
 		$key = 'does_not_exist';
 		$closure = $this->Apc->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->Apc, $params, null);
@@ -201,7 +201,7 @@ class ApcTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->Apc->delete($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->Apc, $params, null);
@@ -218,7 +218,7 @@ class ApcTest extends \lithium\test\Unit {
 		$data = null;
 
 		$closure = $this->Apc->write($key, $data, $expiry);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'data', 'expiry');
 		$result = $closure($this->Apc, $params, null);
@@ -238,7 +238,7 @@ class ApcTest extends \lithium\test\Unit {
 		$data = 'data to delete';
 
 		$closure = $this->Apc->delete($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->Apc, $params, null);
@@ -251,7 +251,7 @@ class ApcTest extends \lithium\test\Unit {
 		$expiry = '+5 seconds';
 
 		$closure = $this->Apc->write($key, $data, $expiry);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'data', 'expiry');
 		$result = $closure($this->Apc, $params, null);
@@ -262,7 +262,7 @@ class ApcTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 
 		$closure = $this->Apc->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->Apc, $params, null);
@@ -270,7 +270,7 @@ class ApcTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 
 		$closure = $this->Apc->delete($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->Apc, $params, null);
@@ -302,7 +302,7 @@ class ApcTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->Apc->decrement($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->Apc, $params, null);
@@ -323,7 +323,7 @@ class ApcTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->Apc->decrement($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->Apc, $params, null);
@@ -343,7 +343,7 @@ class ApcTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->Apc->increment($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->Apc, $params, null);
@@ -364,7 +364,7 @@ class ApcTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->Apc->increment($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->Apc, $params, null);

--- a/tests/cases/storage/cache/adapter/FileTest.php
+++ b/tests/cases/storage/cache/adapter/FileTest.php
@@ -67,21 +67,21 @@ class FileTest extends \lithium\test\Unit {
 		$time = time() + 60;
 
 		$closure = $this->File->write($key, $data, $expiry);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'data', 'expiry');
 		$result = $closure($this->File, $params, null);
 		$expected = 25;
 		$this->assertEqual($expected, $result);
 
-		$this->assertTrue(file_exists(Libraries::get(true, 'resources') . "/tmp/cache/{$key}"));
+		$this->assertFileExists(Libraries::get(true, 'resources') . "/tmp/cache/{$key}");
 		$this->assertEqual(
 			file_get_contents(Libraries::get(true, 'resources') . "/tmp/cache/{$key}"),
 			"{:expiry:$time}\ndata"
 		);
 
 		$this->assertTrue(unlink(Libraries::get(true, 'resources') . "/tmp/cache/{$key}"));
-		$this->assertFalse(file_exists(Libraries::get(true, 'resources') . "/tmp/cache/{$key}"));
+		$this->assertFileNotExists(Libraries::get(true, 'resources') . "/tmp/cache/{$key}");
 	}
 
 	public function testWriteDefaultCacheExpiry() {
@@ -91,21 +91,21 @@ class FileTest extends \lithium\test\Unit {
 		$time = time() + 60;
 
 		$closure = $file->write($key, $data);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'data');
 		$result = $closure($file, $params, null);
 		$expected = 25;
 		$this->assertEqual($expected, $result);
 
-		$this->assertTrue(file_exists(Libraries::get(true, 'resources') . "/tmp/cache/{$key}"));
+		$this->assertFileExists(Libraries::get(true, 'resources') . "/tmp/cache/{$key}");
 		$this->assertEqual(
 			file_get_contents(Libraries::get(true, 'resources') . "/tmp/cache/{$key}"),
 			"{:expiry:{$time}}\ndata"
 		);
 
 		$this->assertTrue(unlink(Libraries::get(true, 'resources') . "/tmp/cache/{$key}"));
-		$this->assertFalse(file_exists(Libraries::get(true, 'resources') . "/tmp/cache/{$key}"));
+		$this->assertFileNotExists(Libraries::get(true, 'resources') . "/tmp/cache/{$key}");
 	}
 
 	public function testRead() {
@@ -113,11 +113,11 @@ class FileTest extends \lithium\test\Unit {
 		$time = time() + 60;
 
 		$closure = $this->File->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$path = Libraries::get(true, 'resources') . "/tmp/cache/{$key}";
 		file_put_contents($path, "{:expiry:$time}\ndata");
-		$this->assertTrue(file_exists($path));
+		$this->assertFileExists($path);
 
 		$params = compact('key');
 		$result = $closure($this->File, $params, null);
@@ -128,7 +128,7 @@ class FileTest extends \lithium\test\Unit {
 		$key = 'non_existent';
 		$params = compact('key');
 		$closure = $this->File->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$result = $closure($this->File, $params, null);
 		$this->assertFalse($result);
@@ -139,11 +139,11 @@ class FileTest extends \lithium\test\Unit {
 		$time = time() + 1;
 
 		$closure = $this->File->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 		$path = Libraries::get(true, 'resources') . "/tmp/cache/{$key}";
 
 		file_put_contents($path, "{:expiry:$time}\ndata");
-		$this->assertTrue(file_exists($path));
+		$this->assertFileExists($path);
 
 		sleep(2);
 		$params = compact('key');
@@ -157,10 +157,10 @@ class FileTest extends \lithium\test\Unit {
 		$path = Libraries::get(true, 'resources') . "/tmp/cache/{$key}";
 
 		file_put_contents($path, "{:expiry:$time}\ndata");
-		$this->assertTrue(file_exists($path));
+		$this->assertFileExists($path);
 
 		$closure = $this->File->delete($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$this->assertTrue($closure($this->File, $params, null));
@@ -178,7 +178,7 @@ class FileTest extends \lithium\test\Unit {
 
 		$result = $this->File->clear();
 		$this->assertTrue($result);
-		$this->assertFalse(file_exists($path));
+		$this->assertFileNotExists($path);
 
 		$result = touch(Libraries::get(true, 'resources') . "/tmp/cache/empty");
 		$this->assertTrue($result);

--- a/tests/cases/storage/cache/adapter/MemcacheTest.php
+++ b/tests/cases/storage/cache/adapter/MemcacheTest.php
@@ -67,7 +67,7 @@ class MemcacheTest extends \lithium\test\Unit {
 		$time = strtotime($expiry);
 
 		$closure = $this->memcache->write($key, $data, $expiry);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'data', 'expiry');
 		$result = $closure($this->memcache, $params);
@@ -87,7 +87,7 @@ class MemcacheTest extends \lithium\test\Unit {
 		$data = 'value';
 
 		$closure = $memcache->write($key, $data);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'data');
 		$result = $closure($memcache, $params);
@@ -113,7 +113,7 @@ class MemcacheTest extends \lithium\test\Unit {
 		$data = null;
 
 		$closure = $this->memcache->write($key, $data, $expiry);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'data', 'expiry');
 		$result = $closure($this->memcache, $params);
@@ -138,7 +138,7 @@ class MemcacheTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->memcache->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->memcache, $params);
@@ -156,7 +156,7 @@ class MemcacheTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->memcache->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->memcache, $params);
@@ -180,7 +180,7 @@ class MemcacheTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->memcache->read(array_keys($key));
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = array('key' => array_keys($key));
 		$result = $closure($this->memcache, $params);
@@ -200,7 +200,7 @@ class MemcacheTest extends \lithium\test\Unit {
 	public function testReadKeyThatDoesNotExist() {
 		$key = 'does_not_exist';
 		$closure = $this->memcache->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->memcache, $params);
@@ -218,7 +218,7 @@ class MemcacheTest extends \lithium\test\Unit {
 		$this->assertEqual($data, $reader($this->memcache, compact('key')));
 
 		$delete = $this->memcache->delete($key);
-		$this->assertTrue(is_callable($delete));
+		$this->assertInternalType('callable', $delete);
 		$this->assertTrue($delete($this->memcache, compact('key')));
 		$this->assertNull($reader($this->memcache, compact('key')));
 	}
@@ -229,7 +229,7 @@ class MemcacheTest extends \lithium\test\Unit {
 		$time = strtotime('+1 minute');
 
 		$closure = $this->memcache->delete($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->memcache, $params);
@@ -278,11 +278,11 @@ class MemcacheTest extends \lithium\test\Unit {
 		$this->assertEqual($data, $this->_conn->get($key));
 
 		$closure = $this->memcache->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 		$this->assertEqual($data, $closure($this->memcache, compact('key')));
 
 		$closure = $this->memcache->delete($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->memcache, $params);
@@ -316,7 +316,7 @@ class MemcacheTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->memcache->decrement($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->memcache, $params);
@@ -338,7 +338,7 @@ class MemcacheTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->memcache->decrement($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->memcache, $params);
@@ -358,7 +358,7 @@ class MemcacheTest extends \lithium\test\Unit {
 		$this->assertTrue($this->_conn->set($key, $value, $time));
 
 		$closure = $this->memcache->increment($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$result = $closure($this->memcache, compact('key'));
 		$this->assertEqual($value + 1, $result);
@@ -377,7 +377,7 @@ class MemcacheTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->memcache->increment($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$result = $closure($this->memcache, compact('key'));
 

--- a/tests/cases/storage/cache/adapter/MemoryTest.php
+++ b/tests/cases/storage/cache/adapter/MemoryTest.php
@@ -31,7 +31,7 @@ class MemoryTest extends \lithium\test\Unit {
 		$expiry = null;
 
 		$closure = $this->Memory->write($key, $data, $expiry);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'data', 'expiry');
 		$result = $closure($this->Memory, $params, null);
@@ -39,7 +39,7 @@ class MemoryTest extends \lithium\test\Unit {
 		$this->assertEqual($this->Memory->cache, $result);
 
 		$closure = $this->Memory->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->Memory, $params, null);
@@ -53,7 +53,7 @@ class MemoryTest extends \lithium\test\Unit {
 		$expiry = null;
 
 		$closure = $this->Memory->write($key, $data, $expiry);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'data', 'expiry');
 		$result = $closure($this->Memory, $params, null);
@@ -61,7 +61,7 @@ class MemoryTest extends \lithium\test\Unit {
 		$this->assertEqual($this->Memory->cache, $result);
 
 		$closure = $this->Memory->read(array_keys($key));
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = array('key' => array_keys($key));
 		$result = $closure($this->Memory, $params, null);
@@ -74,7 +74,7 @@ class MemoryTest extends \lithium\test\Unit {
 		$expiry = null;
 
 		$closure = $this->Memory->write($key, $data, $expiry);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'data');
 		$result = $closure($this->Memory, $params, null);
@@ -82,7 +82,7 @@ class MemoryTest extends \lithium\test\Unit {
 		$this->assertEqual($this->Memory->cache, $result);
 
 		$closure = $this->Memory->delete($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->Memory, $params, null);
@@ -100,7 +100,7 @@ class MemoryTest extends \lithium\test\Unit {
 		$expiry = null;
 
 		$closure = $this->Memory->write($key, $data, $expiry);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'data');
 		$result = $closure($this->Memory, $params, null);
@@ -111,7 +111,7 @@ class MemoryTest extends \lithium\test\Unit {
 		$data2 = 'data to be cleared';
 
 		$closure = $this->Memory->write($key2, $data2, $expiry);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = array('key' => $key2, 'data' => $data2);
 		$result = $closure($this->Memory, $params, null);
@@ -123,7 +123,7 @@ class MemoryTest extends \lithium\test\Unit {
 		$this->assertEqual(array(), $this->Memory->cache);
 
 		$closure = $this->Memory->write($key, $data, $expiry);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'data');
 		$result = $closure($this->Memory, $params, null);
@@ -142,7 +142,7 @@ class MemoryTest extends \lithium\test\Unit {
 		$expiry = null;
 
 		$closure = $this->Memory->write($key, $data, $expiry);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'data');
 		$result = $closure($this->Memory, $params, null);
@@ -162,7 +162,7 @@ class MemoryTest extends \lithium\test\Unit {
 		$expiry = null;
 
 		$closure = $this->Memory->write($key, $data, $expiry);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'data');
 		$result = $closure($this->Memory, $params, null);

--- a/tests/cases/storage/cache/adapter/RedisTest.php
+++ b/tests/cases/storage/cache/adapter/RedisTest.php
@@ -70,7 +70,7 @@ class RedisTest extends \lithium\test\Unit {
 		$time = strtotime($expiry);
 
 		$closure = $this->redis->write($key, $data, $expiry);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'data', 'expiry');
 		$result = $closure($this->redis, $params, null);
@@ -92,7 +92,7 @@ class RedisTest extends \lithium\test\Unit {
 		$time = strtotime($expiry);
 
 		$closure = $this->redis->write($key, $data, $expiry);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'data', 'expiry');
 		$result = $closure($this->redis, $params, null);
@@ -116,7 +116,7 @@ class RedisTest extends \lithium\test\Unit {
 		$time = strtotime('+5 seconds');
 
 		$closure = $redis->write($key, $data);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'data');
 		$result = $closure($redis, $params, null);
@@ -150,7 +150,7 @@ class RedisTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->redis->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->redis, $params, null);
@@ -171,7 +171,7 @@ class RedisTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->redis->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->redis, $params, null);
@@ -188,7 +188,7 @@ class RedisTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->redis->read(array_keys($data));
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = array('key' => array_keys($data));
 		$result = $closure($this->redis, $params, null);
@@ -207,7 +207,7 @@ class RedisTest extends \lithium\test\Unit {
 		$time = strtotime($expiry);
 
 		$closure = $this->redis->write($key, $expiry);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = array('key' => $key, 'data' => $expiry, 'expiry' => null);
 		$result = $closure($this->redis, $params, null);
@@ -222,7 +222,7 @@ class RedisTest extends \lithium\test\Unit {
 	public function testReadKeyThatDoesNotExist() {
 		$key = 'does_not_exist';
 		$closure = $this->redis->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->redis, $params, null);
@@ -239,7 +239,7 @@ class RedisTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->redis->delete($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->redis, $params, null);
@@ -251,7 +251,7 @@ class RedisTest extends \lithium\test\Unit {
 	public function testDeleteNonExistentKey() {
 		$key = 'delete_key';
 		$closure = $this->redis->delete($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->redis, $params, null);
@@ -265,7 +265,7 @@ class RedisTest extends \lithium\test\Unit {
 		$time = strtotime($expiry);
 
 		$closure = $this->redis->write($key, $data, $expiry);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'data', 'expiry');
 		$result = $closure($this->redis, $params, null);
@@ -276,7 +276,7 @@ class RedisTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 
 		$closure = $this->redis->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->redis, $params, null);
@@ -284,7 +284,7 @@ class RedisTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 
 		$closure = $this->redis->delete($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->redis, $params, null);
@@ -315,7 +315,7 @@ class RedisTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->redis->decrement($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->redis, $params, null);
@@ -336,7 +336,7 @@ class RedisTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->redis->decrement($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->redis, $params, null);
@@ -357,7 +357,7 @@ class RedisTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->redis->increment($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->redis, $params, null);
@@ -378,7 +378,7 @@ class RedisTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->redis->increment($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->redis, $params, null);
@@ -400,7 +400,7 @@ class RedisTest extends \lithium\test\Unit {
 		$this->assertEqual($result, array('some_key'), 'redis method dispatch failed');
 
 		$result = $this->redis->info();
-		$this->assertTrue(is_array($result), 'redis method dispatch failed');
+		$this->assertInternalType('array', $assertInternalType, 'redis method dispatch failed');
 	}
 
 	public function testRespondsTo() {

--- a/tests/cases/storage/cache/adapter/XCacheTest.php
+++ b/tests/cases/storage/cache/adapter/XCacheTest.php
@@ -55,7 +55,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$time = strtotime($expiry);
 
 		$closure = $this->XCache->write($key, $data, $expiry);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'data', 'expiry');
 		$result = $closure($this->XCache, $params, null);
@@ -74,7 +74,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$time = strtotime($expiry);
 
 		$closure = $this->XCache->write($key, $data, $expiry);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'data', 'expiry');
 		$result = $closure($this->XCache, $params, null);
@@ -95,7 +95,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$time = strtotime('+5 seconds');
 
 		$closure = $xCache->write($key, $data);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'data');
 		$result = $closure($xCache, $params, null);
@@ -119,7 +119,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->XCache->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->XCache, $params, null);
@@ -137,7 +137,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->XCache->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->XCache, $params, null);
@@ -151,7 +151,7 @@ class XCacheTest extends \lithium\test\Unit {
 	public function testReadKeyThatDoesNotExist() {
 		$key = 'does_not_exist';
 		$closure = $this->XCache->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->XCache, $params, null);
@@ -168,7 +168,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->XCache->delete($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->XCache, $params, null);
@@ -181,7 +181,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$time = strtotime('+1 minute');
 
 		$closure = $this->XCache->delete($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->XCache, $params, null);
@@ -195,7 +195,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$time = strtotime($expiry);
 
 		$closure = $this->XCache->write($key, $data, $expiry);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'data', 'expiry');
 		$result = $closure($this->XCache, $params, null);
@@ -206,7 +206,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 
 		$closure = $this->XCache->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->XCache, $params, null);
@@ -214,7 +214,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 
 		$closure = $this->XCache->delete($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->XCache, $params, null);
@@ -251,7 +251,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->XCache->decrement($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->XCache, $params, null);
@@ -273,7 +273,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->XCache->decrement($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->XCache, $params, null);
@@ -282,7 +282,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$this->assertEqual(-1, $result);
 
 		$closure = $this->XCache->decrement($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->XCache, $params, null);
@@ -303,7 +303,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->XCache->increment($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->XCache, $params, null);
@@ -325,7 +325,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$closure = $this->XCache->increment($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->XCache, $params, null);
@@ -334,7 +334,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$this->assertEqual(1, $result);
 
 		$closure = $this->XCache->increment($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->XCache, $params, null);

--- a/tests/cases/storage/session/adapter/CookieTest.php
+++ b/tests/cases/storage/session/adapter/CookieTest.php
@@ -72,7 +72,7 @@ class CookieTest extends \lithium\test\Unit {
 		$path = '/';
 
 		$closure = $this->cookie->write($key, $value);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'value');
 		$result = $closure($this->cookie, $params, null);
@@ -97,7 +97,7 @@ class CookieTest extends \lithium\test\Unit {
 		$path = '/';
 
 		$closure = $this->cookie->write($key, $value);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 		$params = compact('key', 'value');
 		$result = $closure($this->cookie, $params, null);
 
@@ -116,7 +116,7 @@ class CookieTest extends \lithium\test\Unit {
 		$_COOKIE[$this->name]['read']['test'] = $value;
 
 		$closure = $this->cookie->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->cookie, $params, null);
@@ -127,7 +127,7 @@ class CookieTest extends \lithium\test\Unit {
 
 		$key = 'does.not.exist';
 		$closure = $this->cookie->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->cookie, $params, null);
@@ -143,7 +143,7 @@ class CookieTest extends \lithium\test\Unit {
 		$options = array('expire' => $expires);
 
 		$closure = $this->cookie->write($key, $value, $options);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'value', 'options');
 		$result = $closure($this->cookie, $params, null);
@@ -157,7 +157,7 @@ class CookieTest extends \lithium\test\Unit {
 		$_COOKIE[$this->name][$key] = $value;
 
 		$closure = $this->cookie->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->cookie, $params, null);
@@ -168,7 +168,7 @@ class CookieTest extends \lithium\test\Unit {
 
 		$key = 'does_not_exist';
 		$closure = $this->cookie->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->cookie, $params, null);
@@ -181,7 +181,7 @@ class CookieTest extends \lithium\test\Unit {
 		$_COOKIE[$this->name][$key] = $value;
 
 		$closure = $this->cookie->check($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->cookie, $params, null);
@@ -189,7 +189,7 @@ class CookieTest extends \lithium\test\Unit {
 
 		$key = 'does_not_exist';
 		$closure = $this->cookie->check($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->cookie, $params, null);
@@ -202,14 +202,14 @@ class CookieTest extends \lithium\test\Unit {
 		$_COOKIE[$this->name][$key] = $value;
 
 		$closure = $this->cookie->check($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->cookie, $params, null);
 		$this->assertTrue($result);
 
 		$closure = $this->cookie->clear();
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = array();
 		$result = $closure($this->cookie, $params, null);
@@ -224,7 +224,7 @@ class CookieTest extends \lithium\test\Unit {
 		$_COOKIE[$this->name][$key] = $value;
 
 		$closure = $this->cookie->delete($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->cookie, $params, null);
@@ -243,7 +243,7 @@ class CookieTest extends \lithium\test\Unit {
 		$path = '/';
 
 		$closure = $this->cookie->delete($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->cookie, $params, null);

--- a/tests/cases/storage/session/adapter/MemoryTest.php
+++ b/tests/cases/storage/session/adapter/MemoryTest.php
@@ -31,7 +31,7 @@ class MemoryTest extends \lithium\test\Unit {
 	 */
 	public function testKey() {
 		$key1 = Memory::key();
-		$this->assertTrue($key1);
+		$this->assertNotEmpty($key1);
 
 		$key2 = Memory::key();
 		$this->assertNotEqual($key1, $key2);
@@ -67,7 +67,7 @@ class MemoryTest extends \lithium\test\Unit {
 		$this->Memory->_session[$key] = $value;
 
 		$closure = $this->Memory->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->Memory, $params, null);
@@ -76,14 +76,14 @@ class MemoryTest extends \lithium\test\Unit {
 
 		$key = 'non-existent';
 		$closure = $this->Memory->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->Memory, $params, null);
 		$this->assertNull($result);
 
 		$closure = $this->Memory->read();
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$result = $closure($this->Memory, array('key' => null), null);
 		$expected = array('read_test' => 'value to be read');
@@ -98,7 +98,7 @@ class MemoryTest extends \lithium\test\Unit {
 		$value = 'value to be written';
 
 		$closure = $this->Memory->write($key, $value);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'value');
 		$result = $closure($this->Memory, $params, null);
@@ -116,7 +116,7 @@ class MemoryTest extends \lithium\test\Unit {
 		$this->Memory->_session[$key] = $value;
 
 		$closure = $this->Memory->check($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->Memory, $params, null);
@@ -124,7 +124,7 @@ class MemoryTest extends \lithium\test\Unit {
 
 		$key = 'does_not_exist';
 		$closure = $this->Memory->check($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->Memory, $params, null);
@@ -143,7 +143,7 @@ class MemoryTest extends \lithium\test\Unit {
 		$this->Memory->_session[$key] = $value;
 
 		$closure = $this->Memory->delete($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->Memory, $params, null);
@@ -151,7 +151,7 @@ class MemoryTest extends \lithium\test\Unit {
 
 		$key = 'non-existent';
 		$closure = $this->Memory->delete($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->Memory, $params, null);
@@ -164,9 +164,9 @@ class MemoryTest extends \lithium\test\Unit {
 	public function testClear() {
 		$this->Memory->_session['foobar'] = 'foo';
 		$closure = $this->Memory->clear();
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 		$result = $closure($this->Memory, array(), null);
-		$this->assertTrue(empty($this->Memory->_session));
+		$this->assertEmpty($this->Memory->_session);
 	}
 }
 

--- a/tests/cases/storage/session/adapter/PhpTest.php
+++ b/tests/cases/storage/session/adapter/PhpTest.php
@@ -58,7 +58,7 @@ class PhpTest extends \lithium\test\Unit {
 
 	public function testInit() {
 		$id = session_id();
-		$this->assertTrue(empty($id));
+		$this->assertEmpty($id);
 
 		$result = ini_get('session.name');
 		$this->assertEqual(basename(LITHIUM_APP_PATH), $result);
@@ -67,11 +67,11 @@ class PhpTest extends \lithium\test\Unit {
 		$this->assertEqual(0, (integer) $result);
 
 		$result = ini_get('session.cookie_httponly');
-		$this->assertTrue(1, (integer) $result);
+		$this->assertNotEmpty((integer) $result);
 
 		$name = 'this-is-a-custom-name';
 		$php = new Php(array('session.name' => $name));
-		$this->assertFalse(is_numeric($php->_config['session.name']));
+		$this->assertNotInternalType('numeric', $php->_config['session.name']);
 	}
 
 	public function testCustomConfiguration() {
@@ -94,10 +94,10 @@ class PhpTest extends \lithium\test\Unit {
 		$this->assertEqual($config['session.cookie_domain'], $result);
 
 		$result = ini_get('session.cookie_secure');
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 
 		$result = ini_get('session.cookie_httponly');
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 
 		$result = ini_get('session.save_path');
 		$this->assertEqual($config['session.save_path'], $result);
@@ -147,7 +147,7 @@ class PhpTest extends \lithium\test\Unit {
 		$value = 'value to be written';
 
 		$closure = $this->php->write($key, $value);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'value');
 		$result = $closure($this->php, $params, null);
@@ -164,7 +164,7 @@ class PhpTest extends \lithium\test\Unit {
 		$_SESSION[$key] = $value;
 
 		$closure = $this->php->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->php, $params, null);
@@ -173,14 +173,14 @@ class PhpTest extends \lithium\test\Unit {
 
 		$key = 'non-existent';
 		$closure = $this->php->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->php, $params, null);
 		$this->assertNull($result);
 
 		$closure = $this->php->read();
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$result = $closure($this->php, array('key' => null), null);
 		$expected = array('read_test' => 'value to be read');
@@ -195,7 +195,7 @@ class PhpTest extends \lithium\test\Unit {
 		$_SESSION[$key] = $value;
 
 		$closure = $this->php->check($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->php, $params, null);
@@ -203,7 +203,7 @@ class PhpTest extends \lithium\test\Unit {
 
 		$key = 'does_not_exist';
 		$closure = $this->php->check($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->php, $params, null);
@@ -219,7 +219,7 @@ class PhpTest extends \lithium\test\Unit {
 		$_SESSION[$key] = $value;
 
 		$closure = $this->php->delete($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->php, $params, null);
@@ -227,7 +227,7 @@ class PhpTest extends \lithium\test\Unit {
 
 		$key = 'non-existent';
 		$closure = $this->php->delete($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->php, $params, null);
@@ -239,11 +239,11 @@ class PhpTest extends \lithium\test\Unit {
 	 */
 	public function testClear() {
 		$_SESSION['foo'] = 'bar';
-		$this->assertFalse(empty($_SESSION));
+		$this->assertNotEmpty($_SESSION);
 		$closure = $this->php->clear();
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 		$result = $closure($this->php, array(), null);
-		$this->assertTrue(empty($_SESSION));
+		$this->assertEmpty($_SESSION);
 	}
 
 	public function testCheckThrowException() {
@@ -279,7 +279,7 @@ class PhpTest extends \lithium\test\Unit {
 		$_SESSION[$key] = $value;
 
 		$closure = $this->php->read($key);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
 		$result = $closure($this->php, $params, null);
@@ -297,7 +297,7 @@ class PhpTest extends \lithium\test\Unit {
 		$value = 'value to be written';
 
 		$closure = $this->php->write($key, $value);
-		$this->assertTrue(is_callable($closure));
+		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'value');
 		$result = $closure($this->php, $params, null);

--- a/tests/cases/storage/session/strategy/EncryptTest.php
+++ b/tests/cases/storage/session/strategy/EncryptTest.php
@@ -38,7 +38,7 @@ class EncryptTest extends \lithium\test\Unit {
 
 	public function testConstruct() {
 		$encrypt = new Encrypt(array('secret' => $this->secret));
-		$this->assertTrue($encrypt instanceof Encrypt);
+		$this->assertInstanceOf('lithium\storage\session\strategy\Encrypt', $encrypt);
 	}
 
 	public function testWrite() {
@@ -50,9 +50,9 @@ class EncryptTest extends \lithium\test\Unit {
 		$result = $encrypt->write($value, array('class' => $this->mock, 'key' => $key));
 		$cookie = MockCookieSession::data();
 
-		$this->assertTrue($result);
-		$this->assertTrue($cookie['__encrypted']);
-		$this->assertTrue(is_string($cookie['__encrypted']));
+		$this->assertNotEmpty($result);
+		$this->assertNotEmpty($cookie['__encrypted']);
+		$this->assertInternalType('string', $cookie['__encrypted']);
 		$this->assertNotEqual($cookie['__encrypted'], $value);
 	}
 
@@ -63,7 +63,7 @@ class EncryptTest extends \lithium\test\Unit {
 		$value = 'barvalue';
 
 		$result = $encrypt->write($value, array('class' => $this->mock, 'key' => $key));
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 
 		$cookie = MockCookieSession::data();
 		$result = $encrypt->read($key, array('class' => $this->mock, 'key' => $key));
@@ -79,7 +79,7 @@ class EncryptTest extends \lithium\test\Unit {
 		$value = 'barvalue';
 
 		$result = $encrypt->write($value, array('class' => $this->mock, 'key' => $key));
-		$this->assertTrue($result);
+		$this->assertNotEmpty($result);
 
 		$cookie = MockCookieSession::data();
 		$result = $encrypt->read($key, array('class' => $this->mock, 'key' => $key));
@@ -89,10 +89,10 @@ class EncryptTest extends \lithium\test\Unit {
 		$result = $encrypt->delete($key, array('class' => $this->mock, 'key' => $key));
 
 		$cookie = MockCookieSession::data();
-		$this->assertTrue(empty($cookie['__encrypted']));
+		$this->assertEmpty($cookie['__encrypted']);
 
 		$result = $encrypt->read($key, array('class' => $this->mock));
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 	}
 }
 

--- a/tests/cases/storage/session/strategy/HmacTest.php
+++ b/tests/cases/storage/session/strategy/HmacTest.php
@@ -29,7 +29,7 @@ class HmacTest extends \lithium\test\Unit {
 	public function testConstruct() {
 		$secret = 'foo';
 		$hmac = new Hmac(compact('secret'));
-		$this->assertTrue($hmac instanceof Hmac);
+		$this->assertInstanceOf('lithium\storage\session\strategy\Hmac', $hmac);
 	}
 
 	public function testWrite() {

--- a/tests/cases/template/ViewTest.php
+++ b/tests/cases/template/ViewTest.php
@@ -8,7 +8,6 @@
 
 namespace lithium\tests\cases\template;
 
-use Closure;
 use lithium\core\Libraries;
 use lithium\template\View;
 use lithium\action\Response;
@@ -171,7 +170,7 @@ class ViewTest extends \lithium\test\Unit {
 				)
 			  )
 			);
-		$this->assertTrue($renderData[0]['data']['h'] instanceof Closure);
+		$this->assertInstanceOf('Closure', $renderData[0]['data']['h']);
 		unset($renderData[0]['data']['h']);
 		$this->assertEqual($expected, $renderData);
 	}

--- a/tests/cases/template/helper/FormTest.php
+++ b/tests/cases/template/helper/FormTest.php
@@ -253,8 +253,8 @@ class FormTest extends \lithium\test\Unit {
 			)
 		);
 		$this->assertEqual($expected, $result);
-		$this->assertTrue(is_callable($result['attributes']['id']));
-		$this->assertTrue(is_callable($result['attributes']['name']));
+		$this->assertInternalType('callable', $result['attributes']['id']);
+		$this->assertInternalType('callable', $result['attributes']['name']);
 	}
 
 	public function testFormElementWithDefaultValue() {
@@ -1115,7 +1115,7 @@ class FormTest extends \lithium\test\Unit {
 	public function testFormErrorWithout() {
 		$this->form->create(null);
 		$result = $this->form->error('name');
-		$this->assertTrue(is_null($result));
+		$this->assertInternalType('null', $result);
 	}
 
 	public function testFormErrorWithRecordAndStringError() {
@@ -1451,7 +1451,7 @@ class FormTest extends \lithium\test\Unit {
 		));
 
 		$result = $this->form->error('body');
-		$this->assertTrue(empty($result));
+		$this->assertEmpty($result);
 
 		$result = $this->form->error('record1.title');
 		$this->assertTags($result, array(

--- a/tests/cases/template/helper/HtmlTest.php
+++ b/tests/cases/template/helper/HtmlTest.php
@@ -346,10 +346,10 @@ class HtmlTest extends \lithium\test\Unit {
 	 */
 	public function testNonInlineScriptsAndStyles() {
 		$result = trim($this->context->scripts());
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 
 		$result = $this->html->script('application', array('inline' => false));
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 
 		$result = $this->context->scripts();
 		$this->assertTags($result, array('script' => array(
@@ -357,10 +357,10 @@ class HtmlTest extends \lithium\test\Unit {
 		)));
 
 		$result = trim($this->context->styles());
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 
 		$result = $this->html->style('base', array('inline' => false));
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 
 		$result = $this->context->styles();
 		$this->assertTags($result, array('link' => array(

--- a/tests/cases/template/view/CompilerTest.php
+++ b/tests/cases/template/view/CompilerTest.php
@@ -58,7 +58,7 @@ class CompilerTest extends \lithium\test\Unit {
 
 	public function testTemplateContentRewriting() {
 		$template = Compiler::template("{$this->_path}/{$this->_file}");
-		$this->assertTrue(file_exists($template));
+		$this->assertFileExists($template);
 
 		$expected = array(
 			"<?php echo 'this is unescaped content'; ?" . ">",

--- a/tests/cases/template/view/RendererTest.php
+++ b/tests/cases/template/view/RendererTest.php
@@ -11,7 +11,6 @@ namespace lithium\tests\cases\template\view;
 use stdClass;
 use lithium\action\Request;
 use lithium\action\Response;
-use lithium\template\Helper;
 use lithium\template\helper\Html;
 use lithium\template\view\adapter\Simple;
 use lithium\net\http\Router;
@@ -183,7 +182,7 @@ class RendererTest extends \lithium\test\Unit {
 
 	public function testHelperLoading() {
 		$helper = $this->subject->helper('html');
-		$this->assertTrue($helper instanceof Helper);
+		$this->assertInstanceOf('lithium\template\Helper', $helper);
 
 		$this->expectException('/invalidFoo/');
 		$this->assertNull($this->subject->helper('invalidFoo'));
@@ -191,13 +190,13 @@ class RendererTest extends \lithium\test\Unit {
 
 	public function testHelperQuerying() {
 		$helper = $this->subject->html;
-		$this->assertTrue($helper instanceof Helper);
+		$this->assertInstanceOf('lithium\template\Helper', $helper);
 	}
 
 	public function testTemplateStrings() {
 		$result = $this->subject->strings();
-		$this->assertTrue(is_array($result));
-		$this->assertFalse($result);
+		$this->assertInternalType('array', $result);
+		$this->assertEmpty($result);
 
 		$expected = array('data' => 'The data goes here: {:data}');
 		$result = $this->subject->strings($expected);
@@ -212,8 +211,8 @@ class RendererTest extends \lithium\test\Unit {
 	}
 
 	public function testGetters() {
-		$this->assertTrue($this->subject->request() instanceof Request);
-		$this->assertTrue($this->subject->response() instanceof Response);
+		$this->assertInstanceOf('lithium\action\Request', $this->subject->request());
+		$this->assertInstanceOf('lithium\action\Response', $this->subject->response());
 		$this->subject = new Simple();
 		$this->assertNull($this->subject->request());
 		$this->assertNull($this->subject->response());
@@ -243,26 +242,26 @@ class RendererTest extends \lithium\test\Unit {
 	}
 
 	public function testHandlers() {
-		$this->assertTrue($this->subject->url());
+		$this->assertNotEmpty($this->subject->url());
 		$this->assertPattern('/\/posts\/foo/', $this->subject->url('Posts::foo'));
 
 		$absolute = $this->subject->url('Posts::foo', array('absolute' => true));
 		$this->assertEqual('http://foo.local/posts/foo', $absolute);
 
-		$this->assertFalse(trim($this->subject->scripts()));
+		$this->assertEmpty(trim($this->subject->scripts()));
 		$this->assertEqual('foobar', trim($this->subject->scripts('foobar')));
 		$this->assertEqual('foobar', trim($this->subject->scripts()));
 
-		$this->assertFalse(trim($this->subject->styles()));
+		$this->assertEmpty(trim($this->subject->styles()));
 		$this->assertEqual('foobar', trim($this->subject->styles('foobar')));
 		$this->assertEqual('foobar', trim($this->subject->styles()));
 
-		$this->assertFalse($this->subject->title());
+		$this->assertEmpty($this->subject->title());
 		$this->assertEqual('Foo', $this->subject->title('Foo'));
 		$this->assertEqual('Bar', $this->subject->title('Bar'));
 		$this->assertEqual('Bar', $this->subject->title());
 
-		$this->assertFalse(trim($this->subject->head()));
+		$this->assertEmpty(trim($this->subject->head()));
 		$this->assertEqual('foo', trim($this->subject->head('foo')));
 		$this->assertEqual("foo\n\tbar", trim($this->subject->head('bar')));
 		$this->assertEqual("foo\n\tbar", trim($this->subject->head()));

--- a/tests/cases/template/view/adapter/FileTest.php
+++ b/tests/cases/template/view/adapter/FileTest.php
@@ -43,7 +43,7 @@ class FileTest extends \lithium\test\Unit {
 		$file = new File(array('extract' => false));
 		$this->expectException('Undefined variable: foo');
 		$content = $file->render("{$this->_path}/template1.html.php", array('foo' => 'bar'));
-		$this->assertFalse($content);
+		$this->assertEmpty($content);
 
 		$content = $file->render("{$this->_path}/template2.html.php", array('foo' => 'bar'));
 		$this->assertEqual('bar', $content);

--- a/tests/cases/test/DispatcherTest.php
+++ b/tests/cases/test/DispatcherTest.php
@@ -8,8 +8,6 @@
 
 namespace lithium\tests\cases\test;
 
-use lithium\test\Group;
-use lithium\test\Report;
 use lithium\test\Dispatcher;
 use lithium\util\Collection;
 use lithium\tests\mocks\test\cases\MockTest;
@@ -22,10 +20,10 @@ class DispatcherTest extends \lithium\test\Unit {
 
 	public function testRunDefaults() {
 		$report = Dispatcher::run();
-		$this->assertTrue($report instanceof Report);
+		$this->assertInstanceOf('lithium\test\Report', $report);
 
 		$result = $report->group;
-		$this->assertTrue($result instanceof Group);
+		$this->assertInstanceOf('lithium\test\Group', $result);
 	}
 
 	public function testRunWithReporter() {
@@ -34,10 +32,10 @@ class DispatcherTest extends \lithium\test\Unit {
 				return $info;
 			}
 		));
-		$this->assertTrue($report instanceof Report);
+		$this->assertInstanceOf('lithium\test\Report', $report);
 
 		$result = $report->group;
-		$this->assertTrue($result instanceof Group);
+		$this->assertInstanceOf('lithium\test\Group', $result);
 	}
 
 	public function testRunCaseWithString() {

--- a/tests/cases/test/GroupTest.php
+++ b/tests/cases/test/GroupTest.php
@@ -14,7 +14,6 @@ use lithium\util\Collection;
 use lithium\tests\cases\data\ModelTest;
 use lithium\tests\cases\core\ObjectTest;
 use lithium\tests\cases\g11n\CatalogTest;
-use lithium\tests\mocks\test\MockUnitTest;
 use lithium\tests\mocks\test\cases\MockTest;
 use lithium\tests\mocks\test\cases\MockTestErrorHandling;
 use lithium\tests\mocks\test\cases\MockSkipThrowsException;
@@ -52,7 +51,7 @@ class GroupTest extends \lithium\test\Unit {
 		$group->add('');
 		$group->add('\\');
 		$group->add('foobar');
-		$this->assertFalse($group->items());
+		$this->assertEmpty($group->items());
 	}
 
 	public function testAddByString() {
@@ -111,10 +110,10 @@ class GroupTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 
 		$results = $group->tests();
-		$this->assertTrue($results instanceof Collection);
+		$this->assertInstanceOf('lithium\util\Collection', $results);
 
 		$results = $group->tests();
-		$this->assertTrue($results->current() instanceof CatalogTest);
+		$this->assertInstanceOf('lithium\tests\cases\g11n\CatalogTest', $results->current());
 	}
 
 	public function testAddEmptyTestsRun() {
@@ -124,8 +123,8 @@ class GroupTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 
 		$results = $group->tests();
-		$this->assertTrue($results instanceof Collection);
-		$this->assertTrue($results->current() instanceof MockUnitTest);
+		$this->assertInstanceOf('lithium\util\Collection', $results);
+		$this->assertInstanceOf('lithium\tests\mocks\test\MockUnitTest', $results->current());
 
 		$results = $group->tests()->run();
 

--- a/tests/cases/test/MockerTest.php
+++ b/tests/cases/test/MockerTest.php
@@ -36,9 +36,8 @@ class MockerTest extends \lithium\test\Unit {
 	}
 
 	public function testBasicCreationExtendsCorrectParent() {
-		$mocker = 'lithium\console\Request';
 		$mockeeObj = new \lithium\console\request\Mock();
-		$this->assertTrue(is_a($mockeeObj, $mocker));
+		$this->assertInstanceOf('lithium\console\Request', $mockeeObj);
 	}
 
 	public function testCanMockNonLithiumClasses() {
@@ -89,7 +88,7 @@ class MockerTest extends \lithium\test\Unit {
 
 		$filteredResult = $dispatcher->config(array());
 
-		$this->assertEqual(0, count($filteredResult));
+		$this->assertCount(0, $filteredResult);
 		$this->assertNotEqual($filteredResult, $originalResult);
 	}
 
@@ -120,7 +119,7 @@ class MockerTest extends \lithium\test\Unit {
 
 		$filteredResult = $mockee::tokenize($code, array('wrap' => true));
 
-		$this->assertEqual(0, count($filteredResult));
+		$this->assertCount(0, $filteredResult);
 		$this->assertNotEqual($filteredResult, $originalResult);
 	}
 
@@ -141,11 +140,11 @@ class MockerTest extends \lithium\test\Unit {
 	public function testOriginalMethodNotCalled() {
 		$http = new \lithium\tests\mocks\security\auth\adapter\mockHttp\Mock;
 
-		$this->assertEqual(0, count($http->headers));
+		$this->assertCount(0, $http->headers);
 
 		$http->_writeHeader('Content-type: text/html');
 
-		$this->assertEqual(1, count($http->headers));
+		$this->assertCount(1, $http->headers);
 
 		$http->applyFilter('_writeHeader', function($self, $params, $chain) {
 			return false;
@@ -153,7 +152,7 @@ class MockerTest extends \lithium\test\Unit {
 
 		$http->_writeHeader('Content-type: application/pdf');
 
-		$this->assertEqual(1, count($http->headers));
+		$this->assertCount(1, $http->headers);
 	}
 
 	public function testFilteringAFilteredMethod() {
@@ -161,7 +160,7 @@ class MockerTest extends \lithium\test\Unit {
 		$adapt::applyFilter('_initAdapter', function($self, $params, $chain) {
 			return false;
 		});
-		$this->assertIdentical(false, $adapt::_initAdapter('foo', array()));
+		$this->assertFalse($adapt::_initAdapter('foo', array()));
 	}
 
 	public function testStaticResults() {
@@ -175,13 +174,13 @@ class MockerTest extends \lithium\test\Unit {
 
 		$this->assertIdentical(2, count($docblock::$staticResults['comment']));
 		$this->assertIdentical(array('foobar'), $docblock::$staticResults['comment'][0]['args']);
-		$this->assertIdentical(false, $docblock::$staticResults['comment'][0]['result']);
+		$this->assertFalse($docblock::$staticResults['comment'][0]['result']);
 		$this->assertIdentical(array('bar'), $docblock::$staticResults['comment'][1]['args']);
-		$this->assertIdentical(false, $docblock::$staticResults['comment'][1]['result']);
+		$this->assertFalse($docblock::$staticResults['comment'][1]['result']);
 
 		$this->assertIdentical(1, count($docblock::$staticResults['tags']));
 		$this->assertIdentical(array('baz', 'foo'), $docblock::$staticResults['tags'][0]['args']);
-		$this->assertIdentical(false, $docblock::$staticResults['tags'][0]['result']);
+		$this->assertFalse($docblock::$staticResults['tags'][0]['result']);
 	}
 
 	public function testInstanceResults() {
@@ -195,13 +194,13 @@ class MockerTest extends \lithium\test\Unit {
 
 		$this->assertIdentical(2, count($debugger->results['names']));
 		$this->assertIdentical(array('foo', 'foobar'), $debugger->results['names'][0]['args']);
-		$this->assertIdentical(false, $debugger->results['names'][0]['result']);
+		$this->assertFalse($debugger->results['names'][0]['result']);
 		$this->assertIdentical(array('bar'), $debugger->results['names'][1]['args']);
-		$this->assertIdentical(false, $debugger->results['names'][1]['result']);
+		$this->assertFalse($debugger->results['names'][1]['result']);
 
 		$this->assertIdentical(1, count($debugger->results['meta']));
 		$this->assertIdentical(array('baz'), $debugger->results['meta'][0]['args']);
-		$this->assertIdentical(false, $debugger->results['meta'][0]['result']);
+		$this->assertFalse($debugger->results['meta'][0]['result']);
 	}
 
 	public function testSkipByReference() {
@@ -224,7 +223,7 @@ class MockerTest extends \lithium\test\Unit {
 	}
 
 	public function testChainReturnsMockerChain() {
-		$this->assertTrue(Mocker::chain(new \stdClass) instanceof \lithium\test\MockerChain);
+		$this->assertInstanceOf('lithium\test\MockerChain', Mocker::chain(new \stdClass));
 	}
 
 	public function testMergeWithEmptyArray() {

--- a/tests/cases/test/UnitTest.php
+++ b/tests/cases/test/UnitTest.php
@@ -220,6 +220,16 @@ class UnitTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $results[0]['result']);
 	}
 
+	public function testAssertNotIdentical() {
+		$expected = true;
+		$result = 1;
+		$this->test->assertNotIdentical($expected, $result);
+		$results = $this->test->results();
+
+		$expected = 'pass';
+		$this->assertEqual($expected, $results[0]['result']);
+	}
+
 	public function testAssertIdenticalArray() {
 		$expected = array('1', '2', '3');
 		$result = array('1', '3', '4');
@@ -233,6 +243,16 @@ class UnitTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $results[0]['message']);
 	}
 
+	public function testAssertNotIdenticalArray() {
+		$expected = array('1', '2', '3');
+		$result = array('1', '3', '4');
+		$this->test->assertNotIdentical($expected, $result);
+		$results = $this->test->results();
+
+		$expected = 'pass';
+		$this->assertEqual($expected, $results[0]['result']);
+	}
+
 	public function testAssertNull() {
 		$expected = null;
 		$result = null;
@@ -243,10 +263,10 @@ class UnitTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $results[0]['result']);
 	}
 
-	public function testAssertNoPattern() {
+	public function testAssertNotPattern() {
 		$expected = '/\s/';
 		$result = null;
-		$this->test->assertNoPattern($expected, $result);
+		$this->test->assertNotPattern($expected, $result);
 		$results = $this->test->results();
 
 		$expected = 'pass';
@@ -402,7 +422,7 @@ class UnitTest extends \lithium\test\Unit {
 		$this->assertTrue(touch("{$base}/cleanup_test/.hideme"));
 
 		$this->_cleanUp();
-		$this->assertFalse(file_exists("{$base}/cleanup_test"));
+		$this->assertFileNotExists("{$base}/cleanup_test");
 	}
 
 	public function testCleanUpWithFullPath() {
@@ -414,9 +434,9 @@ class UnitTest extends \lithium\test\Unit {
 		$this->assertTrue(touch("{$base}/cleanup_test/.hideme"));
 
 		$this->_cleanUp("{$base}/cleanup_test");
-		$this->assertTrue(file_exists("{$base}/cleanup_test"));
-		$this->assertFalse(file_exists("{$base}/cleanup_test/file"));
-		$this->assertFalse(file_exists("{$base}/cleanup_test/.hideme"));
+		$this->assertFileExists("{$base}/cleanup_test");
+		$this->assertFileNotExists("{$base}/cleanup_test/file");
+		$this->assertFileNotExists("{$base}/cleanup_test/.hideme");
 
 		$this->_cleanUp();
 	}
@@ -430,9 +450,9 @@ class UnitTest extends \lithium\test\Unit {
 		$this->assertTrue(touch("{$base}/cleanup_test/.hideme"));
 
 		$this->_cleanUp("tests/cleanup_test");
-		$this->assertTrue(file_exists("{$base}/cleanup_test"));
-		$this->assertFalse(file_exists("{$base}/cleanup_test/file"));
-		$this->assertFalse(file_exists("{$base}/cleanup_test/.hideme"));
+		$this->assertFileExists("{$base}/cleanup_test");
+		$this->assertFileNotExists("{$base}/cleanup_test/file");
+		$this->assertFileNotExists("{$base}/cleanup_test/.hideme");
 
 		$this->_cleanUp();
 	}
@@ -468,7 +488,7 @@ class UnitTest extends \lithium\test\Unit {
 		$this->test->expectException('/test handle exception/');
 		$this->test->handleException(new Exception('test handle exception'));
 
-		$this->assertFalse($this->test->expected());
+		$this->assertEmpty($this->test->expected());
 	}
 
 	public function testExpectExceptionPostNotThrown() {
@@ -1470,50 +1490,6 @@ class UnitTest extends \lithium\test\Unit {
 		$this->assertException('InvalidArgumentException', function() use($self) {
 			$self->test->assertObjectNotHasAttribute('foo', 'new \stdClass');
 		});
-	}
-
-	public function testAssertRegExpTrue() {
-		$this->assertTrue($this->test->assertRegExp('/^foo/', 'foobar'));
-
-		$results = $this->test->results();
-		$result = array_pop($results);
-
-		$this->assertEqual('pass', $result['result']);
-	}
-
-	public function testAssertRegExpFalse() {
-		$this->assertFalse($this->test->assertRegExp('/^bar/', 'foobar'));
-
-		$results = $this->test->results();
-		$result = array_pop($results);
-
-		$this->assertEqual('fail', $result['result']);
-		$this->assertEqual(array(
-			'expected' => '/^bar/',
-			'result' => array()
-		), $result['data']);
-	}
-
-	public function testAssertNotRegExpTrue() {
-		$this->assertTrue($this->test->assertNotRegExp('/^bar/', 'foobar'));
-
-		$results = $this->test->results();
-		$result = array_pop($results);
-
-		$this->assertEqual('pass', $result['result']);
-	}
-
-	public function testAssertNotRegExpFalse() {
-		$this->assertFalse($this->test->assertNotRegExp('/^foo/', 'foobar'));
-
-		$results = $this->test->results();
-		$result = array_pop($results);
-
-		$this->assertEqual('fail', $result['result']);
-		$this->assertEqual(array(
-			'expected' => '/^foo/',
-			'result' => array('foo')
-		), $result['data']);
 	}
 
 	public function testAssertStringMatchesFormatTrue() {

--- a/tests/cases/util/CollectionTest.php
+++ b/tests/cases/util/CollectionTest.php
@@ -58,7 +58,7 @@ class CollectionTest extends \lithium\test\Unit {
 		$this->assertEqual($result, array_fill(0, 10, 'testFoo'));
 
 		$result = $collection->invoke('testFoo', array(), array('collect' => true));
-		$this->assertTrue($result instanceof Collection);
+		$this->assertInstanceOf('lithium\util\Collection', $result);
 		$this->assertEqual($result->to('array'), array_fill(0, 10, 'testFoo'));
 	}
 
@@ -95,11 +95,11 @@ class CollectionTest extends \lithium\test\Unit {
 			array_fill(0, 10, 1),
 			array_fill(0, 10, 2)
 		)));
-		$this->assertEqual(20, count($collection->to('array')));
+		$this->assertCount(20, $collection->to('array'));
 
 		$filter = function($item) { return $item === 1; };
 		$result = $collection->find($filter);
-		$this->assertTrue($result instanceof Collection);
+		$this->assertInstanceOf('lithium\util\Collection', $result);
 		$this->assertEqual(array_fill(0, 10, 1), $result->to('array'));
 
 		$result = $collection->find($filter, array('collect' => false));
@@ -252,12 +252,12 @@ class CollectionTest extends \lithium\test\Unit {
 	public function testValueAppend() {
 		$collection = new Collection();
 		$this->assertFalse($collection->valid());
-		$this->assertEqual(0, count($collection));
+		$this->assertCount(0, $collection);
 
 		$collection->append(1);
-		$this->assertEqual(1, count($collection));
+		$this->assertCount(1, $collection);
 		$collection->append(new stdClass());
-		$this->assertEqual(2, count($collection));
+		$this->assertCount(2, $collection);
 
 		$this->assertEqual(1, $collection->current());
 		$this->assertEqual(new stdClass(), $collection->next());
@@ -447,10 +447,10 @@ class CollectionTest extends \lithium\test\Unit {
 			'data' => array($first, $second, $third)
 		));
 
-		$this->assertTrue(is_object($doc[0]));
-		$this->assertTrue(is_object($doc[1]));
-		$this->assertTrue(is_object($doc[2]));
-		$this->assertEqual(3, count($doc));
+		$this->assertInternalType('object', $doc[0]);
+		$this->assertInternalType('object', $doc[1]);
+		$this->assertInternalType('object', $doc[2]);
+		$this->assertCount(3, $doc);
 	}
 
 	public function testValid() {

--- a/tests/cases/util/InflectorTest.php
+++ b/tests/cases/util/InflectorTest.php
@@ -357,25 +357,25 @@ class InflectorTest extends \lithium\test\Unit {
 		Inflector::reset();
 
 		$expected = array('TestField' => 'test_field');
-		$this->assertFalse($this->_getProtectedValue('$_underscored'));
+		$this->assertEmpty($this->_getProtectedValue('$_underscored'));
 		$this->assertEqual(Inflector::underscore('TestField'), 'test_field');
 		$this->assertEqual($expected, $this->_getProtectedValue('$_underscored'));
 		$this->assertEqual(Inflector::underscore('TestField'), 'test_field');
 
 		$expected = array('test_field' => 'TestField');
-		$this->assertFalse($this->_getProtectedValue('$_camelized'));
+		$this->assertEmpty($this->_getProtectedValue('$_camelized'));
 		$this->assertEqual(Inflector::camelize('test_field', true), 'TestField');
 		$this->assertEqual($expected, $this->_getProtectedValue('$_camelized'));
 		$this->assertEqual(Inflector::camelize('test_field', true), 'TestField');
 
 		$expected = array('test_field:_' => 'Test Field');
-		$this->assertFalse($this->_getProtectedValue('$_humanized'));
+		$this->assertEmpty($this->_getProtectedValue('$_humanized'));
 		$this->assertEqual(Inflector::humanize('test_field'), 'Test Field');
 		$this->assertEqual($expected, $this->_getProtectedValue('$_humanized'));
 		$this->assertEqual(Inflector::humanize('test_field'), 'Test Field');
 
 		$expected = array('field' => 'fields');
-		$this->assertFalse($this->_getProtectedValue('$_pluralized'));
+		$this->assertEmpty($this->_getProtectedValue('$_pluralized'));
 		$this->assertEqual(Inflector::pluralize('field'), 'fields');
 		$this->assertEqual($expected, $this->_getProtectedValue('$_pluralized'));
 		$this->assertEqual(Inflector::pluralize('field'), 'fields');

--- a/tests/cases/util/SetTest.php
+++ b/tests/cases/util/SetTest.php
@@ -1143,7 +1143,7 @@ class SetTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 
 		$this->assertTrue(Set::check($set, 'My Index 1'));
-		$this->assertTrue(Set::check($set, array()));
+		$this->assertNotEmpty(Set::check($set, array()));
 
 		$set = array('My Index 1' => array('First' => array('Second' => array('Third' => array(
 			'Fourth' => 'Heavy. Nesting.'
@@ -1162,7 +1162,7 @@ class SetTest extends \lithium\test\Unit {
 		$set = Set::remove($set, 'Session Test');
 		$this->assertFalse(Set::check($set, 'Session Test'));
 
-		$this->assertTrue($set = Set::insert(array(), 'Session Test.Test Case', "test"));
+		$this->assertNotEmpty($set = Set::insert(array(), 'Session Test.Test Case', "test"));
 		$this->assertTrue(Set::check($set, 'Session Test.Test Case'));
 	}
 
@@ -1208,9 +1208,9 @@ class SetTest extends \lithium\test\Unit {
 
 	public function testCombine() {
 		$result = Set::combine(array(), '/User/id', '/User/Data');
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 		$result = Set::combine('', '/User/id', '/User/Data');
-		$this->assertFalse($result);
+		$this->assertEmpty($result);
 
 		$a = array(
 			array('User' => array('id' => 2, 'group_id' => 1,

--- a/tests/cases/util/StringTest.php
+++ b/tests/cases/util/StringTest.php
@@ -40,7 +40,7 @@ class StringTest extends \lithium\test\Unit {
 		for ($i = 0; $i < $count; $i++) {
 			$result = String::uuid();
 			$match = preg_match($pattern, $result);
-			$this->assertTrue($match);
+			$this->assertNotEmpty($match);
 			$this->assertFalse(in_array($result, $check));
 			$check[] = $result;
 		}

--- a/tests/cases/util/ValidatorTest.php
+++ b/tests/cases/util/ValidatorTest.php
@@ -48,19 +48,19 @@ class ValidatorTest extends \lithium\test\Unit {
 			array('number' => 'one', 'name' => 'bob'),
 			$fieldValidationRules
 		);
-		$this->assertTrue(empty($result));
+		$this->assertEmpty($result);
 
 		$result = Validator::check(
 			array('number' => 'four', 'name' => 'bob'),
 			$fieldValidationRules
 		);
-		$this->assertFalse(empty($result));
+		$this->assertNotEmpty($result);
 
 		$result = Validator::check(
 			array('number' => 'one', 'name' => 'rex'),
 			$fieldValidationRules
 		);
-		$this->assertFalse(empty($result));
+		$this->assertNotEmpty($result);
 	}
 
 	/**
@@ -967,40 +967,40 @@ class ValidatorTest extends \lithium\test\Unit {
 		$this->assertFalse(Validator::isLuhn(true));
 	}
 
-    public function testDateValidation() {
-        $this->assertTrue(Validator::isDate('31-12-2012', 'dmy'));
-        $this->assertTrue(Validator::isDate('1 1 1999', 'dmy'));
-        $this->assertTrue(Validator::isDate('12/31/2012', 'mdy'));
-        $this->assertTrue(Validator::isDate('02.29.2000', 'mdy'));
-        $this->assertTrue(Validator::isDate('2012/12/31', 'ymd'));
-        $this->assertTrue(Validator::isDate('1999-1-01', 'ymd'));
-        $this->assertTrue(Validator::isDate('31 Dec 2012', 'dMy'));
-        $this->assertTrue(Validator::isDate('1 January 1999', 'dMy'));
-        $this->assertTrue(Validator::isDate('Dec 31 2012', 'Mdy'));
-        $this->assertTrue(Validator::isDate('January 1, 1999', 'Mdy'));
-        $this->assertTrue(Validator::isDate('December 2012', 'My'));
-        $this->assertTrue(Validator::isDate('Jan 1999', 'My'));
-        $this->assertTrue(Validator::isDate('12/2012', 'my'));
-        $this->assertTrue(Validator::isDate('1 2012', 'my'));
-        
-        $this->assertFalse(Validator::isDate('32-12-2012', 'dmy'));
-        $this->assertFalse(Validator::isDate('29 2 1999', 'dmy'));
-        $this->assertFalse(Validator::isDate('13/31/2012', 'mdy'));
-        $this->assertFalse(Validator::isDate('1.0.1999', 'mdy'));
-        $this->assertFalse(Validator::isDate('2012/11/31', 'ymd'));
-        $this->assertFalse(Validator::isDate('2012/11/0', 'ymd'));
-        $this->assertFalse(Validator::isDate('31 Dic 2012', 'dMy'));
-        $this->assertFalse(Validator::isDate('1.January.1999', 'dMy'));
-        $this->assertFalse(Validator::isDate('Dec-31-2012', 'Mdy'));
-        $this->assertFalse(Validator::isDate('December/2012', 'My'));
-        $this->assertFalse(Validator::isDate('Jan.1999', 'My'));
-        $this->assertFalse(Validator::isDate('13 2012', 'my'));
-    }
-    
+	public function testDateValidation() {
+		$this->assertTrue(Validator::isDate('31-12-2012', 'dmy'));
+		$this->assertTrue(Validator::isDate('1 1 1999', 'dmy'));
+		$this->assertTrue(Validator::isDate('12/31/2012', 'mdy'));
+		$this->assertTrue(Validator::isDate('02.29.2000', 'mdy'));
+		$this->assertTrue(Validator::isDate('2012/12/31', 'ymd'));
+		$this->assertTrue(Validator::isDate('1999-1-01', 'ymd'));
+		$this->assertTrue(Validator::isDate('31 Dec 2012', 'dMy'));
+		$this->assertTrue(Validator::isDate('1 January 1999', 'dMy'));
+		$this->assertTrue(Validator::isDate('Dec 31 2012', 'Mdy'));
+		$this->assertTrue(Validator::isDate('January 1, 1999', 'Mdy'));
+		$this->assertTrue(Validator::isDate('December 2012', 'My'));
+		$this->assertTrue(Validator::isDate('Jan 1999', 'My'));
+		$this->assertTrue(Validator::isDate('12/2012', 'my'));
+		$this->assertTrue(Validator::isDate('1 2012', 'my'));
+
+		$this->assertFalse(Validator::isDate('32-12-2012', 'dmy'));
+		$this->assertFalse(Validator::isDate('29 2 1999', 'dmy'));
+		$this->assertFalse(Validator::isDate('13/31/2012', 'mdy'));
+		$this->assertFalse(Validator::isDate('1.0.1999', 'mdy'));
+		$this->assertFalse(Validator::isDate('2012/11/31', 'ymd'));
+		$this->assertFalse(Validator::isDate('2012/11/0', 'ymd'));
+		$this->assertFalse(Validator::isDate('31 Dic 2012', 'dMy'));
+		$this->assertFalse(Validator::isDate('1.January.1999', 'dMy'));
+		$this->assertFalse(Validator::isDate('Dec-31-2012', 'Mdy'));
+		$this->assertFalse(Validator::isDate('December/2012', 'My'));
+		$this->assertFalse(Validator::isDate('Jan.1999', 'My'));
+		$this->assertFalse(Validator::isDate('13 2012', 'my'));
+	}
+
 	public function testCheckHasErrors() {
 		$rules = array('title' => array('please enter a title'));
 		$result = Validator::check(array(), $rules);
-		$this->assertFalse(empty($result));
+		$this->assertNotEmpty($result);
 
 		$expected = array('title' => array('please enter a title'));
 		$this->assertEqual($expected, $result);
@@ -1010,7 +1010,7 @@ class ValidatorTest extends \lithium\test\Unit {
 		$rules = array('title' => 'please enter a title');
 		$data = array('title' => 'new title');
 		$result = Validator::check($data, $rules);
-		$this->assertTrue(empty($result));
+		$this->assertEmpty($result);
 	}
 
 	public function testCheckSkipEmpty() {
@@ -1021,17 +1021,17 @@ class ValidatorTest extends \lithium\test\Unit {
 		// empty string should pass
 		$data = array('email' => '');
 		$result = Validator::check($data, $rules);
-		$this->assertTrue(empty($result));
+		$this->assertEmpty($result);
 
 		// null value should pass
 		$data = array('email' => null);
 		$result = Validator::check($data, $rules);
-		$this->assertTrue(empty($result));
+		$this->assertEmpty($result);
 
 		// string with spaces should NOT pass
 		$data = array('email' => ' ');
 		$result = Validator::check($data, $rules);
-		$this->assertFalse(empty($result));
+		$this->assertNotEmpty($result);
 	}
 
 	public function testCheckMultipleHasErrors() {
@@ -1043,7 +1043,7 @@ class ValidatorTest extends \lithium\test\Unit {
 			)
 		);
 		$result = Validator::check(array(), $rules);
-		$this->assertFalse(empty($result));
+		$this->assertNotEmpty($result);
 
 		$expected = array(
 			'title' => array('please enter a title'),
@@ -1061,7 +1061,7 @@ class ValidatorTest extends \lithium\test\Unit {
 			)
 		);
 		$result = Validator::check(array(), $rules);
-		$this->assertFalse(empty($result));
+		$this->assertNotEmpty($result);
 
 		$expected = array(
 			'title' => array('title is empty'),
@@ -1086,7 +1086,7 @@ class ValidatorTest extends \lithium\test\Unit {
 			'title' => array('please enter a title'),
 			'email' => array('email is not valid')
 		);
-		$this->assertFalse(empty($result));
+		$this->assertNotEmpty($result);
 		$this->assertEqual($errors, $result);
 	}
 
@@ -1100,7 +1100,7 @@ class ValidatorTest extends \lithium\test\Unit {
 		);
 		$data = array('title' => 'new title', 'email' => 'something');
 		$result = Validator::check($data, $rules);
-		$this->assertFalse(empty($result));
+		$this->assertNotEmpty($result);
 
 		$expected = array('email' => array('email is not valid'));
 		$this->assertEqual($expected, $result);
@@ -1116,7 +1116,7 @@ class ValidatorTest extends \lithium\test\Unit {
 		);
 		$data = array('title' => 'new title', 'email' => 'something@test.com');
 		$result = Validator::check($data, $rules);
-		$this->assertTrue(empty($result));
+		$this->assertEmpty($result);
 
 		$expected = array();
 		$this->assertEqual($expected, $result);

--- a/tests/integration/analysis/LoggerTest.php
+++ b/tests/integration/analysis/LoggerTest.php
@@ -33,7 +33,7 @@ class LoggerTest extends \lithium\test\Integration {
 		Logger::config($config);
 
 		$result = Logger::write('info', 'Original Message');
-		$this->assertTrue(file_exists($base . '/info.log'));
+		$this->assertFileExists($base . '/info.log');
 
 		$expected = "Filtered Message\n";
 		$result = file_get_contents($base . '/info.log');

--- a/tests/integration/data/DatabaseTest.php
+++ b/tests/integration/data/DatabaseTest.php
@@ -156,7 +156,7 @@ class DatabaseTest extends \lithium\test\Integration {
 		$images = $this->db->read($query)->data();
 		reset($this->images);
 
-		$this->assertEqual(3, count($images));
+		$this->assertCount(3, $images);
 		foreach ($images as $key => $image) {
 			$expect = current($this->images) + array(
 				'gallery_id' => 1,
@@ -192,7 +192,7 @@ class DatabaseTest extends \lithium\test\Integration {
 		$galleries = $this->db->read($query)->data();
 		$images = array(1 => $this->images[1], 2 => $this->images[2], 3 => $this->images[3]);
 
-		$this->assertEqual(1, count($galleries));
+		$this->assertCount(1, $galleries);
 		foreach ($galleries as $key => $gallery) {
 			$expect = $this->galleries[1] + array(
 				'images' => $images
@@ -244,7 +244,7 @@ class DatabaseTest extends \lithium\test\Integration {
 
 		$expected = array($this->images[3], $this->images[2], $this->images[1]);
 
-		$this->assertEqual(3, count($images));
+		$this->assertCount(3, $images);
 		foreach ($images as $image) {
 			$this->assertEqual(current($expected), $image);
 			next($expected);
@@ -261,7 +261,7 @@ class DatabaseTest extends \lithium\test\Integration {
 			'order' => array('Galleries.id' => 'ASC')
 		));
 
-		$this->assertEqual(2, count($galleries));
+		$this->assertCount(2, $galleries);
 		$expected = array(3, 2);
 
 		foreach ($galleries as $gallery) {

--- a/tests/integration/data/FieldsTest.php
+++ b/tests/integration/data/FieldsTest.php
@@ -58,7 +58,7 @@ class FieldsTest extends \lithium\test\Integration {
 
 		$entity = MockCompanies::first($id);
 
-		$this->assertTrue($entity instanceof Entity);
+		$this->assertInstanceOf('lithium\data\Entity', $entity);
 		$this->skipIf(!$entity instanceof Entity, 'Queried object is not an entity.');
 
 		$expected = array(
@@ -73,7 +73,7 @@ class FieldsTest extends \lithium\test\Integration {
 			'fields' => array($key)
 		));
 
-		$this->assertTrue($entity instanceof Entity);
+		$this->assertInstanceOf('lithium\data\Entity', $entity);
 		$this->skipIf(!$entity instanceof Entity, 'Queried object is not an entity.');
 
 		$expected = array($key => $id);
@@ -84,7 +84,7 @@ class FieldsTest extends \lithium\test\Integration {
 			'conditions' => array($key => $id),
 			'fields' => array($key, 'name')
 		));
-		$this->assertTrue($entity instanceof Entity);
+		$this->assertInstanceOf('lithium\data\Entity', $entity);
 		$this->skipIf(!$entity instanceof Entity, 'Queried object is not an entity.');
 
 		$entity->name = 'Acme, Incorporated';

--- a/tests/integration/data/SourceTest.php
+++ b/tests/integration/data/SourceTest.php
@@ -100,16 +100,16 @@ class SourceTest extends \lithium\test\Integration {
 		$new = Companies::create(array($key => 12345, 'name' => 'Acme, Inc.'));
 
 		$result = $new->data();
-		$this->assertTrue($result !== null);
+		$this->assertNotNull($result);
 		$this->assertTrue($new->save());
 		$this->assertTrue($new->exists());
 
 		$result = Companies::all(12345);
-		$this->assertTrue($result !== null);
+		$this->assertNotNull($result);
 
 		$result = $result->rewind();
-		$this->assertTrue($result !== null);
-		$this->assertTrue(!is_string($result));
+		$this->assertNotNull($result);
+		$this->assertInternalType('string', $result);
 	}
 
 	public function testFindFirstWithFieldsOption() {
@@ -126,7 +126,7 @@ class SourceTest extends \lithium\test\Integration {
 		$this->assertTrue($new->exists());
 
 		$result = Companies::find('first', array('fields' => array('name')));
-		$this->assertFalse(is_null($result));
+		$this->assertNotInternalType('null', $result);
 
 		$this->skipIf(is_null($result), 'No result returned to test');
 		$result = $result->data();

--- a/tests/integration/net/SocketTest.php
+++ b/tests/integration/net/SocketTest.php
@@ -9,7 +9,6 @@
 namespace lithium\tests\integration\net;
 
 use lithium\net\socket\Curl;
-use lithium\net\http\Response;
 use lithium\net\socket\Stream;
 use lithium\net\socket\Context;
 
@@ -36,7 +35,7 @@ class SocketTest extends \lithium\test\Integration {
 		$socket = new Context($this->_testConfig);
 		$this->assertTrue($socket->open());
 		$response = $socket->send();
-		$this->assertTrue($response instanceof Response);
+		$this->assertInstanceOf('lithium\net\http\Response', $response);
 
 		$expected = 'google.com';
 		$result = $response->host;
@@ -53,7 +52,7 @@ class SocketTest extends \lithium\test\Integration {
 		$socket = new Curl($this->_testConfig);
 		$this->assertTrue($socket->open());
 		$response = $socket->send();
-		$this->assertTrue($response instanceof Response);
+		$this->assertInstanceOf('lithium\net\http\Response', $response);
 
 		$expected = 'google.com';
 		$result = $response->host;
@@ -67,7 +66,7 @@ class SocketTest extends \lithium\test\Integration {
 		$socket = new Stream($this->_testConfig);
 		$this->assertTrue($socket->open());
 		$response = $socket->send();
-		$this->assertTrue($response instanceof Response);
+		$this->assertInstanceOf('lithium\net\http\Response', $response);
 
 		$expected = 'google.com';
 		$result = $response->host;


### PR DESCRIPTION
This includes docblock fixes, remove duplicate assertions, fixing assert true/false, and changing some tests to use the new assertions.

Alternative to #833 
