### PR TITLE
Instanciation of `Document\DocumentSet` should be delegated to the model's connection when possible

### DIFF
--- a/data/DocumentSchema.php
+++ b/data/DocumentSchema.php
@@ -74,13 +74,18 @@ class DocumentSchema extends \lithium\data\Schema {
 
 		if ($options['wrap']) {
 			$config = array(
-				'data' => $val,
 				'parent' => $options['parent'],
-				'model' => $options['model'],
 				'schema' => $this
 			);
 			$config += compact('pathKey') + array_diff_key($options, $defaults);
-			$val = $this->_instance($class, $config);
+
+			if ($model = $options['model']) {
+				$connection = $model::connection();
+				$val = $connection->item($model, $val, $config + array('class' => $class));
+			} else {
+				$config['data'] = $val;
+				$val = $this->_instance($class, $config);
+			}
 		} elseif ($class === 'set') {
 			$val = $val ?: array();
 			foreach ($val as &$value) {

--- a/data/source/http/adapter/CouchDb.php
+++ b/data/source/http/adapter/CouchDb.php
@@ -259,9 +259,6 @@ class CouchDb extends \lithium\data\source\Http {
 				unset($result['rows']);
 				$stats = $result;
 			}
-			foreach ($data as $key => $val) {
-				$data[$key] = $self->item($model, $val, array('exists' => true));
-			}
 			$stats += array('total_rows' => null, 'offset' => null);
 			$opts = compact('stats') + array('class' => 'set', 'exists' => true);
 			return $self->item($query->model(), $data, $opts);


### PR DESCRIPTION
Delegating instanciations to the datasource allow for example this kind of abstraction:

``` php
/**
 * Example of Single Table Inheritance implementation based on `'_type'`.
 */
class MongoDb extends \lithium\data\source\MongoDb {

    public function item($model, array $data = array(), array $options = array()) {
        $defaults = array('class' => 'entity');
        $options += $defaults;

        //Dynamically change the `$class` model according a `'_type'` field.
        if (isset($data['_type']) && $data['_type']) {
            list($namespace, $name) = preg_split("/\\\[^\\\]*$/", $model);
            $model = $namespace . '\\' . Inflector::humanize(Inflector::pluralize($data['_type']));
            if (!class_exists($model)) {
                throw new RuntimeException("Class `{$model}` not found.");
            }
        }

        $class = $options['class'];
        unset($options['class']);
        return $this->_instance($class, compact('model', 'data') + $options);
    }
}
```
