### PR TITLE
changed MongoDate converted format in  to('array') as RFC

### DIFF
--- a/data/collection/DocumentSet.php
+++ b/data/collection/DocumentSet.php
@@ -76,7 +76,10 @@ class DocumentSet extends \lithium\data\Collection {
 	public function to($format, array $options = array()) {
 		$options += array('handlers' => array(
 			'MongoId' => function($value) { return (string) $value; },
-			'MongoDate' => function($value) { return $value->sec; }
+			'MongoDate' => function($value) {
+				$time = microtime($value->sec. $value->usec);
+				return date('r', $time);
+			}
 		));
 
 		$this->offsetGet(null);

--- a/data/entity/Document.php
+++ b/data/entity/Document.php
@@ -419,7 +419,10 @@ class Document extends \lithium\data\Entity implements \Iterator, \ArrayAccess {
 	public function to($format, array $options = array()) {
 		$defaults = array('handlers' => array(
 			'MongoId' => function($value) { return (string) $value; },
-			'MongoDate' => function($value) { return $value->sec; }
+			'MongoDate' => function($value) {
+				$time = microtime($value->sec. $value->usec);
+				return date('r', $time);
+			}
 		));
 		$options += $defaults;
 		$options['internal'] = false;

--- a/tests/cases/data/collection/DocumentSetTest.php
+++ b/tests/cases/data/collection/DocumentSetTest.php
@@ -8,6 +8,7 @@
 
 namespace lithium\tests\cases\data\collection;
 
+use MongoDate;
 use lithium\data\source\MongoDb;
 use lithium\data\source\mongo_db\Schema;
 use lithium\data\entity\Document;
@@ -175,6 +176,25 @@ class DocumentSetTest extends \lithium\test\Unit {
 		$this->assertInternalType('object', $doc[1]);
 		$this->assertInternalType('object', $doc[2]);
 		$this->assertCount(3, $doc);
+	}
+
+	public function testArrayConversion() {
+		$time = time();
+
+		$schema = new Schema();
+		$first  = (object) array('name' => 'First', 'date' => new MongoDate($time));
+		$second = (object) array('name' => 'Second', 'date' => new MongoDate($time));
+		$third  = (object) array('name' => 'Third', 'date' => new MongoDate($time));
+		$doc = new DocumentSet(compact('schema') + array(
+			'data' => array($first, $second, $third)
+		));
+
+		$results = $doc->data();
+
+		$this->assertEqual(array('name' => 'First', 'date' => date('r', $time)), $results[0]);
+		$this->assertEqual(array('name' => 'Second', 'date' => date('r', $time)), $results[1]);
+		$this->assertEqual(array('name' => 'Third', 'date' => date('r', $time)), $results[2]);
+		$this->assertCount(3, $results);
 	}
 
 	public function testOffsetSet() {

--- a/tests/cases/data/entity/DocumentTest.php
+++ b/tests/cases/data/entity/DocumentTest.php
@@ -826,7 +826,7 @@ class DocumentTest extends \lithium\test\Unit {
 		)));
 		$result = $doc->data();
 		$this->assertPattern('/^[a-f0-9]{24}$/', $result['_id']);
-		$this->assertEqual($time, $result['date']);
+		$this->assertEqual(date('r', $time), $result['date']);
 	}
 
 	public function testArrayInterface() {


### PR DESCRIPTION
It's really good if converted MongoDate to RFC formated date. especially response as json, it's not easy to use by other languages if its just sec.

I know it looks simple but big changes.
Please review this.

thanks.
