### PR TITLE
Verify model provided to the Form Auth adapter exists prior to attempted use

### DIFF
--- a/security/auth/adapter/Form.php
+++ b/security/auth/adapter/Form.php
@@ -11,6 +11,7 @@ namespace lithium\security\auth\adapter;
 use lithium\core\Libraries;
 use UnexpectedValueException;
 use lithium\security\Password;
+use lithium\core\ClassNotFoundException;
 
 /**
  * The `Form` adapter provides basic authentication facilities for checking credentials submitted
@@ -306,7 +307,10 @@ class Form extends \lithium\core\Object {
 				$this->_fields[$val] = $val;
 			}
 		}
-		$this->_model = Libraries::locate('models', $this->_model);
+		if (!class_exists($model = Libraries::locate('models', $this->_model))) {
+			throw new ClassNotFoundException("Model class '{$this->_model}' not found.");
+		}
+		$this->_model = $model;
 	}
 
 	/**

--- a/tests/cases/security/auth/adapter/FormTest.php
+++ b/tests/cases/security/auth/adapter/FormTest.php
@@ -47,6 +47,19 @@ class FormTest extends \lithium\test\Unit {
 	}
 
 	/**
+	 * Tests a check for the model class prior to attempted use.
+	 **/
+	public function testModel() {
+		$this->expectException("Model class 'ModelDoesNotExist' not found.");
+		
+		$subject = new Form(array(
+			'model' => 'ModelDoesNotExist',
+			'fields' => array('username'),
+			'validators' => array('password' => false)
+		));
+	}
+
+	/**
 	 * Tests a simple user lookup. Note that we're not using the password validator; due to the
 	 * limitations of this classes first() mock method, password will not be in the dataset
 	 * returned by Form::check().


### PR DESCRIPTION
simple `class_exists` call to provide a more descriptive/useful error message when misconfigured
