### PR TITLE
Move up the itemization step to the model level.

### DIFF
--- a/data/DocumentSchema.php
+++ b/data/DocumentSchema.php
@@ -81,10 +81,9 @@ class DocumentSchema extends \lithium\data\Schema {
 			$config += compact('pathKey') + array_diff_key($options, $defaults);
 
 			if (!$pathKey && $model = $options['model']) {
-				$connection = $model::connection();
 				$exists = is_object($object) ? $object->exists() : false;
-				$config += array('class' => $class, 'exists' => $exists);
-				$val = $connection->item($model, $val, $config);
+				$config += array('class' => $class, 'exists' => $exists, 'defaults' => false);
+				$val = $model::create($val, $config);
 			} else {
 				$config['data'] = $val;
 				$val = $this->_instance($class, $config);

--- a/data/Model.php
+++ b/data/Model.php
@@ -973,8 +973,14 @@ class Model extends \lithium\core\StaticObject {
 	 * @filter
 	 */
 	public static function create(array $data = array(), array $options = array()) {
+		$defaults = array('defaults' => true);
+		$options += $defaults;
 		return static::_filter(__FUNCTION__, compact('data', 'options'), function($self, $params) {
-			$data = Set::merge(Set::expand($self::schema()->defaults()), $params['data']);
+			if ($params['options']['defaults']) {
+				$data = Set::merge(Set::expand($self::schema()->defaults()), $params['data']);
+			} else {
+				$data = $params['data'];
+			}
 			return $self::connection()->item($self, $data, $params['options']);
 		});
 	}

--- a/data/collection/MultiKeyRecordSet.php
+++ b/data/collection/MultiKeyRecordSet.php
@@ -236,7 +236,8 @@ class MultiKeyRecordSet extends \lithium\data\collection\RecordSet {
 
 	protected function _set($data = null, $offset = null, $options = array()) {
 		if ($model = $this->_model) {
-			$data = !is_object($data) ? $model::connection()->item($model, $data, $options) : $data;
+			$options += array('defaults' => false);
+			$data = !is_object($data) ? $model::create($data, $options) : $data;
 			$key = $model::key($data);
 		} else {
 			$key = $offset;

--- a/data/collection/RecordSet.php
+++ b/data/collection/RecordSet.php
@@ -79,7 +79,8 @@ class RecordSet extends \lithium\data\Collection {
 
 	protected function _set($data = null, $offset = null, $options = array()) {
 		if ($model = $this->_model) {
-			$data = !is_object($data) ? $model::connection()->item($model, $data, $options) : $data;
+			$options += array('defaults' => false);
+			$data = !is_object($data) ? $model::create($data, $options) : $data;
 			$key = $model::key($data);
 		} else {
 			$key = $offset;
@@ -148,7 +149,7 @@ class RecordSet extends \lithium\data\Collection {
 	 * @return object Returns a `Record` object
 	 */
 	protected function _hydrateRecord($relations, $primary, $record, $min, $max, $name, &$relMap, $conn) {
-		$options = array('exists' => true);
+		$options = array('exists' => true, 'defaults' => false);
 
 		$count = count($record);
 		if (!empty($relations)) {
@@ -179,7 +180,7 @@ class RecordSet extends \lithium\data\Collection {
 						);
 					}
 					$opts = array('class' => 'set') + $options;
-					$record[$min][$name][$field] = $conn->item($primary, $rel, $opts);
+					$record[$min][$name][$field] = $relModel::create($rel, $opts);
 				} else {
 					$record[$min][$name][$field] = $this->_hydrateRecord(
 						$subrelations, $relModel, $record, $min, $max, $relName, $relMap, $conn
@@ -187,8 +188,8 @@ class RecordSet extends \lithium\data\Collection {
 				}
 			}
 		}
-		return $conn->item(
-			$primary, isset($record[$min][$name]) ? $record[$min][$name] : array(), $options
+		return $primary::create(
+			isset($record[$min][$name]) ? $record[$min][$name] : array(), $options
 		);
 	}
 

--- a/data/entity/Document.php
+++ b/data/entity/Document.php
@@ -133,12 +133,13 @@ class Document extends \lithium\data\Entity implements \Iterator, \ArrayAccess {
 				return $this->_updated[$name];
 			}
 			if (isset($field['array']) && $field['array'] && ($model = $this->_model)) {
-				$this->_updated[$name] = $model::connection()->item($model, array(), array(
+				$this->_updated[$name] = $model::create(array(), array(
 					'class' => 'set',
 					'schema' => $this->schema(),
 					'pathKey' => $this->_pathKey ? $this->_pathKey . '.' . $name : $name,
 					'parent' => $this,
-					'model' => $this->_model
+					'model' => $this->_model,
+					'defaults' => false
 				));
 				return $this->_updated[$name];
 			}
@@ -249,7 +250,7 @@ class Document extends \lithium\data\Entity implements \Iterator, \ArrayAccess {
 			}
 
 			if ($next === null && ($model = $this->_model)) {
-				$current->set(array($key => $model::connection()->item($model)));
+				$current->set(array($key => $model::create(array(), array('defaults' => false))));
 				$next =& $current->{$key};
 			}
 			$current =& $next;

--- a/data/source/Database.php
+++ b/data/source/Database.php
@@ -569,8 +569,8 @@ abstract class Database extends \lithium\data\Source {
 					}
 					return Set::expand($records);
 				case 'item':
-					return $self->item($query->model(), array(), compact('query', 'result') + array(
-						'class' => 'set'
+					return $model::create(array(), compact('query', 'result') + array(
+						'class' => 'set', 'defaults' => false
 					));
 			}
 		});

--- a/data/source/MongoDb.php
+++ b/data/source/MongoDb.php
@@ -474,11 +474,12 @@ class MongoDb extends \lithium\data\Source {
 			$options = $params['options'];
 			$args = $query->export($self);
 			$source = $args['source'];
+			$model = $query->model();
 
 			if ($group = $args['group']) {
 				$result = $self->invokeMethod('_group', array($group, $args, $options));
-				$config = array('class' => 'set') + compact('query') + $result;
-				return $self->item($query->model(), $config['data'], $config);
+				$config = array('class' => 'set', 'defaults' => false) + compact('query') + $result;
+				return $model::create($config['data'], $config);
 			}
 			$collection = $self->connection->{$source};
 
@@ -493,8 +494,8 @@ class MongoDb extends \lithium\data\Source {
 
 			$resource = $result->sort($args['order'])->limit($args['limit'])->skip($args['offset']);
 			$result = $self->invokeMethod('_instance', array('result', compact('resource')));
-			$config = compact('result', 'query') + array('class' => 'set');
-			return $self->item($query->model(), array(), $config);
+			$config = compact('result', 'query') + array('class' => 'set', 'defaults' => false);
+			return $model::create(array(), $config);
 		});
 	}
 

--- a/data/source/http/adapter/CouchDb.php
+++ b/data/source/http/adapter/CouchDb.php
@@ -266,8 +266,10 @@ class CouchDb extends \lithium\data\source\Http {
 				$stats = $result;
 			}
 			$stats += array('total_rows' => null, 'offset' => null);
-			$opts = compact('stats') + array('class' => 'set', 'exists' => true);
-			return $self->item($query->model(), $data, $opts);
+			$opts = compact('stats') + array(
+				'class' => 'set', 'exists' => true, 'defaults' => false
+			);
+			return $model::create($data, $opts);
 		});
 	}
 

--- a/tests/cases/data/ModelTest.php
+++ b/tests/cases/data/ModelTest.php
@@ -687,6 +687,13 @@ class ModelTest extends \lithium\test\Unit {
 		$expected = 'mock_creators';
 		$result = MockCreator::meta('source');
 		$this->assertEqual($expected, $result);
+
+		$creator = MockCreator::create(array('name' => 'Homer'), array('defaults' => false));
+		$expected = array(
+			'name' => 'Homer'
+		);
+		$result = $creator->data();
+		$this->assertEqual($expected, $result);
 	}
 
 	public function testModelWithNoBackend() {


### PR DESCRIPTION
Moving this step up will allow more flexibility on how itemization is done. You can now configure/modify adatpt the item right from a model.

Use case:
- [STI](http://en.wikipedia.org/wiki/Single_Table_Inheritance) (i.e. changing the model name on the fly)
- processing the datas (date format or adding a virtual field (e.g fullName = lastName + firstName)
- first step to solve #958, shouldn't be harder to now pass some custom handlers for `Document`.
