### PR TITLE
Allow for inheritance of Controller::$_render property within subclasses

### DIFF
--- a/action/Controller.php
+++ b/action/Controller.php
@@ -141,6 +141,18 @@ class Controller extends \lithium\core\Object {
 	 */
 	protected function _init() {
 		parent::_init();
+
+		foreach (static::_parents() as $parent) {
+			$inherit = get_class_vars($parent);
+
+			if (isset($inherit['_render'])) {
+				$this->_render += $inherit['_render'];
+			}
+			if ($parent === __CLASS__) {
+				break;
+			}
+		}
+
 		$this->request = $this->request ?: $this->_config['request'];
 		$this->response = $this->_instance('response', $this->_config['response']);
 

--- a/tests/cases/action/ControllerTest.php
+++ b/tests/cases/action/ControllerTest.php
@@ -11,6 +11,7 @@ namespace lithium\tests\cases\action;
 use lithium\action\Request;
 use lithium\action\Controller;
 use lithium\tests\mocks\action\MockPostsController;
+use lithium\tests\mocks\action\MockRenderAltController;
 use lithium\tests\mocks\action\MockControllerRequest;
 
 class ControllerTest extends \lithium\test\Unit {
@@ -301,6 +302,17 @@ class ControllerTest extends \lithium\test\Unit {
 		$postsController(new Request(), array('action' => 'changeTemplate'));
 		$result = $postsController->access('_render');
 		$this->assertEqual('foo', $result['template']);
+	}
+
+	public function testRenderPropertyInheritance() {
+		$controller = new MockRenderAltController();
+
+		$expected = array(
+			'data' => array('foo' => 'bar'), 'layout' => 'alternate', 'type' => null, 'auto' => true,
+			'template' => null, 'hasRendered' => false, 'negotiate' => false
+		);
+		$result = $controller->access('_render');
+		$this->assertEqual($expected, $result);
 	}
 
 	public function testSetData() {

--- a/tests/mocks/action/MockRenderAltController.php
+++ b/tests/mocks/action/MockRenderAltController.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2013, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\tests\mocks\action;
+
+class MockRenderAltController extends \lithium\action\Controller {
+	protected $_render = array(
+		'data' => array('foo' => 'bar'),
+		'layout' => 'alternate'
+	);
+
+	public function access($var) {
+		return $this->{$var};
+	}
+}
+
+?>


### PR DESCRIPTION
I'd like the be able to do the following in a few controllers of mine which utilize an alternative layout:

```
class DashboardController extends \lithium\action\Controller {

    /**
     * Specify dashboard layout by default
     *
     */
    protected $_render = array('layout' => 'dashboard');

    [...]
}
```

However, when doing this, all of the other default attributes of the `$_render` property become undefined unless I lift the entire array from the `\lithium\action\Controller` class.

So I'm left with doing this instead:

```
class DashboardController extends \lithium\action\Controller {

    /**
     * Specify dashboard layout by default
     *
     */
    public function __construct(array $config = array()) {
        $defaults = array('render' => array('layout' => 'dashboard'));
        parent::__construct($config + $defaults);
    }

    [...]
}
```

This PR aims to make inheritance within the $_render property simpler by inheriting and merging defaults from all parent classes similar to how `\lithium\data\Model` handles inheritance in the $_meta property.
