### PR TITLE
Fix misnamed 'priority' parameter in Logger adapter write methods

### DIFF
--- a/analysis/logger/adapter/Cache.php
+++ b/analysis/logger/adapter/Cache.php
@@ -52,7 +52,7 @@ class Cache extends \lithium\core\Object {
 		$defaults = array(
 			'config' => null,
 			'expiry' => '+999 days',
-			'key' => 'log_{:type}_{:timestamp}'
+			'key' => 'log_{:priority}_{:timestamp}'
 		);
 		parent::__construct($config + $defaults);
 	}
@@ -60,11 +60,11 @@ class Cache extends \lithium\core\Object {
 	/**
 	 * Writes the message to the configured cache adapter.
 	 *
-	 * @param string $type
+	 * @param string $priority
 	 * @param string $message
 	 * @return closure Function returning boolean `true` on successful write, `false` otherwise.
 	 */
-	public function write($type, $message) {
+	public function write($priority, $message) {
 		$config = $this->_config + $this->_classes;
 
 		return function($self, $params) use ($config) {

--- a/analysis/logger/adapter/Growl.php
+++ b/analysis/logger/adapter/Growl.php
@@ -116,14 +116,14 @@ class Growl extends \lithium\core\Object {
 	/**
 	 * Writes `$message` to a new Growl notification.
 	 *
-	 * @param string $type The `Logger`-based priority of the message. This value is mapped to
-	 *               a Growl-specific priority value if possible.
+	 * @param string $priority The `Logger`-based priority of the message. This value is mapped
+	 *               to a Growl-specific priority value if possible.
 	 * @param string $message Message to be shown.
 	 * @param array $options Any options that are passed to the `notify()` method. See the
 	 *              `$options` parameter of `notify()`.
 	 * @return closure Function returning boolean `true` on successful write, `false` otherwise.
 	 */
-	public function write($type, $message, array $options = array()) {
+	public function write($priority, $message, array $options = array()) {
 		$_self =& $this;
 		$_priorities = $this->_priorities;
 


### PR DESCRIPTION
The only real function of this fix is on line 55 of analysis/logger/adapter/Cache.php which wasn't catching the priority parameter as it was meant to.

I went ahead and updated the parameter name in the adapter (and the Growl adapter) as well just to be consistent with the other adapters.
