### PR TITLE
Fix Database::_sort outputs empty ORDER BY clauses

### DIFF
--- a/data/source/Database.php
+++ b/data/source/Database.php
@@ -1243,7 +1243,7 @@ abstract class Database extends \lithium\data\Source {
 			$field = array($field => $direction);
 		}
 
-		if (!is_array($field)) {
+		if (!is_array($field) || empty($field)) {
 			return;
 		}
 		$result = array();

--- a/tests/cases/data/source/DatabaseTest.php
+++ b/tests/cases/data/source/DatabaseTest.php
@@ -607,6 +607,10 @@ class DatabaseTest extends \lithium\test\Unit {
 		$result = $this->_db->order(array('author_id', "title" => "DESC"), $query);
 		$expected = 'ORDER BY {MockDatabasePost}.{author_id} ASC, {MockDatabasePost}.{title} DESC';
 		$this->assertEqual($expected, $result);
+
+		$result = $this->_db->order(array(), $query);
+		$expected = '';
+		$this->assertEqual($expected, $result);
 	}
 
 	public function testOrderOnRelated() {


### PR DESCRIPTION
Will not output ORDER BY clause if given field is empty (ie. if  = array()).

Fixes #986.
