### PR TITLE
Fix a bad method call in `console\Command::header()`. Heading style was ignored

### DIFF
--- a/console/Command.php
+++ b/console/Command.php
@@ -261,7 +261,7 @@ class Command extends \lithium\core\Object {
 			$line = strlen($text);
 		}
 		$this->hr($line);
-		$this->out($text, 1, 'heading');
+		$this->out($text, 'heading');
 		$this->hr($line);
 	}
 

--- a/tests/cases/console/ResponseTest.php
+++ b/tests/cases/console/ResponseTest.php
@@ -70,6 +70,16 @@ class ResponseTest extends \lithium\test\Unit {
 		$this->assertEqual('ok', file_get_contents($this->streams['output']));
 	}
 
+	public function testStyledOutput() {
+		$base = Libraries::get(true, 'resources') . '/tmp/tests';
+		$this->skipIf(!is_writable($base), "Path `{$base}` is not writable.");
+
+		$response = new Response(array('output' => fopen($this->streams['output'], 'w+')));
+		$response->styles(array('heading' => "\033[1;36m"));
+		$response->output('{:heading}ok');
+		$this->assertEqual("\033[1;36mok", file_get_contents($this->streams['output']));
+	}
+
 	public function testError() {
 		$base = Libraries::get(true, 'resources') . '/tmp/tests';
 		$this->skipIf(!is_writable($base), "Path `{$base}` is not writable.");


### PR DESCRIPTION
Minor fix of a bad call to `out()` method in `Command::header()`
`Command::out()` take 2 params: text to output, and an int or string or array as the number of new lines and the style of the output.

PS: caught by @rlerdorf's hhvm static analysis #933
