### PR TITLE
minor update to Request::to() and Request::queryString()

### DIFF
--- a/net/http/Request.php
+++ b/net/http/Request.php
@@ -121,21 +121,20 @@ class Request extends \lithium\net\http\Message {
 	 */
 	public function queryString($params = array(), $format = null) {
 		$result = array();
+		$query = array();
 
-		foreach (array_filter(array($this->query, $params)) as $query) {
-			if (is_string($query)) {
-				$result[] = $query;
+		foreach (array_filter(array($this->query, $params)) as $querySet) {
+			if (is_string($querySet)) {
+				$result[] = $querySet;
 				continue;
 			}
-			$query = array_filter($query);
-
-			if (!$format) {
-				$result[] = http_build_query($query);
-				continue;
-			}
+			$query = array_merge($query, $querySet);
+		}
+		$query = array_filter($query);
+		
+		if ($format) {
 			$q = null;
-
-			foreach ($params as $key => $value) {
+			foreach ($query as $key => $value) {
 				if (!is_array($value)) {
 					$q .= String::insert($format, array(
 						'key' => urlencode($key),
@@ -151,7 +150,10 @@ class Request extends \lithium\net\http\Message {
 				}
 			}
 			$result[] = substr($q, 0, -1);
+		} else {
+			$result[] = http_build_query($query);
 		}
+		
 		$result = array_filter($result);
 		return $result ? "?" . join("&", $result) : null;
 	}

--- a/tests/cases/net/http/RequestTest.php
+++ b/tests/cases/net/http/RequestTest.php
@@ -111,6 +111,17 @@ class RequestTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 	}
 
+	public function testQueryStringMerge() {
+		$expected = "?param=foo";
+		$this->request->query = array('param' => 'value');
+		$result = $this->request->queryString(array('param' => 'foo'));
+		$this->assertEqual($expected, $result);
+
+		$expected = "?param=foo&param2=bar";
+		$result = $this->request->queryString(array('param' => 'foo', 'param2' => 'bar'));
+		$this->assertEqual($expected, $result);
+	}
+
 	public function testToString() {
 		$expected = join("\r\n", array(
 			'GET / HTTP/1.1',


### PR DESCRIPTION
`Request::to()` allows query strings to be overridden rather than appended.
`Request::queryString()` allows query parameters to be merged rather than appended.

also removed arbitrary requirement that $port must be pre-formatted with a colon in the parameters.
