### PR TITLE
Add psr-0 autoloading with target-dir to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
 	"name": "UnionOfRAD/lithium",
-	"type": "lithium-library",
 	"description": "The core library of the Lithium PHP framework",
 	"keywords": ["lithium", "framework"],
 	"homepage": "http://lithify.me",
@@ -16,7 +15,10 @@
 		}
 	],
 	"require": {
-		"php": ">=5.3.6",
-		"composer/installers": "dev-master"
-	}
+		"php": ">=5.3.6"
+	},
+	"autoload": {
+		"psr-0": { "lithium": "" }
+	},
+	"target-dir": "lithium"
 }


### PR DESCRIPTION
This lifts the dependency on composer/installers and uses composer autoloading
directly.

This makes lithium no longer install into /libraries/lithium, but instead puts it into /vendor/UnionOfRad/lithium/lithium (second lithium is needed for psr-0 path completion).

Now, I'm not sure if you actually want this. The benefit of doing so is that it plays nice with everyone else. Instead of saying "fuck you, I'm going to make my own folder", putting everything in the vendor dir allows all the library code to be in one place, and the end user can customize it if he wants to.

Let me know if you have any questions.

This PR replaces #916. It was originally spawned off of composer/composer#1865.
