### PR TITLE
Update composer.json to list `li3` command as a binary

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,6 @@
 	"autoload": {
 		"psr-0": { "lithium": "" }
 	},
-	"target-dir": "lithium"
+	"target-dir": "lithium",
+	"bin" : ["console/li3"]
 }


### PR DESCRIPTION
This tech Composer to install `li3` binary in `vendor/bin` or a custom project's `bin-dir`.
http://getcomposer.org/doc/articles/vendor-binaries.md

NB: That was failing before due to `composer/installers`.
