### PR TITLE
Remove the default scope feature for unscoped routes

### DIFF
--- a/net/http/Router.php
+++ b/net/http/Router.php
@@ -700,6 +700,10 @@ class Router extends \lithium\core\StaticObject {
 	 * @param array Variables to populate for the scope.
 	 */
 	public static function attach($name, $config = null, array $vars = array()) {
+		if ($name === false) {
+			return null;
+		}
+
 		if (!isset(static::$_scopes)) {
 			static::_initScopes();
 		}
@@ -712,9 +716,6 @@ class Router extends \lithium\core\StaticObject {
 			return;
 		}
 
-		if ($name === false) {
-			$name = '__defaultScope__';
-		}
 		if (is_array($config) || $config === false) {
 			static::$_scopes->set($name, $config);
 		}
@@ -757,17 +758,17 @@ class Router extends \lithium\core\StaticObject {
 	 *         if `$name === null`.
 	 */
 	public static function attached($name = null, array $vars = array()) {
+		if ($name === false) {
+			return null;
+		}
+
 		if (!isset(static::$_scopes)) {
 			static::_initScopes();
 		}
 
-		if ($name === false) {
-			$name = '__defaultScope__';
-		}
-
 		if ($name === null) {
 			return static::$_scopes->get();
-		} elseif (!$config = static::$_scopes->get($name)){
+		} elseif (!$config = static::$_scopes->get($name)) {
 			static::$_scopes->set($name, array());
 			$config = static::$_scopes->get($name);
 		}
@@ -806,12 +807,9 @@ class Router extends \lithium\core\StaticObject {
 				'base' => null,
 				'prefix' => '',
 				'pattern' => '',
-				'values' => array()
+				'values' => array(),
+				'library' => $name
 			);
-
-			if ($name !== '__defaultScope__') {
-				$defaults['library'] = $name;
-			}
 
 			$config += $defaults;
 

--- a/tests/cases/net/http/RouterTest.php
+++ b/tests/cases/net/http/RouterTest.php
@@ -1809,17 +1809,21 @@ class RouterTest extends \lithium\test\Unit {
 
 	public function testScopeBase() {
 		$request = new Request(array('base' => 'lithium/app'));
-		Router::connect('/{:controller}/{:action}');
 		$url = array('controller' => 'HelloWorld');
+
+		Router::scope('app', function(){
+			Router::connect('/{:controller}/{:action}');
+		});
+		Router::scope('app');
 
 		$expected = '/lithium/app/hello_world';
 		$this->assertEqual($expected, Router::match($url, $request));
 
-		Router::attach(false, array('base' => 'lithium'));
+		Router::attach('app', array('base' => 'lithium'));
 		$expected = '/lithium/hello_world';
 		$this->assertEqual($expected, Router::match($url, $request));
 
-		Router::attach(false, array('base' => ''));
+		Router::attach('app', array('base' => ''));
 		$expected = '/hello_world';
 		$this->assertEqual($expected, Router::match($url, $request));
 	}
@@ -1849,6 +1853,23 @@ class RouterTest extends \lithium\test\Unit {
 
 		$result = Router::match($result->params);
 		$this->assertEqual('/hello/world2', $result);
+	}
+
+	public function testLibraryBasedRoute() {
+		$route = Router::connect('/{:library}/{:controller}/{:action}',
+			array('library' => 'app'),
+			array('persist' => array('library'))
+		);
+
+		$expected = '/app/hello/world';
+		$result = Router::match(array('controller' => 'hello', 'action' => 'world'));
+		$this->assertEqual($expected, $result);
+
+		$expected = '/myapp/hello/world';
+		$result = Router::match(array(
+			'library' => 'myapp', 'controller' => 'hello', 'action' => 'world'
+		));
+		$this->assertEqual($expected, $result);
 	}
 }
 


### PR DESCRIPTION
Library based routes & scope based routes can't be used together. So it's not possible to allow unscoped routes to have a scope without BC breaking the library based routes syntax.

So, the following syntax has no effect any more:

``` php
Router::attach(false, array(/*config values*/));
```
