### PR TITLE
Remove `dirname` in `lithium\action\Request` since not consistent over OS.

### DIFF
--- a/action/Request.php
+++ b/action/Request.php
@@ -689,7 +689,7 @@ class Request extends \lithium\net\http\Request {
 	 */
 	protected function _base($base = null) {
 		if ($base === null) {
-			$base = dirname($this->env('PHP_SELF'));
+			$base = preg_replace('/[^\/]+$/', '', $this->env('PHP_SELF'));
 		}
 		$base = trim(str_replace(array("/app/webroot", '/webroot'), '', $base), '/');
 		return $base ? '/' . $base : '';


### PR DESCRIPTION
`dirname` behave differently in OS which cause some issues on Windows.
