### PR TITLE
Updated all docblock type hints of Closure to FQN for accuracy / IDE compatibility

### DIFF
--- a/analysis/logger/adapter/Cache.php
+++ b/analysis/logger/adapter/Cache.php
@@ -9,6 +9,7 @@
 namespace lithium\analysis\logger\adapter;
 
 use lithium\util\String;
+use Closure;
 
 /**
  * The `Cache` logger allows log messages to be written to cache configurations set up in
@@ -62,7 +63,7 @@ class Cache extends \lithium\core\Object {
 	 *
 	 * @param string $priority
 	 * @param string $message
-	 * @return closure Function returning boolean `true` on successful write, `false` otherwise.
+	 * @return Closure Function returning boolean `true` on successful write, `false` otherwise.
 	 */
 	public function write($priority, $message) {
 		$config = $this->_config + $this->_classes;

--- a/analysis/logger/adapter/File.php
+++ b/analysis/logger/adapter/File.php
@@ -10,6 +10,7 @@ namespace lithium\analysis\logger\adapter;
 
 use lithium\util\String;
 use lithium\core\Libraries;
+use Closure;
 
 /**
  * A simple log adapter that writes messages to files. By default, messages are written to
@@ -66,7 +67,7 @@ class File extends \lithium\core\Object {
 	 * @see lithium\analysis\Logger::$_priorities
 	 * @param string $priority The message priority. See `Logger::$_priorities`.
 	 * @param string $message The message to write to the log.
-	 * @return closure Function returning boolean `true` on successful write, `false` otherwise.
+	 * @return Closure Function returning boolean `true` on successful write, `false` otherwise.
 	 */
 	public function write($priority, $message) {
 		$config = $this->_config;

--- a/analysis/logger/adapter/Growl.php
+++ b/analysis/logger/adapter/Growl.php
@@ -11,6 +11,7 @@ namespace lithium\analysis\logger\adapter;
 use lithium\util\Inflector;
 use lithium\core\NetworkException;
 use lithium\core\Libraries;
+use Closure;
 
 /**
  * The `Growl` logger implements support for the [ Growl](http://growl.info/) notification system
@@ -122,7 +123,7 @@ class Growl extends \lithium\core\Object {
 	 * @param string $message Message to be shown.
 	 * @param array $options Any options that are passed to the `notify()` method. See the
 	 *              `$options` parameter of `notify()`.
-	 * @return closure Function returning boolean `true` on successful write, `false` otherwise.
+	 * @return Closure Function returning boolean `true` on successful write, `false` otherwise.
 	 */
 	public function write($priority, $message, array $options = array()) {
 		$_self =& $this;

--- a/analysis/logger/adapter/Syslog.php
+++ b/analysis/logger/adapter/Syslog.php
@@ -8,6 +8,8 @@
 
 namespace lithium\analysis\logger\adapter;
 
+use Closure;
+
 /**
  * The Syslog adapter facilitates logging messages to a `syslogd` backend. See the constructor for
  * information on configuring this adapter.
@@ -64,7 +66,7 @@ class Syslog extends \lithium\core\Object {
 	 *
 	 * @param string $priority The message priority string. Maps to a `syslogd` priority constant.
 	 * @param string $message The message to write.
-	 * @return closure Function returning boolean `true` on successful write, `false` otherwise.
+	 * @return Closure Function returning boolean `true` on successful write, `false` otherwise.
 	 */
 	public function write($priority, $message) {
 		$config = $this->_config;

--- a/core/Libraries.php
+++ b/core/Libraries.php
@@ -13,6 +13,7 @@ use lithium\util\String;
 use lithium\util\collection\Filters;
 use lithium\core\ConfigException;
 use lithium\core\ClassNotFoundException;
+use Closure;
 
 /**
  * Manages all aspects of class and file location, naming and mapping. Implements auto-loading for
@@ -714,7 +715,7 @@ class Libraries {
 	 *
 	 * @see lithium\util\collection\Filters
 	 * @param string $method The name of the method to apply the closure to.
-	 * @param closure $filter The closure that is used to filter the method.
+	 * @param Closure $filter The closure that is used to filter the method.
 	 * @return void
 	 */
 	public static function applyFilter($method, $filter = null) {

--- a/core/Object.php
+++ b/core/Object.php
@@ -11,6 +11,7 @@ namespace lithium\core;
 use lithium\core\Libraries;
 use lithium\util\collection\Filters;
 use lithium\analysis\Inspector;
+use Closure;
 
 /**
  * Base class in Lithium's hierarchy, from which all concrete classes inherit. This class defines
@@ -140,7 +141,7 @@ class Object {
 	 * @param mixed $method The name of the method to apply the closure to. Can either be a single
 	 *        method name as a string, or an array of method names. Can also be false to remove
 	 *        all filters on the current object.
-	 * @param closure $filter The closure that is used to filter the method(s), can also be false
+	 * @param Closure $filter The closure that is used to filter the method(s), can also be false
 	 *        to remove all the current filters for the given method.
 	 * @return void
 	 */

--- a/core/StaticObject.php
+++ b/core/StaticObject.php
@@ -11,6 +11,7 @@ namespace lithium\core;
 use lithium\core\Libraries;
 use lithium\util\collection\Filters;
 use lithium\analysis\Inspector;
+use Closure;
 
 /**
  * Provides a base class for all static classes in the Lithium framework. Similar to its
@@ -43,7 +44,7 @@ class StaticObject {
 	 * @param mixed $method The name of the method to apply the closure to. Can either be a single
 	 *        method name as a string, or an array of method names. Can also be false to remove
 	 *        all filters on the current object.
-	 * @param closure $filter The closure that is used to filter the method(s), can also be false
+	 * @param Closure $filter The closure that is used to filter the method(s), can also be false
 	 *        to remove all the current filters for the given method.
 	 * @return void
 	 */

--- a/data/Collection.php
+++ b/data/Collection.php
@@ -8,6 +8,8 @@
 
 namespace lithium\data;
 
+use Closure;
+
 /**
  * The `Collection` class extends the generic `lithium\util\Collection` class to provide
  * context-specific features for working with sets of data persisted by a backend data store. This
@@ -374,7 +376,7 @@ abstract class Collection extends \lithium\util\Collection {
 	 * `Collection`.
 	 *
 	 * @param array $filter An array of key/value pairs used to filter `Collection` items.
-	 * @return closure Returns a closure that wraps the array and attempts to match each value
+	 * @return Closure Returns a closure that wraps the array and attempts to match each value
 	 *         against `Collection` item properties.
 	 */
 	protected function _filterFromArray(array $filter) {

--- a/storage/cache/adapter/Apc.php
+++ b/storage/cache/adapter/Apc.php
@@ -8,6 +8,8 @@
 
 namespace lithium\storage\cache\adapter;
 
+use Closure;
+
 /**
  * An Alternative PHP Cache (APC) cache adapter implementation.
  *
@@ -63,7 +65,7 @@ class Apc extends \lithium\core\Object {
 	 * @param mixed $data The value to be cached.
 	 * @param null|string $expiry A strtotime() compatible cache time. If no expiry time is set,
 	 *        then the default cache expiration time set with the cache configuration will be used.
-	 * @return closure Function returning boolean `true` on successful write, `false` otherwise.
+	 * @return Closure Function returning boolean `true` on successful write, `false` otherwise.
 	 */
 	public function write($key, $data, $expiry = null) {
 		$expiry = ($expiry) ?: $this->_config['expiry'];
@@ -87,7 +89,7 @@ class Apc extends \lithium\core\Object {
 	 * containing key/value pairs of the requested data.
 	 *
 	 * @param string|array $key The key to uniquely identify the cached item.
-	 * @return closure Function returning cached value on successful read, `false` otherwise.
+	 * @return Closure Function returning cached value on successful read, `false` otherwise.
 	 */
 	public function read($key) {
 		return function($self, $params) {
@@ -103,7 +105,7 @@ class Apc extends \lithium\core\Object {
 	 * from the user space cache.
 	 *
 	 * @param string|array $key The key to uniquely identify the cached item.
-	 * @return closure Function returning `true` on successful delete, `false` otherwise.
+	 * @return Closure Function returning `true` on successful delete, `false` otherwise.
 	 */
 	public function delete($key) {
 		return function($self, $params) {
@@ -120,7 +122,7 @@ class Apc extends \lithium\core\Object {
 	 *
 	 * @param string $key Key of numeric cache item to decrement
 	 * @param integer $offset Offset to decrement - defaults to 1.
-	 * @return closure Function returning item's new value on successful decrement, else `false`
+	 * @return Closure Function returning item's new value on successful decrement, else `false`
 	 */
 	public function decrement($key, $offset = 1) {
 		return function($self, $params) use ($offset) {
@@ -137,7 +139,7 @@ class Apc extends \lithium\core\Object {
 	 *
 	 * @param string $key Key of numeric cache item to increment
 	 * @param integer $offset Offset to increment - defaults to 1.
-	 * @return closure Function returning item's new value on successful increment, else `false`
+	 * @return Closure Function returning item's new value on successful increment, else `false`
 	 */
 	public function increment($key, $offset = 1) {
 		return function($self, $params) use ($offset) {

--- a/storage/cache/adapter/File.php
+++ b/storage/cache/adapter/File.php
@@ -12,6 +12,7 @@ use SplFileInfo;
 use RecursiveIteratorIterator;
 use RecursiveDirectoryIterator;
 use lithium\core\Libraries;
+use Closure;
 
 /**
  * A minimal file-based cache.
@@ -66,7 +67,7 @@ class File extends \lithium\core\Object {
 	 * @param mixed $data The value to be cached.
 	 * @param null|string $expiry A strtotime() compatible cache time. If no expiry time is set,
 	 *        then the default cache expiration time set with the cache configuration will be used.
-	 * @return closure Function returning boolean `true` on successful write, `false` otherwise.
+	 * @return Closure Function returning boolean `true` on successful write, `false` otherwise.
 	 */
 	public function write($key, $data, $expiry = null) {
 		$path = $this->_config['path'];
@@ -84,7 +85,7 @@ class File extends \lithium\core\Object {
 	 * Read value(s) from the cache.
 	 *
 	 * @param string $key The key to uniquely identify the cached item.
-	 * @return closure Function returning cached value if successful, `false` otherwise.
+	 * @return Closure Function returning cached value if successful, `false` otherwise.
 	 */
 	public function read($key) {
 		$path = $this->_config['path'];
@@ -114,7 +115,7 @@ class File extends \lithium\core\Object {
 	 * Delete an entry from the cache.
 	 *
 	 * @param string $key The key to uniquely identify the cached item.
-	 * @return closure Function returning boolean `true` on successful delete, `false` otherwise.
+	 * @return Closure Function returning boolean `true` on successful delete, `false` otherwise.
 	 */
 	public function delete($key) {
 		$path = $this->_config['path'];

--- a/storage/cache/adapter/Memcache.php
+++ b/storage/cache/adapter/Memcache.php
@@ -10,6 +10,7 @@ namespace lithium\storage\cache\adapter;
 
 use Memcached;
 use lithium\util\Set;
+use Closure;
 
 /**
  * A Memcache (libmemcached) cache adapter implementation. Requires
@@ -149,7 +150,7 @@ class Memcache extends \lithium\core\Object {
 	 * @param mixed $expiry A Unix timestamp or `strtotime()`-compatible string indicating when
 	 *              `$value` should expire. If no expiry time is set, then the default cache
 	 *              expiration time set with the cache configuration will be used.
-	 * @return closure Function returning boolean `true` on successful write, `false` otherwise.
+	 * @return Closure Function returning boolean `true` on successful write, `false` otherwise.
 	 */
 	public function write($key, $value, $expiry = null) {
 		$connection =& $this->connection;
@@ -174,7 +175,7 @@ class Memcache extends \lithium\core\Object {
 	 * containing key/value pairs of the requested data.
 	 *
 	 * @param string|array $key The key to uniquely identify the cached item.
-	 * @return closure Function returning cached value if successful, `null` otherwise.
+	 * @return Closure Function returning cached value if successful, `null` otherwise.
 	 */
 	public function read($key) {
 		$connection =& $this->connection;
@@ -198,7 +199,7 @@ class Memcache extends \lithium\core\Object {
 	 * Delete value from the cache.
 	 *
 	 * @param string $key The key to uniquely identify the cached item.
-	 * @return closure Function returning `true` on successful delete, `false` otherwise.
+	 * @return Closure Function returning `true` on successful delete, `false` otherwise.
 	 */
 	public function delete($key) {
 		$connection =& $this->connection;
@@ -218,7 +219,7 @@ class Memcache extends \lithium\core\Object {
 	 *
 	 * @param string $key Key of numeric cache item to decrement
 	 * @param integer $offset Offset to decrement - defaults to 1.
-	 * @return closure Function returning item's new value on successful decrement, else `false`
+	 * @return Closure Function returning item's new value on successful decrement, else `false`
 	 */
 	public function decrement($key, $offset = 1) {
 		$connection =& $this->connection;
@@ -237,7 +238,7 @@ class Memcache extends \lithium\core\Object {
 	 *
 	 * @param string $key Key of numeric cache item to increment
 	 * @param integer $offset Offset to increment - defaults to 1.
-	 * @return closure Function returning item's new value on successful increment, else `false`
+	 * @return Closure Function returning item's new value on successful increment, else `false`
 	 */
 	public function increment($key, $offset = 1) {
 		$connection =& $this->connection;

--- a/storage/cache/adapter/Memory.php
+++ b/storage/cache/adapter/Memory.php
@@ -8,6 +8,8 @@
 
 namespace lithium\storage\cache\adapter;
 
+use Closure;
+
 /**
  * A minimal in-memory cache.
  *
@@ -50,7 +52,7 @@ class Memory extends \lithium\core\Object {
 	 * note that this is not an atomic operation.
 	 *
 	 * @param string $key The key to uniquely identify the cached item.
-	 * @return closure Function returning cached value if successful, `false` otherwise.
+	 * @return Closure Function returning cached value if successful, `false` otherwise.
 	 */
 	public function read($key) {
 		$cache =& $this->_cache;
@@ -81,7 +83,7 @@ class Memory extends \lithium\core\Object {
 	 * @param string $key The key to uniquely identify the cached item.
 	 * @param mixed $data The value to be cached.
 	 * @param string $expiry A strtotime() compatible cache time.
-	 * @return closure Function returning boolean `true` on successful write, `false` otherwise.
+	 * @return Closure Function returning boolean `true` on successful write, `false` otherwise.
 	 */
 	public function write($key, $data, $expiry) {
 		$cache =& $this->_cache;
@@ -103,7 +105,7 @@ class Memory extends \lithium\core\Object {
 	 * Delete value from the cache
 	 *
 	 * @param string $key The key to uniquely identify the cached item.
-	 * @return closure Function returning boolean `true` on successful delete, `false` otherwise.
+	 * @return Closure Function returning boolean `true` on successful delete, `false` otherwise.
 	 */
 	public function delete($key) {
 		$cache =& $this->_cache;
@@ -124,7 +126,7 @@ class Memory extends \lithium\core\Object {
 	 *
 	 * @param string $key Key of numeric cache item to decrement.
 	 * @param integer $offset Offset to decrement - defaults to 1.
-	 * @return closure Function returning item's new value on successful decrement,
+	 * @return Closure Function returning item's new value on successful decrement,
 	 *         `false` otherwise.
 	 */
 	public function decrement($key, $offset = 1) {
@@ -141,7 +143,7 @@ class Memory extends \lithium\core\Object {
 	 *
 	 * @param string $key Key of numeric cache item to increment.
 	 * @param integer $offset Offset to increment - defaults to 1.
-	 * @return closure Function returning item's new value on successful increment,
+	 * @return Closure Function returning item's new value on successful increment,
 	 *         `false` otherwise.
 	 */
 	public function increment($key, $offset = 1) {

--- a/storage/cache/adapter/Redis.php
+++ b/storage/cache/adapter/Redis.php
@@ -9,6 +9,7 @@
 namespace lithium\storage\cache\adapter;
 
 use Redis as RedisCore;
+use Closure;
 
 /**
  * A Redis (phpredis) cache adapter implementation.
@@ -151,7 +152,7 @@ class Redis extends \lithium\core\Object {
 	 * @param mixed $value The value to be cached
 	 * @param null|string $expiry A strtotime() compatible cache time. If no expiry time is set,
 	 *        then the default cache expiration time set with the cache configuration will be used.
-	 * @return closure Function returning boolean `true` on successful write, `false` otherwise.
+	 * @return Closure Function returning boolean `true` on successful write, `false` otherwise.
 	 */
 	public function write($key, $value = null, $expiry = null) {
 		$connection =& $this->connection;
@@ -186,7 +187,7 @@ class Redis extends \lithium\core\Object {
 	 * Read value(s) from the cache
 	 *
 	 * @param string $key The key to uniquely identify the cached item
-	 * @return closure Function returning cached value if successful, `false` otherwise
+	 * @return Closure Function returning cached value if successful, `false` otherwise
 	 */
 	public function read($key) {
 		$connection =& $this->connection;
@@ -205,7 +206,7 @@ class Redis extends \lithium\core\Object {
 	 * Delete value from the cache
 	 *
 	 * @param string $key The key to uniquely identify the cached item
-	 * @return closure Function returning boolean `true` on successful delete, `false` otherwise
+	 * @return Closure Function returning boolean `true` on successful delete, `false` otherwise
 	 */
 	public function delete($key) {
 		$connection =& $this->connection;
@@ -224,7 +225,7 @@ class Redis extends \lithium\core\Object {
 	 *
 	 * @param string $key Key of numeric cache item to decrement
 	 * @param integer $offset Offset to decrement - defaults to 1.
-	 * @return closure Function returning item's new value on successful decrement, else `false`
+	 * @return Closure Function returning item's new value on successful decrement, else `false`
 	 */
 	public function decrement($key, $offset = 1) {
 		$connection =& $this->connection;
@@ -243,7 +244,7 @@ class Redis extends \lithium\core\Object {
 	 *
 	 * @param string $key Key of numeric cache item to increment
 	 * @param integer $offset Offset to increment - defaults to 1.
-	 * @return closure Function returning item's new value on successful increment, else `false`
+	 * @return Closure Function returning item's new value on successful increment, else `false`
 	 */
 	public function increment($key, $offset = 1) {
 		$connection =& $this->connection;

--- a/storage/cache/adapter/XCache.php
+++ b/storage/cache/adapter/XCache.php
@@ -8,6 +8,8 @@
 
 namespace lithium\storage\cache\adapter;
 
+use Closure;
+
 /**
  * An XCache opcode cache adapter implementation.
  *
@@ -62,7 +64,7 @@ class XCache extends \lithium\core\Object {
 	 * @param mixed $data The value to be cached
 	 * @param null|string $expiry A strtotime() compatible cache time. If no expiry time is set,
 	 *        then the default cache expiration time set with the cache configuration will be used.
-	 * @return closure Function returning boolean `true` on successful write, `false` otherwise.
+	 * @return Closure Function returning boolean `true` on successful write, `false` otherwise.
 	 */
 	public function write($key, $data, $expiry = null) {
 		$expiry = ($expiry) ?: $this->_config['expiry'];
@@ -76,7 +78,7 @@ class XCache extends \lithium\core\Object {
 	 * Read value(s) from the cache
 	 *
 	 * @param string $key The key to uniquely identify the cached item
-	 * @return closure Function returning cached value if successful, `false` otherwise
+	 * @return Closure Function returning cached value if successful, `false` otherwise
 	 */
 	public function read($key) {
 		return function($self, $params) {
@@ -88,7 +90,7 @@ class XCache extends \lithium\core\Object {
 	 * Delete value from the cache
 	 *
 	 * @param string $key The key to uniquely identify the cached item
-	 * @return closure Function returning boolean `true` on successful delete, `false` otherwise
+	 * @return Closure Function returning boolean `true` on successful delete, `false` otherwise
 	 */
 	public function delete($key) {
 		return function($self, $params) {
@@ -105,7 +107,7 @@ class XCache extends \lithium\core\Object {
 	 *
 	 * @param string $key Key of numeric cache item to decrement
 	 * @param integer $offset Offset to decrement - defaults to 1.
-	 * @return closure Function returning item's new value on successful decrement, else `false`
+	 * @return Closure Function returning item's new value on successful decrement, else `false`
 	 */
 	public function decrement($key, $offset = 1) {
 		return function($self, $params) use ($offset) {
@@ -121,7 +123,7 @@ class XCache extends \lithium\core\Object {
 	 *
 	 * @param string $key Key of numeric cache item to increment
 	 * @param integer $offset Offset to increment - defaults to 1.
-	 * @return closure Function returning item's new value on successful increment, else `false`
+	 * @return Closure Function returning item's new value on successful increment, else `false`
 	 */
 	public function increment($key, $offset = 1) {
 		return function($self, $params) use ($offset) {

--- a/storage/session/adapter/Cookie.php
+++ b/storage/session/adapter/Cookie.php
@@ -11,6 +11,7 @@ namespace lithium\storage\session\adapter;
 use RuntimeException;
 use lithium\util\Set;
 use lithium\core\Libraries;
+use Closure;
 
 /**
  * A minimal adapter to interface with HTTP cookies.
@@ -80,7 +81,7 @@ class Cookie extends \lithium\core\Object {
 	 * Checks if a value has been set in the cookie.
 	 *
 	 * @param string $key Key of the entry to be checked.
-	 * @return closure Function returning boolean `true` if the key exists, `false` otherwise.
+	 * @return Closure Function returning boolean `true` if the key exists, `false` otherwise.
 	 */
 	public function check($key) {
 		$config = $this->_config;
@@ -96,7 +97,7 @@ class Cookie extends \lithium\core\Object {
 	 * @param null|string $key Key of the entry to be read. If $key is null, returns
 	 *        all cookie key/value pairs that have been set.
 	 * @param array $options Options array. Not used in this adapter.
-	 * @return closure Function returning data in the session if successful, `null` otherwise.
+	 * @return Closure Function returning data in the session if successful, `null` otherwise.
 	 */
 	public function read($key = null, array $options = array()) {
 		$config = $this->_config;
@@ -133,7 +134,7 @@ class Cookie extends \lithium\core\Object {
 	 * @param string $key Key of the item to be stored.
 	 * @param mixed $value The value to be stored.
 	 * @param array $options Options array.
-	 * @return closure Function returning boolean `true` on successful write, `false` otherwise.
+	 * @return Closure Function returning boolean `true` on successful write, `false` otherwise.
 	 */
 	public function write($key, $value = null, array $options = array()) {
 		$expire = (!isset($options['expire']) && empty($this->_config['expire']));
@@ -172,7 +173,7 @@ class Cookie extends \lithium\core\Object {
 	 *
 	 * @param string $key The key to be deleted from the cookie store.
 	 * @param array $options Options array.
-	 * @return closure Function returning boolean `true` on successful delete, `false` otherwise.
+	 * @return Closure Function returning boolean `true` on successful delete, `false` otherwise.
 	 */
 	public function delete($key, array $options = array()) {
 		$config = $this->_config;

--- a/storage/session/adapter/Memory.php
+++ b/storage/session/adapter/Memory.php
@@ -9,6 +9,7 @@
 namespace lithium\storage\session\adapter;
 
 use lithium\util\String;
+use Closure;
 
 /**
  * Simple memory session storage engine. Used for testing.
@@ -47,7 +48,7 @@ class Memory extends \lithium\core\Object {
 	 *
 	 * @param string $key Key of the entry to be checked.
 	 * @param array $options Options array. Not used for this adapter method.
-	 * @return closure Function returning boolean `true` if the key exists, `false` otherwise.
+	 * @return Closure Function returning boolean `true` if the key exists, `false` otherwise.
 	 */
 	public function check($key, array $options = array()) {
 		$session =& $this->_session;
@@ -62,7 +63,7 @@ class Memory extends \lithium\core\Object {
 	 * @param null|string $key Key of the entry to be read. If no key is passed, all
 	 *        current session data is returned.
 	 * @param array $options Options array. Not used for this adapter method.
-	 * @return closure Function returning data in the session if successful, `false` otherwise.
+	 * @return Closure Function returning data in the session if successful, `false` otherwise.
 	 */
 	public function read($key = null, array $options = array()) {
 		$session = $this->_session;
@@ -83,7 +84,7 @@ class Memory extends \lithium\core\Object {
 	 * @param string $key Key of the item to be stored.
 	 * @param mixed $value The value to be stored.
 	 * @param array $options Options array. Not used for this adapter method.
-	 * @return closure Function returning boolean `true` on successful write, `false` otherwise.
+	 * @return Closure Function returning boolean `true` on successful write, `false` otherwise.
 	 */
 	public function write($key, $value, array $options = array()) {
 		$session =& $this->_session;
@@ -99,7 +100,7 @@ class Memory extends \lithium\core\Object {
 	 *
 	 * @param string $key The key to be deleted
 	 * @param array $options Options array. Not used for this adapter method.
-	 * @return closure Function returning boolean `true` on successful delete, `false` otherwise
+	 * @return Closure Function returning boolean `true` on successful delete, `false` otherwise
 	 */
 	public function delete($key, array $options = array()) {
 		$session =& $this->_session;
@@ -115,7 +116,7 @@ class Memory extends \lithium\core\Object {
 	 * Clears all keys from the session.
 	 *
 	 * @param array $options Options array. Not used for this adapter method.
-	 * @return closure Function that clears the session
+	 * @return Closure Function that clears the session
 	 */
 	public function clear(array $options = array()) {
 		$session =& $this->_session;

--- a/storage/session/adapter/Php.php
+++ b/storage/session/adapter/Php.php
@@ -12,6 +12,7 @@ use lithium\util\Set;
 use RuntimeException;
 use lithium\core\ConfigException;
 use lithium\core\Libraries;
+use Closure;
 
 /**
  * A minimal adapter to interface with native PHP sessions.
@@ -117,7 +118,7 @@ class Php extends \lithium\core\Object {
 	 *
 	 * @param string $key Key of the entry to be checked.
 	 * @param array $options Options array. Not used for this adapter method.
-	 * @return closure Function returning boolean `true` if the key exists, `false` otherwise.
+	 * @return Closure Function returning boolean `true` if the key exists, `false` otherwise.
 	 */
 	public static function check($key, array $options = array()) {
 		if (!static::isStarted() && !static::_start()) {
@@ -134,7 +135,7 @@ class Php extends \lithium\core\Object {
 	 * @param null|string $key Key of the entry to be read. If no key is passed, all
 	 *        current session data is returned.
 	 * @param array $options Options array. Not used for this adapter method.
-	 * @return closure Function returning data in the session if successful, `false` otherwise.
+	 * @return Closure Function returning data in the session if successful, `false` otherwise.
 	 */
 	public static function read($key = null, array $options = array()) {
 		if (!static::isStarted() && !static::_start()) {
@@ -165,7 +166,7 @@ class Php extends \lithium\core\Object {
 	 * @param string $key Key of the item to be stored.
 	 * @param mixed $value The value to be stored.
 	 * @param array $options Options array. Not used for this adapter method.
-	 * @return closure Function returning boolean `true` on successful write, `false` otherwise.
+	 * @return Closure Function returning boolean `true` on successful write, `false` otherwise.
 	 */
 	public static function write($key, $value, array $options = array()) {
 		if (!static::isStarted() && !static::_start()) {
@@ -185,7 +186,7 @@ class Php extends \lithium\core\Object {
 	 *
 	 * @param string $key The key to be deleted
 	 * @param array $options Options array. Not used for this adapter method.
-	 * @return closure Function returning boolean `true` if the key no longer exists
+	 * @return Closure Function returning boolean `true` if the key no longer exists
 	 *         in the session, `false` otherwise
 	 */
 	public static function delete($key, array $options = array()) {
@@ -205,7 +206,7 @@ class Php extends \lithium\core\Object {
 	 * Clears all keys from the session.
 	 *
 	 * @param array $options Options array. Not used fro this adapter method.
-	 * @return closure Function returning boolean `true` on successful clear, `false` otherwise.
+	 * @return Closure Function returning boolean `true` on successful clear, `false` otherwise.
 	 */
 	public function clear(array $options = array()) {
 		if (!static::isStarted() && !static::_start()) {

--- a/test/Mocker.php
+++ b/test/Mocker.php
@@ -16,6 +16,7 @@ use ReflectionFunction;
 use ReflectionFunctionAbstract;
 use Reflection;
 use stdClass;
+use Closure;
 
 /**
  * The Mocker class aids in the creation of Mocks on the fly, allowing you to
@@ -591,7 +592,7 @@ class Mocker {
 	 * @param mixed $method The name of the method to apply the closure to. Can either be a single
 	 *        method name as a string, or an array of method names. Can also be false to remove
 	 *        all filters on the current object.
-	 * @param closure $filter The closure that is used to filter the method(s), can also be false
+	 * @param Closure $filter The closure that is used to filter the method(s), can also be false
 	 *        to remove all the current filters for the given method.
 	 * @return void
 	 */

--- a/test/Unit.php
+++ b/test/Unit.php
@@ -18,6 +18,7 @@ use lithium\analysis\Debugger;
 use lithium\analysis\Inspector;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use Closure;
 
 /**
  * This is the base class for all test cases. Test are performed using an assertion method. If the
@@ -592,7 +593,7 @@ class Unit extends \lithium\core\Object {
 	 * @param mixed $expected A string indicating what the error text is expected to be.  This can
 	 *              be an exact string, a /-delimited regular expression, or true, indicating that
 	 *              any error text is acceptable.
-	 * @param closure $closure A closure containing the code that should throw the exception.
+	 * @param Closure $closure A closure containing the code that should throw the exception.
 	 * @param string $message
 	 * @return boolean
 	 */

--- a/util/String.php
+++ b/util/String.php
@@ -118,7 +118,7 @@ class String {
 	 * speaking, this fallback is inadequate, but good enough.)
 	 *
 	 * @see lithium\util\String::$_source
-	 * @return closure Returns a closure containing a random number generator.
+	 * @return Closure Returns a closure containing a random number generator.
 	 */
 	protected static function _source() {
 		switch (true) {

--- a/util/Validator.php
+++ b/util/Validator.php
@@ -10,6 +10,7 @@ namespace lithium\util;
 
 use lithium\util\Set;
 use InvalidArgumentException;
+use Closure;
 
 /**
  * The `Validator` class provides static access to commonly used data validation logic. These common
@@ -640,7 +641,7 @@ class Validator extends \lithium\core\StaticObject {
 	 * and an array specifying which formats within the rule to use.
 	 *
 	 * @param array $rules All available rules.
-	 * @return closure Function returning boolean `true` if validation succeeded, `false` otherwise.
+	 * @return Closure Function returning boolean `true` if validation succeeded, `false` otherwise.
 	 */
 	protected static function _checkFormats($rules) {
 		return function($self, $params, $chain) use ($rules) {

--- a/util/collection/Filters.php
+++ b/util/collection/Filters.php
@@ -8,6 +8,8 @@
 
 namespace lithium\util\collection;
 
+use Closure;
+
 /**
  * The `Filters` class is the basis of Lithium's method filtering system: an efficient way to enable
  * event-driven communication between classes without tight coupling and without depending on a
@@ -117,7 +119,7 @@ class Filters extends \lithium\util\Collection {
 	 *               be applied. The class name specified in `$class` **must** extend
 	 *               `StaticObject`, or else statically implement the `applyFilter()` method.
 	 * @param string $method The method to which the filter will be applied.
-	 * @param closure $filter The filter to apply to the class method.
+	 * @param Closure $filter The filter to apply to the class method.
 	 * @return void
 	 */
 	public static function apply($class, $method, $filter) {


### PR DESCRIPTION
When using an IDE that supports parameter type checking (e.g. PHPStorm, Netbeans, etc) if you don't specify the correct type hints in your docblocks then you get false errors being reported because it can't determine the class (see below).

![error](https://f.cloud.github.com/assets/1880478/300567/e5c4c114-959c-11e2-8af4-306e293f91b5.png)

I've performed a project wide search / replace on instances of 

```
@param closure
@param Closure
@return closure
```

and replaced them with the Fully Qualified Name for the internal Closure class.

```
@param \Closure
@return \Closure
```

This should prevent the IDE complaining and makes the docblock more accurate.
