### PR TITLE
Fix for issue #774

### DIFF
--- a/net/http/Route.php
+++ b/net/http/Route.php
@@ -232,7 +232,9 @@ class Route extends \lithium\core\Object {
 		if (isset($match['args'])) {
 			$match['args'] = explode('/', $match['args']);
 		}
-		$result = array_filter(array_intersect_key($match, $this->_keys));
+		$result = array_filter(array_intersect_key($match, $this->_keys), function($val) {
+			return !is_scalar($val) || strlen($val);
+		});
 		if (isset($this->_keys['args'])) {
 			$result += array('args' => array());
 		}

--- a/tests/cases/net/http/RouteTest.php
+++ b/tests/cases/net/http/RouteTest.php
@@ -171,6 +171,11 @@ class RouteTest extends \lithium\test\Unit {
 		$result = $route->parse($request);
 		$this->assertEqual($expected, $result->params);
 
+		$request->url = '/posts/view/0';
+		$result = $route->parse($request);
+		$expected = array('controller' => 'posts', 'action' => 'view', 'id' => '0');
+		$this->assertEqual($expected, $result->params);
+
 		$request->url = '/posts/view/5';
 		$result = $route->parse($request);
 		$expected = array('controller' => 'posts', 'action' => 'view', 'id' => '5');


### PR DESCRIPTION
Ensure explicit request variables with value 0 are not treated as though they are undefined.
