### PR TITLE
ensure Request::env('REMOTE_ADDR') consistently returns only one IP address

### DIFF
--- a/action/Request.php
+++ b/action/Request.php
@@ -248,7 +248,7 @@ class Request extends \lithium\net\http\Request {
 			$https = array('HTTP_X_FORWARDED_FOR', 'HTTP_PC_REMOTE_ADDR', 'HTTP_X_REAL_IP');
 			foreach ($https as $altKey) {
 				if ($addr = $this->env($altKey)) {
-					$val = $addr;
+					list($val) = explode(', ', $addr);
 					break;
 				}
 			}

--- a/tests/cases/action/RequestTest.php
+++ b/tests/cases/action/RequestTest.php
@@ -131,6 +131,12 @@ class RequestTest extends \lithium\test\Unit {
 
 		$request = new Request(array('env' => array(
 			'REMOTE_ADDR' => '123.456.789.000',
+			'HTTP_X_FORWARDED_FOR' => '333.222.444.111, 444.333.222.111, 255.255.255.255'
+		)));
+		$this->assertEqual('333.222.444.111', $request->env('REMOTE_ADDR'));
+
+		$request = new Request(array('env' => array(
+			'REMOTE_ADDR' => '123.456.789.000',
 			'HTTP_PC_REMOTE_ADDR' => '222.333.444.555'
 		)));
 		$this->assertEqual('222.333.444.555', $request->env('REMOTE_ADDR'));


### PR DESCRIPTION
In some environments, such as Orchestra.io's load-balanced nginx environment, `$_SERVER['HTTP_X_FORWARDED_FOR']` will actually contain three IP addresses concatenated by comma+space.

When running `Request::env('REMOTE_ADDR')`, I'd like to reasonably expect that I'm only going to get the remote IP address of the client.

see [stackoverflow.com](http://stackoverflow.com/questions/753645/how-do-i-get-the-correct-ip-from-http-x-forwarded-for-if-it-contains-multiple-ip) and [wikipedia.org](http://en.wikipedia.org/wiki/X-Forwarded-For)
