### PR TITLE
Skip tests which require Mongo if Mongo is not installed (close #991).

### DIFF
--- a/data/Schema.php
+++ b/data/Schema.php
@@ -24,7 +24,7 @@ class Schema extends \lithium\core\Object implements \ArrayAccess {
 
 	protected $_types = array();
 
-	protected $_autoConfig = array('fields', 'meta', 'locked');
+	protected $_autoConfig = array('fields', 'meta', 'locked', 'types');
 
 	public function __construct(array $config = array()) {
 		$defaults = array('fields' => array());

--- a/tests/cases/data/source/mongo_db/ExporterTest.php
+++ b/tests/cases/data/source/mongo_db/ExporterTest.php
@@ -453,6 +453,18 @@ class ExporterTest extends \lithium\test\Unit {
 		$result = Exporter::get('update', $doc->export());
 		$this->assertEqual($result['update'], $data);
 	}
+
+	public function testArrayConversion() {
+		$time = time();
+		$doc = new Document(array('data' => array(
+			'_id' => new MongoId(),
+			'date' => new MongoDate($time)
+		)));
+		$result = $doc->data();
+		$this->assertPattern('/^[a-f0-9]{24}$/', $result['_id']);
+		$this->assertEqual($time, $result['date']);
+	}
+
 	/**
 	 * Allow basic type field to be replaced by a `Document` / `DocumentSet` type.
 	 */

--- a/tests/cases/data/source/mongo_db/SchemaTest.php
+++ b/tests/cases/data/source/mongo_db/SchemaTest.php
@@ -14,14 +14,14 @@ use lithium\data\source\mongo_db\Schema;
 
 class SchemaTest extends \lithium\test\Unit {
 
-	public $db;
+	protected $_db;
 
 	public function skip() {
 		$this->skipIf(!MongoDb::enabled(), 'MongoDb is not enabled');
 	}
 
 	public function setUp() {
-		$this->db = new MongoDb(array('autoConnect' => false));
+		$this->_db = new MongoDb(array('autoConnect' => false));
 	}
 
 	public function testCastingIdArray() {
@@ -31,7 +31,7 @@ class SchemaTest extends \lithium\test\Unit {
 		)));
 
 		$result = $schema->cast(null, null, array('users' => new MongoId()), array(
-			'database' => $this->db
+			'database' => $this->_db
 		));
 
 		$this->assertEqual(array('users'), array_keys($result->data()));
@@ -44,7 +44,7 @@ class SchemaTest extends \lithium\test\Unit {
 			'_id' => array('type' => 'id'),
 			'foo' => array('type' => 'string', 'array' => true)
 		)));
-		$result = $schema->cast(null, null, null, array('database' => $this->db));
+		$result = $schema->cast(null, null, null, array('database' => $this->_db));
 	}
 }
 


### PR DESCRIPTION
Ok looks like the common collection stuff are tested in `lithium\tests\cases\data\CollectionTest.php`. `DocumentSetTest` & `DocumetTest` seems using `lithium\data\source\mongo_db\Schema` to perform some casting tests. Maybe this will need to be refactored but skipping test would be fine for now.
