### PR TITLE
Removed forced pluralization from console `create` command(s).

### DIFF
--- a/console/command/Create.php
+++ b/console/command/Create.php
@@ -116,10 +116,10 @@ class Create extends \lithium\console\Command {
 	 */
 	protected function _default($name) {
 		$commands = array(
-			array('model', Inflector::pluralize($name)),
-			array('controller', Inflector::pluralize($name)),
-			array('test', 'model', Inflector::pluralize($name)),
-			array('test', 'controller', Inflector::pluralize($name))
+			array('model', $name),
+			array('controller', $name),
+			array('test', 'model', $name),
+			array('test', 'controller', $name)
 		);
 		foreach ($commands as $args) {
 			$command = $this->template = $this->request->params['command'] = array_shift($args);

--- a/console/command/create/Controller.php
+++ b/console/command/create/Controller.php
@@ -47,7 +47,7 @@ class Controller extends \lithium\console\command\Create {
 	 * @return string
 	 */
 	protected function _name($request) {
-		return Inflector::camelize(Inflector::pluralize($request->action));
+		return Inflector::camelize($request->action);
 	}
 
 	/**
@@ -67,7 +67,7 @@ class Controller extends \lithium\console\command\Create {
 	 * @return string
 	 */
 	protected function _model($request) {
-		return Inflector::camelize(Inflector::pluralize($request->action));
+		return Inflector::camelize($request->action);
 	}
 
 	/**

--- a/console/command/create/Mock.php
+++ b/console/command/create/Mock.php
@@ -39,7 +39,7 @@ class Mock extends \lithium\console\command\Create {
 	 */
 	protected function _parent($request) {
 		$namespace = parent::_namespace($request);
-		$class = Inflector::pluralize($request->action);
+		$class = Inflector::camelize($request->action);
 		return "\\{$namespace}\\{$class}";
 	}
 
@@ -57,7 +57,7 @@ class Mock extends \lithium\console\command\Create {
 			$request->params['action'] = $name;
 			$name = $command->invokeMethod('_class', array($request));
 		}
-		return  Inflector::pluralize("Mock{$name}");
+		return "Mock{$name}";
 	}
 
 	/**

--- a/console/command/create/Model.php
+++ b/console/command/create/Model.php
@@ -26,7 +26,7 @@ class Model extends \lithium\console\command\Create {
 	 * @return string
 	 */
 	protected function _class($request) {
-		return Inflector::camelize(Inflector::pluralize($request->action));
+		return Inflector::camelize($request->action);
 	}
 }
 

--- a/console/command/create/View.php
+++ b/console/command/create/View.php
@@ -27,7 +27,7 @@ class View extends \lithium\console\command\Create {
 	 * @return string
 	 */
 	protected function _name($request) {
-		return Inflector::camelize(Inflector::pluralize($request->action));
+		return Inflector::camelize($request->action);
 	}
 
 	/**


### PR DESCRIPTION
Removed the forced pluralization happening in the `li3 create` commands.

This came up [today in #li3](http://lithify.me/bot/logs/li3/2013-04-11#80) and @gwoo and @jails both :thumbsup:, but I wanted to submit a PR rather than push directly so everyone could review it.
