### PR TITLE
Entity::errors() will append errors and will merge the new given errors

### DIFF
--- a/data/Entity.php
+++ b/data/Entity.php
@@ -277,23 +277,32 @@ class Entity extends \lithium\core\Object {
 	 * Access the errors of the record.
 	 *
 	 * @see lithium\data\Entity::$_errors
-	 * @param array|string $field If an array, overwrites `$this->_errors`. If a string, and
-	 *        `$value` is not `null`, sets the corresponding key in `$this->_errors` to `$value`.
+	 * @param array|string $field If an array, overwrites `$this->_errors` if it is empty, if not,
+	 *		  merges the errors with the current values. If a string, and `$value` is not `null`,
+	 *		  sets the corresponding key in `$this->_errors` to `$value`. Setting `$field` to
+	 *		  `false` will reset the current state.
 	 * @param string $value Value to set.
 	 * @return mixed Either the `$this->_errors` array, or single value from it.
 	 */
 	public function errors($field = null, $value = null) {
+		if ($field === false) {
+			return ($this->_errors = array());
+		}
 		if ($field === null) {
 			return $this->_errors;
 		}
 		if (is_array($field)) {
-			return ($this->_errors = $field);
+			return ($this->_errors = array_merge_recursive($this->_errors, $field));
 		}
 		if ($value === null && isset($this->_errors[$field])) {
 			return $this->_errors[$field];
 		}
 		if ($value !== null) {
-			return $this->_errors[$field] = $value;
+			if (array_key_exists($field, $this->_errors)) {
+				$current = $this->_errors[$field];
+				return ($this->_errors[$field] = array_merge((array) $current, (array) $value));
+			}
+			return ($this->_errors[$field] = $value);
 		}
 		return $value;
 	}

--- a/data/Model.php
+++ b/data/Model.php
@@ -1161,9 +1161,10 @@ class Model extends \lithium\core\StaticObject {
 		$options += $defaults;
 		$self = static::_object();
 		$validator = $self->_classes['validator'];
+		$entity->errors(false);
 		$params = compact('entity', 'options');
 
-		$filter = function($parent, $params) use (&$self, $validator) {
+		$filter = function($parent, $params) use ($validator) {
 			$entity = $params['entity'];
 			$options = $params['options'];
 			$rules = $options['rules'];

--- a/tests/cases/data/EntityTest.php
+++ b/tests/cases/data/EntityTest.php
@@ -118,6 +118,71 @@ class EntityTest extends \lithium\test\Unit {
 		$entity->errors($errors);
 		$this->assertEqual($errors, $entity->errors());
 		$this->assertEqual('Something bad happened.', $entity->errors('foo'));
+
+		$otherError = array('bar' => 'Something really bad happened.');
+		$errors += $otherError;
+		$entity->errors($otherError);
+		$this->assertEqual($errors, $entity->errors());
+
+		$this->assertCount(2, $entity->errors());
+		$this->assertEqual('Something bad happened.', $entity->errors('foo'));
+		$this->assertEqual('Something really bad happened.', $entity->errors('bar'));
+	}
+
+	public function testResetErrors() {
+		$entity = new Entity();
+		$errors = array(
+			'foo' => 'Something bad happened.',
+			'bar' => 'Something really bad happened.'
+		);
+
+		$entity->errors($errors);
+		$this->assertEqual($errors, $entity->errors());
+
+		$entity->errors(false);
+		$this->assertEmpty($entity->errors());
+	}
+
+	public function testAppendingErrors() {
+		$entity = new Entity();
+		$expected = array(
+			'Something bad happened.',
+			'Something really bad happened.'
+		);
+
+		$entity->errors('foo', $expected[0]);
+		$entity->errors('foo', $expected[1]);
+
+		$this->assertCount(1, $entity->errors());
+		$this->assertEqual($expected, $entity->errors('foo'));
+	}
+
+	public function testAppendingErrorsWithArraySyntax() {
+		$entity = new Entity();
+		$expected = array(
+			'Something bad happened.',
+			'Something really bad happened.'
+		);
+
+		$entity->errors(array('foo' => $expected[0]));
+		$entity->errors(array('foo' => $expected[1]));
+
+		$this->assertCount(1, $entity->errors());
+		$this->assertEqual($expected, $entity->errors('foo'));
+	}
+
+	public function testAppendingErrorsWithMixedSyntax() {
+		$entity = new Entity();
+		$expected = array(
+			'Something bad happened.',
+			'Something really bad happened.'
+		);
+
+		$entity->errors('foo', $expected[0]);
+		$entity->errors(array('foo' => $expected[1]));
+
+		$this->assertCount(1, $entity->errors());
+		$this->assertEqual($expected, $entity->errors('foo'));
 	}
 
 	public function testConversion() {

--- a/tests/cases/data/ModelTest.php
+++ b/tests/cases/data/ModelTest.php
@@ -634,6 +634,20 @@ class ModelTest extends \lithium\test\Unit {
 		$this->assertEqual($errors, $antique->errors());
 	}
 
+	public function testErrorsIsClearedOnEachValidates() {
+		$post = MockPostForValidates::create(array('title' => 'new post'));
+		$result = $post->validates();
+		$this->assertFalse($result);
+		$result = $post->errors();
+		$this->assertNotEmpty($result);
+
+		$post->email = 'contact@lithify.me';
+		$result = $post->validates();
+		$this->assertTrue($result);
+		$result = $post->errors();
+		$this->assertEmpty($result);
+	}
+
 	public function testDefaultValuesFromSchema() {
 		$creator = MockCreator::create();
 

--- a/tests/cases/data/entity/DocumentTest.php
+++ b/tests/cases/data/entity/DocumentTest.php
@@ -656,8 +656,11 @@ class DocumentTest extends \lithium\test\Unit {
 		$result = $doc->errors('title');
 		$this->assertEqual($expected, $result);
 
+		/**
+		 * Errors are appended so, both errors are expected to be in an array
+		 */
 		$doc->errors('title', 'Too generic');
-		$expected = 'Too generic';
+		$expected = array('Too short', 'Too generic');
 		$result = $doc->errors('title');
 		$this->assertEqual($expected, $result);
 	}


### PR DESCRIPTION
with the previous ones already stored in the Entity's $_errors variable.
