### PR TITLE
Fixes test environment detection.

### DIFF
--- a/core/Environment.php
+++ b/core/Environment.php
@@ -332,7 +332,7 @@ class Environment {
 					return 'test';
 				case ($request->env('PLATFORM') == 'CLI'):
 					return 'development';
-				case (preg_match('/^test\//', $request->url) && $isLocal):
+				case (preg_match('/^\/test/', $request->url) && $isLocal):
 					return 'test';
 				case ($isLocal):
 					return 'development';

--- a/tests/cases/core/EnvironmentTest.php
+++ b/tests/cases/core/EnvironmentTest.php
@@ -105,7 +105,12 @@ class EnvironmentTest extends \lithium\test\Unit {
 		$this->assertTrue($isProduction);
 
 		$request = new MockRequest(array('SERVER_ADDR' => '::1'));
-		$request->url = 'test/myTest';
+		$request->url = '/test/myTest';
+		Environment::set($request);
+		$this->assertTrue(Environment::is('test'));
+
+		$request = new MockRequest(array('SERVER_ADDR' => '::1'));
+		$request->url = '/test';
 		Environment::set($request);
 		$this->assertTrue(Environment::is('test'));
 


### PR DESCRIPTION
Since #878, `Request`'s url starts with an '/' (for a better consistency with the HTTP protocol).
