### PR TITLE
Fix for Browser-Based Tests in PHP 5.3

### DIFF
--- a/test/Controller.php
+++ b/test/Controller.php
@@ -56,9 +56,9 @@ class Controller extends \lithium\core\Object {
 				$options['title'] = 'All Tests';
 			}
 
-			$this->_saveCtrlContext();
+			$self->invokeMethod('_saveCtrlContext');
 			$report = Dispatcher::run($group, $options);
-			$this->_restoreCtrlContext();
+			$self->invokeMethod('_restoreCtrlContext');
 
 			$filters = Libraries::locate('test.filter');
 			$menu = Libraries::locate('tests', null, array(


### PR DESCRIPTION
See [this thread](https://github.com/UnionOfRAD/lithium/commit/d0716917ad737dfa1d020f0a2bc590524de46ad0#commitcomment-3150236)

Quick fix for `$this` scope inside a filter which was breaking in PHP 5.3.
