### PR TITLE
update Request::referer() to correctly identify local urls which contain a full url string

### DIFF
--- a/action/Request.php
+++ b/action/Request.php
@@ -514,7 +514,15 @@ class Request extends \lithium\net\http\Request {
 			if (!$local) {
 				return $ref;
 			}
-			if (strpos($ref, '://') === false) {
+			$url = parse_url($ref) + array('path' => '');
+			if (empty($url['host']) || $url['host'] == $this->env('HTTP_HOST')) {
+				$ref = $url['path'];
+				if (!empty($url['query'])) {
+					$ref .= '?' . $url['query'];
+				}
+				if (!empty($url['fragment'])) {
+					$ref .= '#' . $url['fragment'];
+				}
 				return $ref;
 			}
 		}

--- a/tests/cases/action/RequestTest.php
+++ b/tests/cases/action/RequestTest.php
@@ -387,6 +387,7 @@ class RequestTest extends \lithium\test\Unit {
 
 	public function testRefererNotLocal() {
 		$_SERVER['HTTP_REFERER'] = 'http://lithium.com/posts/index';
+		$_SERVER['HTTP_HOST'] = 'foo.com';
 		$request = new Request();
 
 		$expected = 'http://lithium.com/posts/index';
@@ -403,8 +404,19 @@ class RequestTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 	}
 
+	public function testRefererLocalWithHost() {
+		$_SERVER['HTTP_REFERER'] = 'http://lithium.com/posts/index';
+		$_SERVER['HTTP_HOST'] = 'lithium.com';
+		$request = new Request();
+
+		$expected = '/posts/index';
+		$result = $request->referer('/', true);
+		$this->assertEqual($expected, $result);
+	}
+
 	public function testRefererLocalFromNotLocal() {
 		$_SERVER['HTTP_REFERER'] = 'http://lithium.com/posts/index';
+		$_SERVER['HTTP_HOST'] = 'foo.com';
 		$request = new Request();
 
 		$expected = '/';


### PR DESCRIPTION
`\lithium\net\http\Request::referer()` would be much more useful if it could identify `HTTP_REFERER` values which contain `HTTP_HOST` when filtering for local urls.

AFAIK, `HTTP_REFERER` is almost never set to an absolute path sans-host, so I don't see how the current implementation of the $local parameter is useful.

This method is useful to me on a particular project of mine where I wanted to return a user to the referring page after login (say due to a 403 response), but only when the referrer was local.
