### PR TITLE
BC Break (minor): Fix collision on `'type'` option for `Query`.

### DIFF
--- a/data/model/Relationship.php
+++ b/data/model/Relationship.php
@@ -115,8 +115,6 @@ class Relationship extends \lithium\core\Object {
 	protected function _init() {
 		parent::_init();
 		$config =& $this->_config;
-		$type = $config['type'];
-
 		if (!$config['to']) {
 			$assoc = preg_replace("/\\w+$/", "", $config['from']) . $config['name'];
 			$config['to'] = Libraries::locate('models', $assoc);

--- a/data/source/Database.php
+++ b/data/source/Database.php
@@ -54,7 +54,7 @@ abstract class Database extends \lithium\data\Source {
 		'create' => "INSERT INTO {:source} ({:fields}) VALUES ({:values});{:comment}",
 		'update' => "UPDATE {:source} SET {:fields} {:conditions};{:comment}",
 		'delete' => "DELETE {:flags} FROM {:source} {:conditions};{:comment}",
-		'join' => "{:type} JOIN {:source} {:alias} {:constraints}",
+		'join' => "{:mode} JOIN {:source} {:alias} {:constraints}",
 		'schema' => "CREATE TABLE {:source} (\n{:columns}{:constraints}){:table};{:comment}",
 		'drop'   => "DROP TABLE {:exists}{:source};"
 	);
@@ -248,7 +248,7 @@ abstract class Database extends \lithium\data\Source {
 					}
 				};
 
-				$tree = Set::expand(Set::normalize(array_keys($with)));
+				$tree = Set::expand(array_fill_keys(array_keys($with), false));
 				$alias = $context->alias();
 				$deps = array($alias => array());
 				$strategy($strategy, $model, $tree, '', $alias, $deps);
@@ -1126,7 +1126,7 @@ abstract class Database extends \lithium\data\Source {
 				$result .= ' ';
 			}
 			$join = is_array($join) ? $this->_instance('query', $join) : $join;
-			$options['keys'] = array('source', 'alias', 'constraints');
+			$options['keys'] = array('mode', 'source', 'alias', 'constraints');
 			$result .= $this->renderCommand('join', $join->export($this, $options));
 		}
 		return $result;
@@ -1414,9 +1414,13 @@ abstract class Database extends \lithium\data\Source {
 	 * Applying a strategy to a `lithium\data\model\Query` object
 	 *
 	 * @param array $options The option array
-	 * @param object $context A query object to configure
+	 * @param object $context A find query object to configure
 	 */
 	public function applyStrategy($options, $context) {
+		if ($context->type() !== 'read') {
+			return;
+		}
+
 		$options += array('strategy' => 'joined');
 		if (!$model = $context->model()) {
 			throw new ConfigException('The `\'with\'` option need a valid `\'model\'` option.');
@@ -1458,7 +1462,7 @@ abstract class Database extends \lithium\data\Source {
 		}
 
 		$context->joins($toAlias, compact('constraints', 'model') + array(
-			'type' => 'LEFT',
+			'mode' => 'LEFT',
 			'alias' => $toAlias
 		));
 	}

--- a/tests/cases/data/ModelTest.php
+++ b/tests/cases/data/ModelTest.php
@@ -821,7 +821,7 @@ class ModelTest extends \lithium\test\Unit {
 		$this->assertEqual(array('published' => false), $query->conditions());
 
 		$keys = array_keys(array_filter($query->export(MockPost::$connection)));
-		$this->assertEqual(array('type', 'conditions', 'model', 'source', 'alias'), $keys);
+		$this->assertEqual(array('conditions', 'model', 'type', 'source', 'alias'), $keys);
 	}
 
 	public function testFindFirst() {

--- a/tests/cases/data/model/QueryTest.php
+++ b/tests/cases/data/model/QueryTest.php
@@ -310,6 +310,7 @@ class QueryTest extends \lithium\test\Unit {
 			'joins',
 			'limit',
 			'map',
+			'mode',
 			'model',
 			'offset',
 			'order',
@@ -345,7 +346,7 @@ class QueryTest extends \lithium\test\Unit {
 		$query = new Query($options);
 
 		$result = $query->export($this->db, array(
-			'keys' => array('data', 'conditions')
+			'keys' => array('type', 'data', 'conditions')
 		));
 		$expected = array(
 			'type' => 'update',
@@ -689,6 +690,7 @@ class QueryTest extends \lithium\test\Unit {
 			'order' => null,
 			'limit' => null,
 			'joins' => $joins,
+			'mode' => null,
 			'model' => 'lithium\tests\mocks\data\model\MockGallery',
 			'calculate' => 'MyCalculate',
 			'with' => array(

--- a/tests/cases/data/source/DatabaseTest.php
+++ b/tests/cases/data/source/DatabaseTest.php
@@ -1077,7 +1077,7 @@ class DatabaseTest extends \lithium\test\Unit {
 			'alias' => 'Comments',
 			'conditions' => array('Comment.id' => 1),
 			'joins' => array(array(
-				'type' => 'INNER',
+				'mode' => 'INNER',
 				'source' => 'posts',
 				'alias' => 'Post',
 				'constraints' => array('Comment.post_id' => array('<=' => 'Post.id'))
@@ -1102,7 +1102,7 @@ class DatabaseTest extends \lithium\test\Unit {
 			'alias' => 'Comments',
 			'conditions' => array('Comment.id' => 1),
 			'joins' => array(array(
-				'type' => 'LEFT',
+				'mode' => 'LEFT',
 				'source' => 'posts',
 				'alias' => 'Post',
 				'constraints' => array(
@@ -1125,7 +1125,7 @@ class DatabaseTest extends \lithium\test\Unit {
 			'source' => 'comments',
 			'alias' => 'Comments',
 			'joins' => array(array(
-				'type' => 'LEFT',
+				'mode' => 'LEFT',
 				'source' => 'posts',
 				'alias' => 'Post',
 				'constraints' => array(
@@ -1146,7 +1146,7 @@ class DatabaseTest extends \lithium\test\Unit {
 			'alias' => 'Comment',
 			'conditions' => array('Comment.id' => 1),
 			'joins' => array(array(
-				'type' => 'INNER',
+				'mode' => 'INNER',
 				'source' => 'posts',
 				'alias' => 'Post',
 				'constraints' => array('Comment.post_id' => 'Post.id')
@@ -1405,7 +1405,7 @@ class DatabaseTest extends \lithium\test\Unit {
 					'MockDatabasePost.published' => (object) "'yes'"
 				),
 				'model' => 'lithium\tests\mocks\data\model\MockDatabaseComment',
-				'type' => 'LEFT',
+				'mode' => 'LEFT',
 				'alias' => 'MockDatabaseComment'
 			)
 		);
@@ -1425,7 +1425,7 @@ class DatabaseTest extends \lithium\test\Unit {
 					'published' => (object) "'yes'"
 				),
 				'model' => 'lithium\tests\mocks\data\model\MockDatabaseComment',
-				'type' => 'LEFT',
+				'mode' => 'LEFT',
 				'alias' => 'MockDatabaseComment'
 			)
 		);

--- a/tests/fixture/model/gallery/ImagesTagsFixture.php
+++ b/tests/fixture/model/gallery/ImagesTagsFixture.php
@@ -20,11 +20,11 @@ class ImagesTagsFixture extends \li3_fixtures\test\Fixture {
 
 	protected $_records = array(
 		array('id' => 1, 'image_id' => 1, 'tag_id' => 1),
-		array('id' => 2, 'image_id' => 1, 'tag_id' => 4),
-		array('id' => 3, 'image_id' => 2, 'tag_id' => 6),
-		array('id' => 4, 'image_id' => 3, 'tag_id' => 7),
-		array('id' => 5, 'image_id' => 4, 'tag_id' => 7),
-		array('id' => 6, 'image_id' => 4, 'tag_id' => 4),
+		array('id' => 2, 'image_id' => 1, 'tag_id' => 3),
+		array('id' => 3, 'image_id' => 2, 'tag_id' => 5),
+		array('id' => 4, 'image_id' => 3, 'tag_id' => 6),
+		array('id' => 5, 'image_id' => 4, 'tag_id' => 6),
+		array('id' => 6, 'image_id' => 4, 'tag_id' => 3),
 		array('id' => 7, 'image_id' => 4, 'tag_id' => 1)
 	);
 }

--- a/tests/fixture/model/gallery/TagsFixture.php
+++ b/tests/fixture/model/gallery/TagsFixture.php
@@ -20,11 +20,11 @@ class TagsFixture extends \li3_fixtures\test\Fixture {
 
 	protected $_records = array(
 		array('id' => 1, 'name' => 'High Tech', 'author_id' => 6),
-		array('id' => 3, 'name' => 'Sport', 'author_id' => 9),
-		array('id' => 4, 'name' => 'Computer', 'author_id' => 6),
-		array('id' => 5, 'name' => 'Art', 'author_id' => 2),
-		array('id' => 6, 'name' => 'Science', 'author_id' => 1),
-		array('id' => 7, 'name' => 'City', 'author_id' => 2)
+		array('id' => 2, 'name' => 'Sport', 'author_id' => 9),
+		array('id' => 3, 'name' => 'Computer', 'author_id' => 6),
+		array('id' => 4, 'name' => 'Art', 'author_id' => 2),
+		array('id' => 5, 'name' => 'Science', 'author_id' => 1),
+		array('id' => 6, 'name' => 'City', 'author_id' => 2)
 	);
 }
 

--- a/tests/fixture/model/gallery/export/testManyToOne.php
+++ b/tests/fixture/model/gallery/export/testManyToOne.php
@@ -1,15 +1,13 @@
 <?php
-return array (
-	1 => 
-	array (
+return array(
+	1 => array(
 		'id' => '1',
 		'gallery_id' => '1',
 		'image' => 'someimage.png',
 		'title' => 'Amiga 1200',
 		'created' => '2011-05-22 10:43:13',
 		'modified' => '2012-11-30 18:38:10',
-		'gallery' => 
-		array (
+		'gallery' => array(
 			'id' => '1',
 			'name' => 'Foo Gallery',
 			'active' => '1',
@@ -17,16 +15,14 @@ return array (
 			'modified' => '2009-12-14 22:36:09',
 		),
 	),
-	2 => 
-	array (
+	2 => array(
 		'id' => '2',
 		'gallery_id' => '1',
 		'image' => 'image.jpg',
 		'title' => 'Srinivasa Ramanujan',
 		'created' => '2009-01-05 08:39:27',
 		'modified' => '2009-03-14 05:42:07',
-		'gallery' => 
-		array (
+		'gallery' => array(
 			'id' => '1',
 			'name' => 'Foo Gallery',
 			'active' => '1',
@@ -34,16 +30,14 @@ return array (
 			'modified' => '2009-12-14 22:36:09',
 		),
 	),
-	3 => 
-	array (
+	3 => array(
 		'id' => '3',
 		'gallery_id' => '1',
 		'image' => 'photo.jpg',
 		'title' => 'Las Vegas',
 		'created' => '2010-08-11 23:12:03',
 		'modified' => '2010-09-24 04:45:14',
-		'gallery' => 
-		array (
+		'gallery' => array(
 			'id' => '1',
 			'name' => 'Foo Gallery',
 			'active' => '1',

--- a/tests/fixture/model/gallery/export/testOneToMany.php
+++ b/tests/fixture/model/gallery/export/testOneToMany.php
@@ -1,16 +1,13 @@
 <?php
-return array (
-	1 => 
-	array (
+return array(
+	1 => array(
 		'id' => '1',
 		'name' => 'Foo Gallery',
 		'active' => '1',
 		'created' => '2007-06-20 21:02:27',
 		'modified' => '2009-12-14 22:36:09',
-		'images' => 
-		array (
-			1 => 
-			array (
+		'images' => array(
+			1 => array(
 				'id' => '1',
 				'gallery_id' => '1',
 				'image' => 'someimage.png',
@@ -18,8 +15,7 @@ return array (
 				'created' => '2011-05-22 10:43:13',
 				'modified' => '2012-11-30 18:38:10',
 			),
-			2 => 
-			array (
+			2 => array(
 				'id' => '2',
 				'gallery_id' => '1',
 				'image' => 'image.jpg',
@@ -27,8 +23,7 @@ return array (
 				'created' => '2009-01-05 08:39:27',
 				'modified' => '2009-03-14 05:42:07',
 			),
-			3 => 
-			array (
+			3 => array(
 				'id' => '3',
 				'gallery_id' => '1',
 				'image' => 'photo.jpg',


### PR DESCRIPTION
- Manual join queries use `'mode'` instead of `'type'` to specify the `JOIN` mode of a read query (imo the `Query`'s `'type'` attribute should be reserved to a CRUD action only).
- Set `'read'` as the default option for `Query`'s `'type'`.
- Fix some typos in fixtures.
