### PR TITLE
Modify AssertHasKey and AssertHasNotKey to work with null value

### DIFF
--- a/test/Unit.php
+++ b/test/Unit.php
@@ -1203,7 +1203,13 @@ class Unit extends \lithium\core\Object {
 	 * @return bool
 	 */
 	public function assertArrayHasKey($key, $array, $message = '{:message}') {
-		return $this->assert(isset($array[$key]), $message, array(
+		if (is_object($array) && $array instanceof \ArrayAccess) {
+		    $result = isset($array[$key]);
+		} else {
+			$result = array_key_exists($key, $array);
+		}
+
+		return $this->assert($result, $message, array(
 			'expected' => $key,
 			'result' => $array
 		));
@@ -1226,7 +1232,13 @@ class Unit extends \lithium\core\Object {
 	 * @return bool
 	 */
 	public function assertArrayNotHasKey($key, $array, $message = '{:message}') {
-		return $this->assert(!isset($array[$key]), $message, array(
+		if (is_object($array) && $array instanceof \ArrayAccess) {
+			$result = isset($array[$key]);
+		} else {
+			$result = array_key_exists($key, $array);
+		}
+
+		return $this->assert(!$result, $message, array(
 			'expected' => $key,
 			'result' => $array
 		));

--- a/tests/cases/test/UnitTest.php
+++ b/tests/cases/test/UnitTest.php
@@ -757,6 +757,15 @@ class UnitTest extends \lithium\test\Unit {
 		), $result['data']);
 	}
 
+	public function testArrayHasKeyValueNull() {
+		$this->assertTrue($this->test->assertArrayHasKey('bar', array('bar' => null)));
+
+		$results = $this->test->results();
+		$result = array_pop($results);
+
+		$this->assertEqual('pass', $result['result']);
+	}
+
 	public function testArrayNotHasKeyTrue() {
 		$this->assertTrue($this->test->assertArrayNotHasKey('foo', array('bar' => 'baz')));
 


### PR DESCRIPTION
Currently the new Assertion methods only check for a key
with `isset` and that a value is present (not null).

This change modifies the `isset` to use `array_key_exists`
to verify a key is in an array regardless of the value of
they key. This ensure if the value is null, and they key
is there the test passes.
