### PR TITLE
Suppress open_basedir restriction warning

### DIFF
--- a/util/String.php
+++ b/util/String.php
@@ -124,7 +124,7 @@ class String {
 		switch (true) {
 			case isset(static::$_source):
 				return static::$_source;
-			case is_readable('/dev/urandom') && $fp = fopen('/dev/urandom', 'rb'):
+			case @is_readable('/dev/urandom') && $fp = fopen('/dev/urandom', 'rb'):
 				return static::$_source = function($bytes) use (&$fp) {
 					return fread($fp, $bytes);
 				};


### PR DESCRIPTION
Suppress open_basedir restriction warning in lithium\util\String::_source().
