### PR TITLE
Feature/router array cdn

### DIFF
--- a/net/http/Media.php
+++ b/net/http/Media.php
@@ -461,7 +461,19 @@ class Media extends \lithium\core\StaticObject {
 			} else {
 				$host = '';
 				if ($defaults['absolute']) {
-					$host = $defaults['scheme'] . $defaults['host'];
+					$host = $defaults['host'];
+					$index = 0;
+					if (is_array($host)) {
+						$hash = substr(hexdec(md5($path)), 0, 10);
+						$index = ((int) $hash) % count($host);
+						if (is_array($defaults['scheme'])) {
+							$host = $defaults['scheme'][$index] . $host[$index];
+						} else {
+							$host = $defaults['scheme'] . $host[$index];
+						}
+					} else {
+						$host = $defaults['scheme'] . $defaults['host'];
+					}
 				}
 				$base = $host ? ($base ? '/' . ltrim($base, '/') : '') : $base;
 				$options['base'] = rtrim($host . $base . '/' . $defaults['prefix'], '/');
@@ -991,6 +1003,35 @@ class Media extends \lithium\core\StaticObject {
 	 * ));
 	 * }}}
 	 *
+	 * {{{
+	 * Media::attach('cdn', array(
+	 *     'absolute' => true,
+	 *     'path' => null,
+	 *     'host' => array('my.cdn.com', 'secure.cdn.com'),
+	 *     'scheme' => array('http://', 'https://'),
+	 *     'prefix' => 'project1/assets',
+	 * ));
+	 * }}}
+	 *
+	 * {{{
+	 * Media::attach('cdn', array(
+	 *     'absolute' => true,
+	 *     'path' => null,
+	 *     'host' => array('my1.cdn.com', 'my2.cdn.com'),
+	 *     'scheme' => 'http://',
+	 *     'prefix' => 'project1/assets',
+	 * ));
+	 * }}}
+	 *
+	 * @param  string $name   Name of the media you wish to attach.
+	 * @param  array  $config
+	 *        - `'path'` _string_: Path of the media.
+	 *        - `'prefix'` _string_: Contains the uri prefix. Such as `css`.
+	 *        - `'absolute'` _boolean_: Defaults to `false`. If you want to generate
+	 *                                  absolute URL's.
+	 *        - `'host'` _mixed_: String host, or array of hosts, of the media, if absolute is `true`.
+	 *        - `'scheme'` _mixed_: String scheme, or array of sc, of the media, if absolute is `true`.
+	 * @return void
 	 */
 	public static function attach($name, $config = null) {
 		if (!isset(static::$_scopes)) {

--- a/tests/cases/net/http/MediaTest.php
+++ b/tests/cases/net/http/MediaTest.php
@@ -1015,6 +1015,48 @@ class MediaTest extends \lithium\test\Unit {
 
 		$this->assertEqual($expected, Media::attached());
 	}
+
+	public function testMultipleHostsAndSchemeSelectSameIndex() {
+		Media::attach('cdn', array(
+			'absolute' => true,
+			'host' => array('cdn.com', 'cdn.org'),
+			'scheme' => array('http://', 'https://'),
+		));
+
+		$result = Media::asset('style.css', 'css', array('scope' => 'cdn'));
+		$expected = '%https://cdn.org/css/style.css|http://cdn.com/css/style.css%';
+
+		$this->assertPattern($expected, $result);
+	}
+
+	public function testMultipleHostsAndSingleSchemePicksOnlyScheme() {
+		Media::attach('cdn', array(
+			'absolute' => true,
+			'host' => array('cdn.com', 'cdn.org'),
+			'scheme' => 'http://',
+		));
+
+		$result = Media::asset('style.css', 'css', array('scope' => 'cdn'));
+		$expected = '%http://cdn.org/css/style.css|http://cdn.com/css/style.css%';
+
+		$this->assertPattern($expected, $result);
+	}
+
+	public function testMultipleHostsPickSameHostForIdenticalAsset() {
+		Media::attach('cdn', array(
+			'absolute' => true,
+			'host' => array('cdn.com', 'cdn.org'),
+			'scheme' => 'http://',
+		));
+
+		$first = Media::asset('style.css', 'css', array('scope' => 'cdn'));
+		$second = Media::asset('style.css', 'css', array('scope' => 'cdn'));
+		$third = Media::asset('style.css', 'css', array('scope' => 'cdn'));
+
+		$this->assertIdentical($first, $second);
+		$this->assertIdentical($third, $second);
+	}
+
 }
 
 ?>


### PR DESCRIPTION
For a site that uses a CDN, but has an uneven amount of js/css/imgages. They might upload all assets to all CDN's then have a script to 'randomly' select one based on the filename. Doing it based on the filename ensures the same CDN will always get picked, which allows for browser caching.

To be applied on top of #878.
