### PR TITLE
resolving case 891 - model::first with return type of array would not grab the first result.

### DIFF
--- a/data/Model.php
+++ b/data/Model.php
@@ -1332,10 +1332,17 @@ class Model extends \lithium\core\StaticObject {
 
 		return array(
 			'first' => function($self, $params, $chain) {
-				$params['options']['limit'] = 1;
+				$options =& $params['options'];
+				$options['limit'] = 1;
 				$data = $chain->next($self, $params, $chain);
-				$data = is_object($data) ? $data->rewind() : $data;
-				return $data ?: null;
+
+				if (isset($options['return']) && $options['return'] == 'array') {
+					$data = is_array($data) ? reset($data) : $data;
+				} else {
+					$data = is_object($data) ? $data->rewind() : $data;
+				}
+
+				return $data ? : null;
 			},
 			'list' => function($self, $params, $chain) {
 				$result = array();

--- a/tests/cases/data/ModelTest.php
+++ b/tests/cases/data/ModelTest.php
@@ -760,6 +760,15 @@ class ModelTest extends \lithium\test\Unit {
 		$expected = $tag['query']->export(MockTag::$connection);
 		$this->assertEqual($expected, $tag2['query']->export(MockTag::$connection));
 		$this->assertEqual($expected, $tag3['query']->export(MockTag::$connection));
+
+		$tag = MockTag::find('first', array(
+			'conditions' => array('id' => 2),
+			'return' => 'array'
+		));
+
+		$expected['return'] = 'array';
+		$this->assertTrue($tag instanceof Query);
+		$this->assertEqual($expected, $tag->export(MockTag::$connection));
 	}
 
 	/**


### PR DESCRIPTION
...ray' does not return the first result.
