### PR TITLE
Fixing support for library dot notation when using URL compact syntax

### DIFF
--- a/net/http/Router.php
+++ b/net/http/Router.php
@@ -615,7 +615,7 @@ class Router extends \lithium\core\StaticObject {
 	 * @return array
 	 */
 	protected static function _parseString($path, $context, array $options = array()) {
-		if (!preg_match('/^[A-Za-z0-9_\\\\]+::[A-Za-z0-9_]+$/', $path)) {
+		if (!preg_match('/^[A-Za-z0-9._\\\\]+::[A-Za-z0-9_]+$/', $path)) {
 			$base = rtrim($options['base'], '/');
 			if ((!$path || $path[0] != '/') && $context && isset($context->controller)) {
 				$formatters = static::formatters();

--- a/tests/cases/net/http/RouterTest.php
+++ b/tests/cases/net/http/RouterTest.php
@@ -247,6 +247,7 @@ class RouterTest extends \lithium\test\Unit {
 	public function testShorthandParameterMatching() {
 		Router::reset();
 		Router::connect('/posts/{:page:[0-9]+}', array('Posts::index', 'page' => '1'));
+		Router::connect('/admin/posts/{:page:[0-9]+}', array('Posts::index', 'page' => '1', 'library' => 'admin'));
 
 		$result = Router::match(array('controller' => 'posts', 'page' => '5'));
 		$expected = '/posts/5';
@@ -255,6 +256,10 @@ class RouterTest extends \lithium\test\Unit {
 		$result = Router::match(array('Posts::index', 'page' => '10'));
 		$expected = '/posts/10';
 		$this->assertIdentical($expected, $result);
+
+		$result = Router::match(array("admin.Posts::index", 'page' => '9'));
+		$expected = '/admin/posts/9';
+		$this->assertEqual($expected, $result);
 
 		$request = new Request(array('url' => '/posts/13'));
 		$result = Router::process($request);


### PR DESCRIPTION
In Router::_parseString(), adding . (dot) to regex character class, for matching library-based routes specified in "compact syntax," e.g., 'myplugin.Posts::index'

Prior to this update, library dot notation did not work when using compact URL syntax. For example:

``` php
$url = Router::match(array('myplugin.Posts::view', 'id' => '1138'));
```

This failed because the . character within the controller component ('myplugin.Posts') was unrecognized by _parseString(). By including the . character in the regex pattern, the above compact URL path will not fail, and the controller portion, "myplugin.Posts" will subsequently be parsed by _parseController(), which recognizes the library dot notation.
