### PR TITLE
Relations can be retrived by the relation name or its corresponding field name.

### DIFF
--- a/data/Model.php
+++ b/data/Model.php
@@ -164,6 +164,13 @@ class Model extends \lithium\core\StaticObject {
 	protected $_relations = array();
 
 	/**
+	 * Matching between relation's fieldnames and their corresponding relation name.
+	 *
+	 * @var array
+	 */
+	protected $_relationFieldNames = array();
+
+	/**
 	 * List of relation types.
 	 *
 	 * Valid relation types are:
@@ -792,6 +799,10 @@ class Model extends \lithium\core\StaticObject {
 			return static::_relations();
 		}
 
+		if (isset($self->_relationFieldNames[$type])) {
+			$type = $self->_relationFieldNames[$type];
+		}
+
 		if (isset($self->_relations[$type])) {
 			return $self->_relations[$type];
 		}
@@ -858,10 +869,14 @@ class Model extends \lithium\core\StaticObject {
 	 */
 	public static function bind($type, $name, array $config = array()) {
 		$self = static::_object();
+		if (!isset($config['fieldName'])) {
+			$config['fieldName'] = $self->_relationFieldName($type, $name);
+		}
 
 		if (!in_array($type, $self->_relationTypes)) {
 			throw new ConfigException("Invalid relationship type `{$type}` specified.");
 		}
+		$self->_relationFieldNames[$config['fieldName']] = $name;
 		$rel = static::connection()->relationship(get_called_class(), $type, $name, $config);
 		return $self->_relations[$name] = $rel;
 	}
@@ -1018,7 +1033,7 @@ class Model extends \lithium\core\StaticObject {
 	 *
 	 * {{{
 	 * if (!$post->save($someData)) {
-	 *  return array('errors' => $post->errors());
+	 *     return array('errors' => $post->errors());
 	 * }
 	 * }}}
 	 *
@@ -1322,20 +1337,35 @@ class Model extends \lithium\core\StaticObject {
 	 */
 	protected static function _relationsToLoad() {
 		try {
-			if (!static::connection()) {
+			if (!$connection = static::connection()) {
 				return;
 			}
 		} catch (ConfigExcepton $e) {
 			return;
 		}
+
+		if (!$connection::enabled('relationships')) {
+			return;
+		}
+
 		$self = static::_object();
 
 		foreach ($self->_relationTypes as $type) {
 			$self->$type = Set::normalize($self->$type);
 			foreach ($self->$type as $name => $config) {
 				$self->_relationsToLoad[$name] = $type;
+				$fieldName = $self->_relationFieldName($type, $name);
+				$self->_relationFieldNames[$fieldName] = $name;
 			}
 		}
+	}
+
+	protected function _relationFieldName($type, $name) {
+		if (!isset($this->{$type}[$name]['fieldName'])) {
+			$fieldName = static::connection()->relationFieldName($type, $name);
+			$this->{$type}[$name]['fieldName'] = $fieldName;
+		}
+		return $this->{$type}[$name]['fieldName'];
 	}
 
 	/**

--- a/data/Source.php
+++ b/data/Source.php
@@ -9,6 +9,7 @@
 namespace lithium\data;
 
 use lithium\core\NetworkException;
+use lithium\util\Inflector;
 
 /**
  * This is the base class for Lithium's data abstraction layer.
@@ -276,6 +277,35 @@ abstract class Source extends \lithium\core\Object {
 	 * @param object $context A query object to configure
 	 */
 	public function applyStrategy($options, $context) {}
+
+	/**
+	 * With no parameter, checks a specific supported feature.
+	 *
+	 * @param string $feature Test for support for a specific feature, i.e. `"transactions"` or
+	 *        `"arrays"`.
+	 * @return boolean Returns `true` if the particular feature (or if MongoDB) support is enabled,
+	 *         otherwise `false`.
+	 */
+	public static function enabled($feature = null) {
+		return false;
+	}
+
+	/**
+	 * Returns the field name of a relation name (underscore).
+	 *
+	 * @param string The type of the relation.
+	 * @param string The name of the relation.
+	 * @return string
+	 */
+	public function relationFieldName($type, $name) {
+		$fieldName = Inflector::underscore($name);
+		if (preg_match('/Many$/', $type)) {
+			$fieldName = Inflector::pluralize($fieldName);
+		} else {
+			$fieldName = Inflector::singularize($fieldName);
+		}
+		return $fieldName;
+	}
 }
 
 ?>

--- a/data/model/Relationship.php
+++ b/data/model/Relationship.php
@@ -9,7 +9,6 @@
 namespace lithium\data\model;
 
 use lithium\core\Libraries;
-use lithium\util\Inflector;
 use lithium\core\ConfigException;
 use lithium\core\ClassNotFoundException;
 
@@ -63,7 +62,7 @@ class Relationship extends \lithium\core\Object {
 	 *          referenced in the originating model.
 	 *        - `'key'` _mixed_: An array of fields that define the relationship, where the
 	 *          keys are fields in the originating model, and the values are fields in the
-	 *          target model. If the relationship is not deined by keys, this array should be
+	 *          target model. If the relationship is not defined by keys, this array should be
 	 *          empty.
 	 *        - `'type'` _string_: The type of relationship. Should be one of `'belongsTo'`,
 	 *          `'hasOne'` or `'hasMany'`.
@@ -103,7 +102,14 @@ class Relationship extends \lithium\core\Object {
 			'fieldName' => null,
 			'constraints' => array()
 		);
-		parent::__construct($config + $defaults);
+		$config += $defaults;
+		if (!$config['type'] || !$config['fieldName']) {
+			throw new ConfigException("`'type'`, `'fieldName'` and `'from'` options can't be empty.");
+		}
+		if (!$config['to'] && !$config['name']) {
+			throw new ConfigException("`'to'` and `'name'` options can't both be empty.");
+		}
+		parent::__construct($config);
 	}
 
 	protected function _init() {
@@ -111,11 +117,8 @@ class Relationship extends \lithium\core\Object {
 		$config =& $this->_config;
 		$type = $config['type'];
 
-		$name = ($type === 'hasOne') ? Inflector::pluralize($config['name']) : $config['name'];
-		$config['fieldName'] = $config['fieldName'] ?: lcfirst($name);
-
 		if (!$config['to']) {
-			$assoc = preg_replace("/\\w+$/", "", $config['from']) . $name;
+			$assoc = preg_replace("/\\w+$/", "", $config['from']) . $config['name'];
 			$config['to'] = Libraries::locate('models', $assoc);
 		}
 		if (!$config['key'] || !is_array($config['key'])) {

--- a/data/source/Database.php
+++ b/data/source/Database.php
@@ -641,15 +641,12 @@ abstract class Database extends \lithium\data\Source {
 		if (is_array($primary)) {
 			$key = array_combine($primary, $primary);
 		} elseif ($type === 'hasMany' || $type === 'hasOne') {
-			if ($type === 'hasMany') {
-				$field = Inflector::pluralize($field);
-			}
 			$secondary = Inflector::underscore(Inflector::singularize($class::meta('name')));
 			$key = array($primary => "{$secondary}_id");
 		}
 
 		$from = $class;
-		$fieldName = $field;
+		$fieldName = $this->relationFieldName($type, $name);
 		$config += compact('type', 'name', 'key', 'from', 'fieldName');
 		return $this->_instance('relationship', $config);
 	}

--- a/data/source/Mock.php
+++ b/data/source/Mock.php
@@ -32,6 +32,10 @@ class Mock extends \lithium\data\Source {
 		return true;
 	}
 
+	public static function enabled($feature = null) {
+		return false;
+	}
+
 	public function sources($class = null) {
 		return array();
 	}

--- a/data/source/MongoDb.php
+++ b/data/source/MongoDb.php
@@ -630,7 +630,8 @@ class MongoDb extends \lithium\data\Source {
 	public function relationship($class, $type, $name, array $config = array()) {
 		$key = Inflector::camelize($type === 'belongsTo' ? $class::meta('name') : $name, false);
 
-		$config += compact('name', 'type', 'key');
+		$fieldName = $this->relationFieldName($type, $name);
+		$config += compact('name', 'type', 'key', 'fieldName');
 		$config['from'] = $class;
 		$relationship = $this->_classes['relationship'];
 
@@ -838,6 +839,23 @@ class MongoDb extends \lithium\data\Source {
 		if (!$this->_isConnected && !$this->connect()) {
 			throw new NetworkException("Could not connect to the database.");
 		}
+	}
+
+	/**
+	 * Returns the field name of a relation name (camelBack).
+	 *
+	 * @param string The type of the relation.
+	 * @param string The name of the relation.
+	 * @return string
+	 */
+	public function relationFieldName($type, $name) {
+		$fieldName = Inflector::camelize($name, false);
+		if (preg_match('/Many$/', $type)) {
+			$fieldName = Inflector::pluralize($fieldName);
+		} else {
+			$fieldName = Inflector::singularize($fieldName);
+		}
+		return $fieldName;
 	}
 }
 

--- a/tests/cases/data/EntityTest.php
+++ b/tests/cases/data/EntityTest.php
@@ -23,8 +23,11 @@ class EntityTest extends \lithium\test\Unit {
 	}
 
 	public function testPropertyAccess() {
-		$entity = new Entity(array('model' => 'Foo', 'exists' => false));
-		$this->assertEqual('Foo', $entity->model());
+		$entity = new Entity(array(
+			'model' => 'lithium\tests\mocks\data\MockPost',
+			'exists' => false
+		));
+		$this->assertEqual('lithium\tests\mocks\data\MockPost', $entity->model());
 		$this->assertFalse($entity->exists());
 
 		$entity = new Entity(array('exists' => true));
@@ -38,7 +41,7 @@ class EntityTest extends \lithium\test\Unit {
 
 	public function testPropertyIssetEmpty() {
 		$entity = new Entity(array(
-			'model' => 'Foo',
+			'model' => 'lithium\tests\mocks\data\MockPost',
 			'exists' => true,
 			'data' => array('test_field' => 'foo'),
 			'relationships' => array('test_relationship' => array('test_me' => 'bar'))

--- a/tests/cases/data/ModelTest.php
+++ b/tests/cases/data/ModelTest.php
@@ -981,6 +981,25 @@ class ModelTest extends \lithium\test\Unit {
 		$this->assertTrue(MockPost::respondsTo('foo_Bar_Baz'));
 	}
 
+	public function testFieldName() {
+		MockPost::bind('hasMany', 'MockTag');
+		$relation = MockPost::relations('MockComment');
+		$this->assertEqual('mock_comments', $relation->fieldName());
+
+		$relation = MockPost::relations('MockTag');
+		$this->assertEqual('mock_tags', $relation->fieldName());
+
+		$relation = MockComment::relations('MockPost');
+		$this->assertEqual('mock_post', $relation->fieldName());
+	}
+
+	public function testRelationFromFieldName() {
+		MockPost::bind('hasMany', 'MockTag');
+		$this->assertEqual('MockComment', MockPost::relations('mock_comments')->name());
+		$this->assertEqual('MockTag', MockPost::relations('mock_tags')->name());
+		$this->assertEqual('MockPost', MockComment::relations('mock_post')->name());
+		$this->assertNull(MockPost::relations('undefined'));
+	}
 }
 
 ?>

--- a/tests/cases/data/SourceTest.php
+++ b/tests/cases/data/SourceTest.php
@@ -43,9 +43,9 @@ class SourceTest extends \lithium\test\Unit {
 
 	public function testItem() {
 		$source = new MockSource();
-		$entity = $source->item('Foo', array('foo' => 'bar'));
+		$entity = $source->item('lithium\tests\mocks\data\MockPost', array('foo' => 'bar'));
 		$this->assertInstanceOf('lithium\data\Entity', $entity);
-		$this->assertEqual('Foo', $entity->model());
+		$this->assertEqual('lithium\tests\mocks\data\MockPost', $entity->model());
 		$this->assertEqual(array('foo' => 'bar'), $entity->data());
 	}
 }

--- a/tests/cases/data/model/QueryTest.php
+++ b/tests/cases/data/model/QueryTest.php
@@ -398,7 +398,11 @@ class QueryTest extends \lithium\test\Unit {
 		$model::meta('source', 'foo');
 		$model::bind('hasMany', 'MockQueryComment');
 
-		$query = new Query(compact('model') + array('with' => 'MockQueryComment'));
+		$query = new Query(array(
+			'type' => 'read',
+			'model' => $model,
+			'with' => 'MockQueryComment'
+		));
 		$export = $query->export(new MockDatabase());
 
 		$expected = array('MockQueryComment' => array(
@@ -496,7 +500,10 @@ class QueryTest extends \lithium\test\Unit {
 	}
 
 	public function testAutomaticAliasing() {
-		$query = new Query(array('model' => $this->_model));
+		$query = new Query(array(
+			'type' => 'read',
+			'model' => $this->_model
+		));
 		$this->assertEqual('MockQueryPost', $query->alias());
 	}
 
@@ -519,7 +526,9 @@ class QueryTest extends \lithium\test\Unit {
 	public function testQueryWithCustomAlias() {
 		$model = 'lithium\tests\mocks\data\model\MockQueryComment';
 
-		$query = new Query(compact('model') + array(
+		$query = new Query(array(
+			'type' => 'read',
+			'model' => $model,
 			'source' => 'my_custom_table',
 			'alias' => 'MyCustomAlias'
 		));
@@ -604,7 +613,10 @@ class QueryTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $query->paths($this->db));
 
 		$model = 'lithium\tests\mocks\data\model\MockQueryPost';
-		$query = new Query(compact('model'));
+		$query = new Query(array(
+			'type' => 'read',
+			'model' => $model
+		));
 		$query->alias(null, 'MockQueryComment');
 		$query->alias('MockQueryPost2', 'MockQueryComment.MockQueryPost');
 
@@ -619,6 +631,7 @@ class QueryTest extends \lithium\test\Unit {
 	public function testModels() {
 		$model = 'lithium\tests\mocks\data\model\MockQueryPost';
 		$query = new Query(array(
+			'type' => 'read',
 			'model' => $model,
 			'with' => 'MockQueryComment'
 		));
@@ -630,6 +643,7 @@ class QueryTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $query->models($this->db));
 
 		$query = new Query(array(
+			'type' => 'read',
 			'model' => $model,
 			'alias' => 'Post',
 			'with' => array(
@@ -648,13 +662,13 @@ class QueryTest extends \lithium\test\Unit {
 
 	public function testExportWithJoinedStrategy() {
 		$query = new Query(array(
+			'type' => 'read',
 			'alias' => 'MyAlias',
 			'model' => 'lithium\tests\mocks\data\model\MockGallery',
 			'calculate' => 'MyCalculate',
 			'comment' => 'No comment',
 			'conditions' => array('id' => 2),
 			'fields' => array('Tag'),
-			'type' => 'read',
 			'with' => array('Image.ImageTag.Tag', 'Image', 'Image.ImageTag')
 		));
 		$export = $query->export($this->db);

--- a/tests/cases/data/model/RelationshipTest.php
+++ b/tests/cases/data/model/RelationshipTest.php
@@ -12,12 +12,32 @@ use lithium\data\model\Relationship;
 
 class RelationshipTest extends \lithium\test\Unit {
 
+	protected $_gallery = 'lithium\tests\mocks\data\model\MockGallery';
+	protected $_image = 'lithium\tests\mocks\data\model\MockImage';
+
 	public function testRespondsTo() {
-		$query = new Relationship();
+		$query = new Relationship(array(
+			'type' => 'belongsTo',
+			'fieldName' => 'bob',
+			'to' => $this->_image
+		));
 		$this->assertTrue($query->respondsTo('foobarbaz'));
 		$this->assertFalse($query->respondsTo(0));
 	}
 
+	public function testEmptyRequiredOptions() {
+		$this->expectException("/`'type'`, `'fieldName'` and `'from'` options can't be empty./");
+		$query = new Relationship();
+	}
+
+	public function testEmptyToAndName() {
+		$this->expectException("/`'to'` and `'name'` options can't both be empty./");
+		$query = new Relationship(array(
+			'from' => $this->_gallery,
+			'type' => 'belongsTo',
+			'fieldName' => 'field_id'
+		));
+	}
 }
 
 ?>

--- a/tests/cases/data/source/DatabaseTest.php
+++ b/tests/cases/data/source/DatabaseTest.php
@@ -163,6 +163,7 @@ class DatabaseTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 
 		$query = new Query(array(
+			'type' => 'read',
 			'model' => $this->_model,
 			'fields' => array('MockDatabaseComment'),
 			'with' => array('MockDatabaseComment')
@@ -177,6 +178,7 @@ class DatabaseTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 
 		$options = array(
+			'type' => 'read',
 			'model' => $this->_model,
 			'with' => 'MockDatabaseComment'
 		);
@@ -863,6 +865,7 @@ class DatabaseTest extends \lithium\test\Unit {
 
 	public function testFields() {
 		$query = new Query(array(
+			'type' => 'read',
 			'model' => $this->_model,
 			'with' => array('MockDatabaseComment')
 		));
@@ -1438,6 +1441,7 @@ class DatabaseTest extends \lithium\test\Unit {
 
 	public function testExportedFieldsWithJoinedStrategy() {
 		$query = new Query(array(
+			'type' => 'read',
 			'model' => $this->_gallery,
 			'with' => array('Image.ImageTag.Tag')
 		));
@@ -1445,6 +1449,7 @@ class DatabaseTest extends \lithium\test\Unit {
 		$this->assertEqual('*', $result['fields']);
 
 		$query = new Query(array(
+			'type' => 'read',
 			'model' => $this->_gallery,
 			'fields' => 'id',
 			'with' => array('Image.ImageTag.Tag')
@@ -1454,6 +1459,7 @@ class DatabaseTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result['fields']);
 
 		$query = new Query(array(
+			'type' => 'read',
 			'model' => $this->_gallery,
 			'fields' => 'Tag.id',
 			'with' => array('Image.ImageTag.Tag')
@@ -1463,6 +1469,7 @@ class DatabaseTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result['fields']);
 
 		$query = new Query(array(
+			'type' => 'read',
 			'model' => $this->_gallery,
 			'fields' => 'Tag',
 			'with' => array('Image.ImageTag.Tag')
@@ -1472,6 +1479,7 @@ class DatabaseTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result['fields']);
 
 		$query = new Query(array(
+			'type' => 'read',
 			'model' => $this->_gallery,
 			'fields' => 'Tag.*',
 			'with' => array('Image.ImageTag.Tag')
@@ -1483,6 +1491,7 @@ class DatabaseTest extends \lithium\test\Unit {
 
 	public function testExportedFieldsWithJoinedStrategyAndRecursiveRelation() {
 		$query = new Query(array(
+			'type' => 'read',
 			'model' => $this->_gallery,
 			'with' => array('Parent.Parent')
 		));
@@ -1491,6 +1500,7 @@ class DatabaseTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result['fields']);
 
 		$query = new Query(array(
+			'type' => 'read',
 			'model' => $this->_gallery,
 			'fields' => 'Parent.name',
 			'with' => array('Parent.Parent')
@@ -1500,6 +1510,7 @@ class DatabaseTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result['fields']);
 
 		$query = new Query(array(
+			'type' => 'read',
 			'model' => $this->_gallery,
 			'fields' => 'ParentOfParent.name',
 			'with' => array('Parent.Parent' => array('alias' => 'ParentOfParent'))

--- a/tests/cases/data/source/MongoDbTest.php
+++ b/tests/cases/data/source/MongoDbTest.php
@@ -541,6 +541,7 @@ class MongoDbTest extends \lithium\test\Unit {
 		$to::config(array('meta' => array('key' => '_id')));
 
 		$result = $this->db->relationship($from, 'belongsTo', 'MockPost');
+
 		$expected = array(
 			'name' => 'MockPost',
 			'type' => 'belongsTo',

--- a/tests/mocks/data/MockProductForSchemas.php
+++ b/tests/mocks/data/MockProductForSchemas.php
@@ -8,9 +8,7 @@
 
 namespace lithium\tests\mocks\data;
 
-class MockProductForSchemas extends \lithium\data\Model {
-
-	protected $_meta = array('source' => false, 'connection' => false);
+class MockProductForSchemas extends \lithium\tests\mocks\data\MockBase {
 
 	protected $_schema = array(
 		'name' => array('type' => 'string', 'null' => false),

--- a/tests/mocks/data/MockSource.php
+++ b/tests/mocks/data/MockSource.php
@@ -178,6 +178,21 @@ class MockSource extends \lithium\data\Source {
 		$query->calculate($type);
 		return compact('query', 'options');
 	}
+
+	public static function enabled($feature = null) {
+		if (!$feature) {
+			return true;
+		}
+		$features = array(
+			'arrays' => false,
+			'transactions' => true,
+			'booleans' => true,
+			'schema' => true,
+			'relationships' => true,
+			'sources' => true
+		);
+		return isset($features[$feature]) ? $features[$feature] : null;
+	}
 }
 
 ?>

--- a/tests/mocks/data/model/MockDatabase.php
+++ b/tests/mocks/data/model/MockDatabase.php
@@ -64,8 +64,8 @@ class MockDatabase extends \lithium\data\source\Database {
 
 	public function sources($class = null) {}
 
-	public function describe($entity, $schema = array(), array $meta = array()) {
-		return $this->_instance('schema', array('fields' => $schema));
+	public function describe($entity, $fields = array(), array $meta = array()) {
+		return $this->_instance('schema', compact('fields'));
 	}
 
 	public function encoding($encoding = null) {}
@@ -107,6 +107,21 @@ class MockDatabase extends \lithium\data\source\Database {
 		$query = $query->export($this);
 		ksort($query);
 		return sha1(serialize($query));
+	}
+
+	public static function enabled($feature = null) {
+		if (!$feature) {
+			return true;
+		}
+		$features = array(
+			'arrays' => false,
+			'transactions' => true,
+			'booleans' => true,
+			'schema' => true,
+			'relationships' => true,
+			'sources' => true
+		);
+		return isset($features[$feature]) ? $features[$feature] : null;
 	}
 }
 

--- a/tests/mocks/data/source/database/adapter/MockAdapter.php
+++ b/tests/mocks/data/source/database/adapter/MockAdapter.php
@@ -146,6 +146,21 @@ class MockAdapter extends \lithium\data\source\Database {
 	}
 
 	protected function _insertId($query) {}
+
+	public static function enabled($feature = null) {
+		if (!$feature) {
+			return true;
+		}
+		$features = array(
+			'arrays' => false,
+			'transactions' => true,
+			'booleans' => true,
+			'schema' => true,
+			'relationships' => true,
+			'sources' => true
+		);
+		return isset($features[$feature]) ? $features[$feature] : null;
+	}
 }
 
 ?>

--- a/tests/mocks/template/helper/MockFormPost.php
+++ b/tests/mocks/template/helper/MockFormPost.php
@@ -8,7 +8,7 @@
 
 namespace lithium\tests\mocks\template\helper;
 
-class MockFormPost extends \lithium\data\Model {
+class MockFormPost extends \lithium\tests\mocks\data\MockBase {
 
 	public $hasMany = array('MockQueryComment');
 

--- a/tests/mocks/template/helper/MockFormPostInfo.php
+++ b/tests/mocks/template/helper/MockFormPostInfo.php
@@ -8,7 +8,8 @@
 
 namespace lithium\tests\mocks\template\helper;
 
-class MockFormPostInfo extends \lithium\data\Model {
+class MockFormPostInfo extends \lithium\tests\mocks\data\MockBase {
+
 	protected $_schema = array(
 		'id' => array('type' => 'integer'),
 		'section' => array('type' => 'string'),


### PR DESCRIPTION
Consolidate `Model::relations()` to also accept a field name as parameter.

Currently all model relations own a `'fieldName'` attribute used to format datas. For example for a Post hasMany Comment, comments will "appear" in a `comments` attribute:

``` php
print_r($post->comments->data());
```

With this PR:

``` php
Model::relations('Comment'); // return the Comment relation
Model::relations('comments'); // return the Comment relation
```

To keep the lazy loading works, I removed the field name generation from the `Relationship` class.

By default the default field name generation is delegated to the datasource. This mean `Database` compatible source will return underscored field names and camelBack field names with `MongoDb` (Maybe we can provide some consistency here ?).

Anyway, is you are like me not a big fan of underscored, pluralization, camelBack, etc., you can provide you own fieldname convention by overriding the `Model::_relationFieldName()` methods.

For example the "CakePHP" way can be obtained by overriding the `Model::_relationFieldName()` with:

``` php
protected function _relationFieldName($type, $name) {
    return $name;
}
```
