### PR TITLE
Mocker doesn't manage construct params.

### DIFF
--- a/test/Mocker.php
+++ b/test/Mocker.php
@@ -171,7 +171,7 @@ class Mocker {
 			'        $this->parent = $class->newInstanceArgs($args);',
 			'    }',
 			'    $this->parent->mocker = $this;',
-			'    if (method_exists("{:mocker}", "__construct")) {',
+			'    if (method_exists(\'{:mocker}\', "__construct")) {',
 			'        call_user_func_array("parent::__construct", $args);',
 			'    }',
 			'}',

--- a/tests/cases/test/MockerTest.php
+++ b/tests/cases/test/MockerTest.php
@@ -451,6 +451,11 @@ class MockerTest extends \lithium\test\Unit {
 		$entity = MockPost::create();
 	}
 
+	public function testConstructParams() {
+		$expected = 'lithium\tests\mocks\data\MockPost';
+		$document = new Document(array('model' => $expected));
+		$this->assertIdentical($expected, $document->model());
+	}
 }
 
 ?>


### PR DESCRIPTION
@BlaineSch, sorry woud like to provide a full PR for this but I failed to understand some part in the Mocker, so I'm only able to provide the test case.
