### PR TITLE
PATCH support added to Curl Socket

### DIFF
--- a/net/socket/Curl.php
+++ b/net/socket/Curl.php
@@ -159,6 +159,13 @@ class Curl extends \lithium\net\Socket {
 					CURLOPT_POSTFIELDS => $data->body()
 				));
 			}
+			if (isset($data->method) && $data->method === 'PATCH') {
+				$this->set(array(
+					CURLOPT_CUSTOMREQUEST => 'PATCH',
+					CURLOPT_POSTFIELDS => $data->body()
+				));
+			}
+
 		}
 		return (boolean) curl_setopt_array($this->_resource, $this->options);
 	}

--- a/tests/cases/net/socket/CurlTest.php
+++ b/tests/cases/net/socket/CurlTest.php
@@ -216,6 +216,22 @@ EOD;
 		$this->assertFalse(isset($stream->options[CURLOPT_CUSTOMREQUEST]));
 		$this->assertTrue($stream->close());
 	}
+	public function testSendPatchThenGet() {
+		$postConfig = array('method' => 'PATCH', 'body' => '{"body"}');
+		$stream = new Curl($this->_testConfig);
+		$this->assertInternalType('resource', $stream->open());
+		$this->assertTrue($stream->write(new Request($postConfig + $this->_testConfig)));
+		$this->assertTrue(isset($stream->options[CURLOPT_CUSTOMREQUEST]));
+		$this->assertEqual($stream->options[CURLOPT_CUSTOMREQUEST],'PATCH');
+		$this->assertTrue(isset($stream->options[CURLOPT_POSTFIELDS]));
+		$this->assertEqual($stream->options[CURLOPT_POSTFIELDS],$postConfig['body']);
+		$this->assertTrue($stream->close());
+
+		$this->assertInternalType('resource', $stream->open());
+		$this->assertTrue($stream->write(new Request($this->_testConfig)));
+		$this->assertFalse(isset($stream->options[CURLOPT_CUSTOMREQUEST]));
+		$this->assertTrue($stream->close());
+	}
 
 	public function testCurlAdapter() {
 		$socket = new Curl($this->_testConfig);


### PR DESCRIPTION
PATCH was not being handled in the Curl Socket class.  Added support to be treated similar to PUT.  Test case also added: testSendPatchThenGet
