### PR TITLE
Implementation of translation contexts.

### DIFF
--- a/g11n/catalog/Adapter.php
+++ b/g11n/catalog/Adapter.php
@@ -83,6 +83,10 @@ class Adapter extends \lithium\core\Object {
 		);
 		$item += $defaults;
 
+		if (isset($item['context']) && $item['context']) {
+			$id .= '|' . $item['context'];
+		}
+
 		if (!isset($data[$id])) {
 			$data[$id] = $item;
 			return $data;

--- a/g11n/catalog/adapter/Php.php
+++ b/g11n/catalog/adapter/Php.php
@@ -92,7 +92,10 @@ class Php extends \lithium\g11n\catalog\Adapter {
 
 		if (file_exists($file)) {
 			foreach (require $file as $id => $translated) {
-				$data = $this->_merge($data, compact('id', 'translated'));
+				if (strpos($id, '|') !== false) {
+					list($id, $context) = explode('|', $id);
+				}
+				$data = $this->_merge($data, compact('id', 'translated', 'context'));
 			}
 		}
 		return $data;

--- a/tests/cases/console/command/g11n/ExtractTest.php
+++ b/tests/cases/console/command/g11n/ExtractTest.php
@@ -124,6 +124,233 @@ EOD;
 		$result = $this->command->response->error;
 		$this->assertEmpty($result);
 	}
+
+	public function testContextsMultiple() {
+		$file = "{$this->_path}/source/a.html.php";
+		$data = <<<EOD
+<h2>Balls</h2>
+<?=\$t('Ball', array('context' => 'Spherical object')); ?>
+<?=\$t('Ball', array('context' => 'Social gathering')); ?>
+<?=\$t('Ball'); ?>
+EOD;
+		file_put_contents($file, $data);
+
+		$configs = Catalog::config();
+		$configKey1 = key($configs);
+		next($configs);
+		$configKey2 = key($configs);
+		$this->_writeInput(array($configKey1, $configKey2, '', 'y'));
+		$result = $this->command->run();
+		$expected = 0;
+		$this->assertIdentical($expected, $result);
+
+		$expected = '/.*Yielded 3 item.*/';
+		$result = $this->command->response->output;
+		$this->assertPattern($expected, $result);
+
+		$file = "{$this->_path}/destination/message_default.pot";
+		$this->assertFileExists($file);
+
+		$result = file_get_contents($file);
+
+		$expected = '#/tmp/tests/source(/|\\\\)a.html.php:2';
+		$expected .= "\n";
+		$expected .= 'msgctxt "Spherical object"';
+		$expected .= "\n";
+		$expected .= 'msgid "Ball"#';
+		$this->assertPattern($expected, $result);
+
+		$expected = '#/tmp/tests/source(/|\\\\)a.html.php:3';
+		$expected .= "\n";
+		$expected .= 'msgctxt "Social gathering"';
+		$expected .= "\n";
+		$expected .= 'msgid "Ball"#';
+		$this->assertPattern($expected, $result);
+
+		$expected = '#/tmp/tests/source(/|\\\\)a.html.php:4';
+		$expected .= "\n";
+		$expected .= 'msgid "Ball"#';
+		$this->assertPattern($expected, $result);
+
+		$result = $this->command->response->error;
+		$this->assertEmpty($result);
+	}
+
+	public function testContextsWithMultipleOccurences() {
+		$file = "{$this->_path}/source/a.html.php";
+		$data = <<<EOD
+<h2>Balls</h2>
+<?=\$t('Ball', array('context' => 'Spherical object')); ?>
+<?=\$t('Ball', array('context' => 'Social gathering')); ?>
+<?=\$t('Ball'); ?>
+<?=\$t('Ball', array('context' => 'Social gathering')); ?>
+EOD;
+		file_put_contents($file, $data);
+
+		$configs = Catalog::config();
+		$configKey1 = key($configs);
+		next($configs);
+		$configKey2 = key($configs);
+		$this->_writeInput(array($configKey1, $configKey2, '', 'y'));
+		$result = $this->command->run();
+		$expected = 0;
+		$this->assertIdentical($expected, $result);
+
+		$expected = '/.*Yielded 3 item.*/';
+		$result = $this->command->response->output;
+		$this->assertPattern($expected, $result);
+
+		$file = "{$this->_path}/destination/message_default.pot";
+		$this->assertFileExists($file);
+
+		$result = file_get_contents($file);
+
+		$expected = '#/tmp/tests/source(/|\\\\)a.html.php:3';
+		$expected .= "\n";
+		$expected .= '.*/tmp/tests/source(/|\\\\)a.html.php:5';
+		$expected .= "\n";
+		$expected .= 'msgctxt "Social gathering"';
+		$expected .= "\n";
+		$expected .= 'msgid "Ball"#';
+		$this->assertPattern($expected, $result);
+
+		$result = $this->command->response->error;
+		$this->assertEmpty($result);
+	}
+
+	public function testContextsWithOtherParams() {
+		$file = "{$this->_path}/source/a.html.php";
+		$data = <<<EOD
+<?=\$t('Ball', array('context' => 'Social gathering', 'foo' => 'bar')); ?>
+<?=\$t('Ball', array('foo' => 123, 'bar' => baz(), 'context' => 'Spherical object')); ?>
+EOD;
+		file_put_contents($file, $data);
+
+		$configs = Catalog::config();
+		$configKey1 = key($configs);
+		next($configs);
+		$configKey2 = key($configs);
+		$this->_writeInput(array($configKey1, $configKey2, '', 'y'));
+		$result = $this->command->run();
+		$expected = 0;
+		$this->assertIdentical($expected, $result);
+
+		$expected = '/.*Yielded 2 item.*/';
+		$result = $this->command->response->output;
+		$this->assertPattern($expected, $result);
+
+		$file = "{$this->_path}/destination/message_default.pot";
+		$this->assertFileExists($file);
+
+		$result = file_get_contents($file);
+
+		$expected = '#/tmp/tests/source(/|\\\\)a.html.php:1';
+		$expected .= "\n";
+		$expected .= 'msgctxt "Social gathering"';
+		$expected .= "\n";
+		$expected .= 'msgid "Ball"#';
+		$this->assertPattern($expected, $result);
+
+		$expected = '#/tmp/tests/source(/|\\\\)a.html.php:2';
+		$expected .= "\n";
+		$expected .= 'msgctxt "Spherical object"';
+		$expected .= "\n";
+		$expected .= 'msgid "Ball"#';
+		$this->assertPattern($expected, $result);
+
+		$result = $this->command->response->error;
+		$this->assertEmpty($result);
+	}
+
+	public function testContextsWithAmbiguousContextTokens() {
+		$file = "{$this->_path}/source/a.html.php";
+		$data = <<<EOD
+<?=\$t('Ball', array('context', 'foo' => 'context', 'context' => 'Spherical object')); ?>
+<?=\$t('Ball', array('foo' => \$t('context'), 'context' => 'Social gathering')); ?>
+EOD;
+		file_put_contents($file, $data);
+
+		$configs = Catalog::config();
+		$configKey1 = key($configs);
+		next($configs);
+		$configKey2 = key($configs);
+		$this->_writeInput(array($configKey1, $configKey2, '', 'y'));
+		$result = $this->command->run();
+		$expected = 0;
+		$this->assertIdentical($expected, $result);
+
+		$file = "{$this->_path}/destination/message_default.pot";
+		$this->assertFileExists($file);
+
+		$result = file_get_contents($file);
+
+		$expected = '#/tmp/tests/source(/|\\\\)a.html.php:1';
+		$expected .= "\n";
+		$expected .= 'msgctxt "Spherical object"';
+		$expected .= "\n";
+		$expected .= 'msgid "Ball"#';
+		$this->assertPattern($expected, $result);
+
+		$expected = '#/tmp/tests/source(/|\\\\)a.html.php:2';
+		$expected .= "\n";
+		$expected .= 'msgctxt "Social gathering"';
+		$expected .= "\n";
+		$expected .= 'msgid "Ball"#';
+		$this->assertPattern($expected, $result);
+
+		$result = $this->command->response->error;
+		$this->assertEmpty($result);
+	}
+
+	public function testContextsNested() {
+		$file = "{$this->_path}/source/a.html.php";
+		$data = <<<EOD
+<?=\$t('Robin, {:a}', array('a' => \$t('Michael, {:b}', array('b' => \$t('Bruce', array('context' => 'Lee')), 'context' => 'Jackson')), 'context' => 'Hood')); ?>
+EOD;
+		file_put_contents($file, $data);
+
+		$configs = Catalog::config();
+		$configKey1 = key($configs);
+		next($configs);
+		$configKey2 = key($configs);
+		$this->_writeInput(array($configKey1, $configKey2, '', 'y'));
+		$result = $this->command->run();
+		$expected = 0;
+		$this->assertIdentical($expected, $result);
+
+		$expected = '/.*Yielded 3 item.*/';
+		$result = $this->command->response->output;
+		$this->assertPattern($expected, $result);
+
+		$file = "{$this->_path}/destination/message_default.pot";
+		$this->assertFileExists($file);
+
+		$result = file_get_contents($file);
+
+		$expected = '#/tmp/tests/source(/|\\\\)a.html.php:1';
+		$expected .= "\n";
+		$expected .= 'msgctxt "Hood"';
+		$expected .= "\n";
+		$expected .= 'msgid "Robin, {:a}"#';
+		$this->assertPattern($expected, $result);
+
+		$expected = '#/tmp/tests/source(/|\\\\)a.html.php:1';
+		$expected .= "\n";
+		$expected .= 'msgctxt "Jackson"';
+		$expected .= "\n";
+		$expected .= 'msgid "Michael, {:b}"#';
+		$this->assertPattern($expected, $result);
+
+		$expected = '#/tmp/tests/source(/|\\\\)a.html.php:1';
+		$expected .= "\n";
+		$expected .= 'msgctxt "Lee"';
+		$expected .= "\n";
+		$expected .= 'msgid "Bruce"#';
+		$this->assertPattern($expected, $result);
+
+		$result = $this->command->response->error;
+		$this->assertEmpty($result);
+	}
 }
 
 ?>

--- a/tests/cases/g11n/MessageTest.php
+++ b/tests/cases/g11n/MessageTest.php
@@ -200,6 +200,28 @@ class MessageTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 	}
 
+	public function testTranslateContext() {
+		$data = array(
+			'fast|speed' => 'rapide',
+			'fast|go without food' => 'jeûner'
+		);
+		Catalog::write('runtime', 'message', 'fr', $data);
+
+		$expected = 'rapide';
+		$result = Message::translate('fast', array(
+			'locale' => 'fr',
+			'context' => 'speed'
+		));
+		$this->assertEqual($expected, $result);
+
+		$expected = 'jeûner';
+		$result = Message::translate('fast', array(
+			'locale' => 'fr',
+			'context' => 'go without food'
+		));
+		$this->assertEqual($expected, $result);
+	}
+
 	public function testTranslateLocales() {
 		$data = array(
 			'catalog' => 'Katalog'

--- a/tests/cases/g11n/catalog/AdapterTest.php
+++ b/tests/cases/g11n/catalog/AdapterTest.php
@@ -370,6 +370,79 @@ class AdapterTest extends \lithium\test\Unit {
 		$result = $this->adapter->merge($data, $item);
 		$this->assertEqual($expected, $result);
 	}
+
+	public function testMergeWithContexts() {
+		$item = array(
+			'id' => 'test',
+			'ids' => array('singular' => 'a')
+		);
+		$data = $this->adapter->merge(array(), $item);
+
+		$item = array(
+			'id' => 'test',
+			'ids' => array('singular' => 'X', 'plural' => 'b')
+		);
+		$data = $this->adapter->merge($data, $item);
+
+		$item = array(
+			'id' => 'test',
+			'ids' => array('singular' => 'a'),
+			'context' => 'A'
+		);
+		$data = $this->adapter->merge($data, $item);
+
+		$item = array(
+			'id' => 'test',
+			'ids' => array('singular' => 'X', 'plural' => 'b'),
+			'context' => 'A'
+		);
+		$data = $this->adapter->merge($data, $item);
+
+		$item = array(
+			'id' => 'test',
+			'ids' => array('singular' => 'a'),
+			'context' => 'B'
+		);
+		$data = $this->adapter->merge($data, $item);
+
+		$item = array(
+			'id' => 'test',
+			'ids' => array('singular' => 'X', 'plural' => 'b'),
+			'context' => 'B'
+		);
+		$data = $this->adapter->merge($data, $item);
+
+		$expected = array(
+			'test' => array(
+				'id' => 'test',
+				'ids' => array('singular' => 'X', 'plural' => 'b'),
+				'translated' => null,
+				'flags' => array(),
+				'comments' => array(),
+				'occurrences' => array()
+			),
+			'test|A' => array(
+				'id' => 'test',
+				'ids' => array('singular' => 'X', 'plural' => 'b'),
+				'translated' => null,
+				'flags' => array(),
+				'comments' => array(),
+				'occurrences' => array(),
+				'context' => 'A'
+			),
+			'test|B' => array(
+				'id' => 'test',
+				'ids' => array('singular' => 'X', 'plural' => 'b'),
+				'translated' => null,
+				'flags' => array(),
+				'comments' => array(),
+				'occurrences' => array(),
+				'context' => 'B'
+			)
+		);
+		$result = $this->adapter->merge($data, $item);
+		$this->assertEqual($expected, $result);
+	}
 }
 
 ?>

--- a/tests/cases/g11n/catalog/adapter/CodeTest.php
+++ b/tests/cases/g11n/catalog/adapter/CodeTest.php
@@ -33,6 +33,14 @@ $t('options 1', null, array('locale' => 'en'));
 
 $t('replace 1 {:a}', array('a' => 'b'));
 
+$t('simple context', array('context' => 'foo'));
+$t('simple context', array('context' => 'bar'));
+
+$t('replace context 1 {:a}', array('a' => 'b', 'context' => 'foo'));
+$t('replace context 1 {:a}', array('a' => 'b', 'context' => 'bar'));
+$t('replace context 2 {:a}', array('context' => 'foo', 'a' => 'b'));
+$t('replace context 2 {:a}', array('context' => 'bar', 'a' => 'b'));
+
 $t($test['invalid']);
 $t(32203);
 $t('invalid 1', $test['invalid']);
@@ -121,6 +129,51 @@ EOD;
 
 		$expected = array('singular' => 'replace 1 {:a}');
 		$result = $results['replace 1 {:a}']['ids'];
+		$this->assertEqual($expected, $result);
+	}
+
+	public function testReadMessageTemplateTContext() {
+		$results = $this->adapter->read('messageTemplate', 'root', null);
+
+		$this->assertArrayHasKey('simple context|foo', $results);
+		$this->assertArrayHasKey('simple context|bar', $results);
+
+		$this->assertArrayHasKey('replace context 1 {:a}|foo', $results);
+		$this->assertArrayHasKey('replace context 1 {:a}|bar', $results);
+
+		$this->assertArrayHasKey('replace context 2 {:a}|foo', $results);
+		$this->assertArrayHasKey('replace context 2 {:a}|bar', $results);
+
+		$expected = array('ids' => array('singular' => 'simple context'), 'context' => 'foo');
+		$key = 'simple context|foo';
+		if (!isset($results[$key])) {
+			$this->expectException();
+		}
+		$result = array('ids' => $results[$key]['ids'],	'context' => 'foo');
+		$this->assertEqual($expected, $result);
+
+		$expected = array('ids' => array('singular' => 'simple context'), 'context' => 'bar');
+		$key = 'simple context|bar';
+		if (!isset($results[$key])) {
+			$this->expectException();
+		}
+		$result = array('ids' => $results[$key]['ids'],	'context' => 'bar');
+		$this->assertEqual($expected, $result);
+
+		$expected = array('ids' => array('singular' => 'replace context 1 {:a}'), 'context' => 'foo');
+		$key = 'replace context 1 {:a}|foo';
+		if (!isset($results[$key])) {
+			$this->expectException();
+		}
+		$result = array('ids' => $results[$key]['ids'],	'context' => 'foo');
+		$this->assertEqual($expected, $result);
+
+		$expected = array('ids' => array('singular' => 'replace context 1 {:a}'), 'context' => 'bar');
+		$key = 'replace context 1 {:a}|bar';
+		if (!isset($results[$key])) {
+			$this->expectException();
+		}
+		$result = array('ids' => $results[$key]['ids'],	'context' => 'bar');
 		$this->assertEqual($expected, $result);
 	}
 

--- a/tests/cases/g11n/catalog/adapter/GettextTest.php
+++ b/tests/cases/g11n/catalog/adapter/GettextTest.php
@@ -72,7 +72,8 @@ class GettextTest extends \lithium\test\Unit {
 				),
 				'comments' => array(
 					'comment 1'
-				)
+				),
+				'context' => null
 			)
 		);
 
@@ -100,7 +101,33 @@ EOD;
 				'flags' => array(),
 				'translated' => 'translated 1',
 				'occurrences' => array(),
-				'comments' => array()
+				'comments' => array(),
+				'context' => null
+			)
+		);
+		$result = $this->adapter->read('message', 'de', null);
+		unset($result['pluralRule']);
+		$this->assertEqual($expected, $result);
+	}
+
+	public function testReadPoSingleItemWithContext() {
+		$file = "{$this->_path}/de/LC_MESSAGES/default.po";
+		$data = <<<EOD
+msgctxt "A"
+msgid "singular 1"
+msgstr "translated 1"
+EOD;
+		file_put_contents($file, $data);
+
+		$expected = array(
+			'singular 1|A' => array(
+				'id' => 'singular 1',
+				'ids' => array('singular' => 'singular 1'),
+				'flags' => array(),
+				'translated' => 'translated 1',
+				'occurrences' => array(),
+				'comments' => array(),
+				'context' => 'A'
 			)
 		);
 		$result = $this->adapter->read('message', 'de', null);
@@ -116,6 +143,17 @@ msgstr "translated 1"
 
 msgid "singular 2"
 msgstr "translated 2"
+
+msgid "context"
+msgstr "context (none specified)"
+
+msgctxt "A"
+msgid "context"
+msgstr "context A"
+
+msgctxt "B"
+msgid "context"
+msgstr "context B"
 EOD;
 		file_put_contents($file, $data);
 
@@ -126,7 +164,8 @@ EOD;
 				'flags' => array(),
 				'translated' => 'translated 1',
 				'occurrences' => array(),
-				'comments' => array()
+				'comments' => array(),
+				'context' => null
 			),
 			'singular 2' => array(
 				'id' => 'singular 2',
@@ -134,7 +173,35 @@ EOD;
 				'flags' => array(),
 				'translated' => 'translated 2',
 				'occurrences' => array(),
-				'comments' => array()
+				'comments' => array(),
+				'context' => null
+			),
+			'context' => array(
+				'id' => 'context',
+				'ids' => array('singular' => 'context'),
+				'flags' => array(),
+				'translated' => 'context (none specified)',
+				'occurrences' => array(),
+				'comments' => array(),
+				'context' => null
+			),
+			'context|A' => array(
+				'id' => 'context',
+				'ids' => array('singular' => 'context'),
+				'flags' => array(),
+				'translated' => 'context A',
+				'occurrences' => array(),
+				'comments' => array(),
+				'context' => 'A'
+			),
+			'context|B' => array(
+				'id' => 'context',
+				'ids' => array('singular' => 'context'),
+				'flags' => array(),
+				'translated' => 'context B',
+				'occurrences' => array(),
+				'comments' => array(),
+				'context' => 'B'
 			)
 		);
 		$result = $this->adapter->read('message', 'de', null);
@@ -159,7 +226,8 @@ EOD;
 				'flags' => array(),
 				'translated' => array('translated 1-0', 'translated 1-1'),
 				'occurrences' => array(),
-				'comments' => array()
+				'comments' => array(),
+				'context' => null
 			)
 		);
 		$result = $this->adapter->read('message', 'de', null);
@@ -202,7 +270,8 @@ EOD;
 				'flags' => array(),
 				'translated' => 'translated 1',
 				'occurrences' => array(),
-				'comments' => array()
+				'comments' => array(),
+				'context' => null
 			)
 		);
 		$result = $this->adapter->read('message', 'de', null);
@@ -248,7 +317,8 @@ EOD;
 				'comments' => array(
 					'extracted comment',
 					'translator comment'
-				)
+				),
+				'context' => null
 			)
 		);
 		$po = <<<EOD
@@ -300,7 +370,8 @@ EOD;
 				'flags' => array(),
 				'translated' => 'This is a translation spanning multiple lines.',
 				'occurrences' => array(),
-				'comments' => array()
+				'comments' => array(),
+				'context' => null
 			)
 		);
 		$result = $this->adapter->read('message', 'de', null);
@@ -327,7 +398,8 @@ EOD;
 				'flags' => array(),
 				'translated' => 'This is a translation spanning multiple lines.',
 				'occurrences' => array(),
-				'comments' => array()
+				'comments' => array(),
+				'context' => null
 			)
 		);
 		$result = $this->adapter->read('message', 'de', null);
@@ -363,7 +435,8 @@ EOD;
 					'This is a plural translation spanning multiple lines.'
 				),
 				'occurrences' => array(),
-				'comments' => array()
+				'comments' => array(),
+				'context' => null
 			)
 		);
 		$result = $this->adapter->read('message', 'de', null);
@@ -416,7 +489,8 @@ EOD;
 				'flags' => array(),
 				'translated' => array('translated 1-0', 'translated 1-1'),
 				'occurrences' => array(),
-				'comments' => array()
+				'comments' => array(),
+				'context' => null
 			),
 			'singular 2' => array(
 				'id' => 'singular 2',
@@ -424,7 +498,8 @@ EOD;
 				'flags' => array(),
 				'translated' => 'translated 2',
 				'occurrences' => array(),
-				'comments' => array()
+				'comments' => array(),
+				'context' => null
 			)
 		);
 		$result = $this->adapter->read('message', 'de', null);
@@ -466,6 +541,69 @@ EOD;
 		$this->assert($result);
 	}
 
+	public function testReadMoWithContext() {
+		$file = "{$this->_path}/de/LC_MESSAGES/default.mo";
+		$data = <<<EOD
+3hIElQAAAAAGAAAAHAAAAEwAAAAAAAAAfAAAAAAAAAB8AAAACQAAAH0AAAAJAAAAhwAAAAcAAACRAAAACgAAAJkAAAAKAAAApAAA
+AAAAAACvAAAACQAAALAAAAAJAAAAugAAABgAAADEAAAADAAAAN0AAAAMAAAA6gAAAABBBGNvbnRleHQAQgRjb250ZXh0AGNvbnRl
+eHQAc2luZ3VsYXIgMQBzaW5ndWxhciAyAABjb250ZXh0IEEAY29udGV4dCBCAGNvbnRleHQgKG5vbmUgc3BlY2lmaWVkKQB0cmFu
+c2xhdGVkIDEAdHJhbnNsYXRlZCAyAA==
+EOD;
+
+		file_put_contents($file, base64_decode($data));
+
+		$expected = array(
+			'singular 1' => array(
+				'id' => 'singular 1',
+				'ids' => array('singular' => 'singular 1', 'plural' => null),
+				'flags' => array(),
+				'translated' => 'translated 1',
+				'occurrences' => array(),
+				'comments' => array(),
+				'context' => null
+			),
+			'singular 2' => array(
+				'id' => 'singular 2',
+				'ids' => array('singular' => 'singular 2', 'plural' => null),
+				'flags' => array(),
+				'translated' => 'translated 2',
+				'occurrences' => array(),
+				'comments' => array(),
+				'context' => null
+			),
+			'context' => array(
+				'id' => 'context',
+				'ids' => array('singular' => 'context', 'plural' => null),
+				'flags' => array(),
+				'translated' => 'context (none specified)',
+				'occurrences' => array(),
+				'comments' => array(),
+				'context' => null
+			),
+			'context|A' => array(
+				'id' => 'context',
+				'ids' => array('singular' => 'context', 'plural' => null),
+				'flags' => array(),
+				'translated' => 'context A',
+				'occurrences' => array(),
+				'comments' => array(),
+				'context' => 'A'
+			),
+			'context|B' => array(
+				'id' => 'context',
+				'ids' => array('singular' => 'context', 'plural' => null),
+				'flags' => array(),
+				'translated' => 'context B',
+				'occurrences' => array(),
+				'comments' => array(),
+				'context' => 'B'
+			)
+		);
+		$result = $this->adapter->read('message', 'de', null);
+		unset($result['pluralRule']);
+		$this->assertEqual($expected, $result);
+	}
+
 	public function testWriteMessageCompilesPo() {
 		$data = array(
 			'singular 1' => array(
@@ -474,7 +612,8 @@ EOD;
 				'flags' => array(),
 				'translated' => array('translated 1'),
 				'occurrences' => array(),
-				'comments' => array()
+				'comments' => array(),
+				'context' => null
 			)
 		);
 		$this->adapter->write('message', 'de', null, $data);
@@ -489,7 +628,8 @@ EOD;
 				'flags' => array(),
 				'translated' => array(),
 				'occurrences' => array(),
-				'comments' => array()
+				'comments' => array(),
+				'context' => null
 			)
 		);
 		$this->adapter->write('messageTemplate', 'root', null, $data);
@@ -510,7 +650,34 @@ EOD;
 				),
 				'comments' => array(
 					'comment 1'
-				)
+				),
+				'context' => null
+			),
+			'singular 1|A' => array(
+				'id' => 'singular 1',
+				'ids' => array('singular' => 'singular 1', 'plural' => 'plural 1'),
+				'flags' => array('fuzzy' => true),
+				'translated' => array('translated singular 1A', 'translated plural 1A'),
+				'occurrences' => array(
+					array('file' => 'test.php', 'line' => 2)
+				),
+				'comments' => array(
+					'comment 1a'
+				),
+				'context' => 'A'
+			),
+			'singular 1|B' => array(
+				'id' => 'singular 1',
+				'ids' => array('singular' => 'singular 1', 'plural' => 'plural 1'),
+				'flags' => array('fuzzy' => true),
+				'translated' => array('translated singular 1B', 'translated plural 1B'),
+				'occurrences' => array(
+					array('file' => 'test.php', 'line' => 2)
+				),
+				'comments' => array(
+					'comment 1b'
+				),
+				'context' => 'B'
 			)
 		);
 
@@ -535,7 +702,8 @@ EOD;
 				'flags' => array(),
 				'translated' => array('translated 1-0', 'translated 1-1'),
 				'occurrences' => array(),
-				'comments' => array()
+				'comments' => array(),
+				'context' => null
 			),
 			'singular 2' => array(
 				'id' => 'singular 2',
@@ -543,7 +711,8 @@ EOD;
 				'flags' => array(),
 				'translated' => array('translated 2'),
 				'occurrences' => array(),
-				'comments' => array()
+				'comments' => array(),
+				'context' => null
 			)
 		);
 		$this->adapter->write('message', 'de', null, $data);
@@ -592,7 +761,8 @@ EOD;
 				'flags' => array(),
 				'translated' => '/[0-9].*/i',
 				'occurrences' => array(),
-				'comments' => array()
+				'comments' => array(),
+				'context' => null
 			)
 		);
 		$po = <<<EOD
@@ -625,7 +795,8 @@ EOD;
 					array('file' => Libraries::get(true, 'path') . '/testa.php', 'line' => 22),
 					array('file' => '/testb.php', 'line' => 23)
 				),
-				'comments' => array()
+				'comments' => array(),
+				'context' => null
 			)
 		);
 		$this->adapter->write('messageTemplate', 'root', null, $data);
@@ -688,7 +859,8 @@ EOD;
 					'flags' => array(),
 					'translated' => "this is the{$unescaped}translation",
 					'occurrences' => array(),
-					'comments' => array()
+					'comments' => array(),
+					'context' => null
 				)
 			);
 			$po = <<<EOD
@@ -726,7 +898,8 @@ EOD;
 				'flags' => array(),
 				'translated' => "this is the\r\ntranslation",
 				'occurrences' => array(),
-				'comments' => array()
+				'comments' => array(),
+				'context' => null
 			)
 		);
 		$po = <<<EOD
@@ -750,7 +923,8 @@ EOD;
 				'flags' => array(),
 				'translated' => "this is the\\'translation",
 				'occurrences' => array(),
-				'comments' => array()
+				'comments' => array(),
+				'context' => null
 			)
 		);
 		$po = <<<EOD
@@ -774,7 +948,8 @@ EOD;
 				'flags' => array(),
 				'translated' => "this is the\\\\translation",
 				'occurrences' => array(),
-				'comments' => array()
+				'comments' => array(),
+				'context' => null
 			)
 		);
 		$po = <<<EOD

--- a/tests/cases/g11n/catalog/adapter/PhpTest.php
+++ b/tests/cases/g11n/catalog/adapter/PhpTest.php
@@ -146,6 +146,52 @@ EOD;
 		$this->assertEqual($expected, $result);
 	}
 
+	public function testReadWithContext() {
+		mkdir("{$this->_path}/fr/message", 0755, true);
+
+		$data = <<<EOD
+<?php
+return array(
+	'green' => 'vert',
+	'fast|speed' => 'rapide',
+	'fast|go without food' => 'jeûner'
+);
+?>
+EOD;
+		file_put_contents("{$this->_path}/fr/message/default.php", $data);
+
+		$result = $this->adapter->read('message', 'fr', null);
+		$expected = array(
+			'green' => array(
+				'id' => 'green',
+				'ids' => array(),
+				'translated' => 'vert',
+				'flags' => array(),
+				'comments' => array(),
+				'occurrences' => array()
+			),
+			'fast|speed' => array(
+				'id' => 'fast',
+				'ids' => array(),
+				'translated' => 'rapide',
+				'flags' => array(),
+				'comments' => array(),
+				'occurrences' => array(),
+				'context' => 'speed'
+			),
+			'fast|go without food' => array(
+				'id' => 'fast',
+				'ids' => array(),
+				'translated' => 'jeûner',
+				'flags' => array(),
+				'comments' => array(),
+				'occurrences' => array(),
+				'context' => 'go without food'
+			)
+		);
+		$this->assertEqual($expected, $result);
+	}
+
 	public function testReadValidation() {
 		mkdir("{$this->_path}/fr/validation", 0755, true);
 


### PR DESCRIPTION
# Overview

This update implements support for translation contexts. With this, a disambiguating context can be specified across identical strings:

``` php
<?php
// Three unique translations: 
?>
<?= $t('Ball', array('context' => 'Spherical object')); ?>
<?= $t('Ball', array('context' => 'Social gathering')); ?>
<?= $t('Ball'); ?> // The null case
```
# Catalog Adapters
## Code

The updated code adapter will parse message contexts from source code, even in situations where insertions and nested syntax are used:

``` php
<?= $t('Robin, {:a}', array('a' => $t('Michael, {:b}', array('b' => $t('Bruce', array('context' => 'Lee')), 'context' => 'Jackson')), 'context' => 'Hood')); ?>
```
## Gettext

The gettext adapter will write contexts using the "msgctxt" string. See http://pology.nedohodnik.net/doc/user/en_US/ch-poformat.html (2.2.2. Disambiguating Contexts):

``` po
# ...
msgctxt "Spherical object"
msgid "Ball"
msgstr ""

# ...
msgctxt "Social gathering"
msgid "Ball"
msgstr ""

# ...
msgid "Ball"
msgstr ""
```

These context strings will be detected when .po and .mo files are read by the gettext adapter, whenever applicable.
## PHP

When reading PHP data, contexts are specified in the array key, delimited by a pipe character. If no context is required (or null context), array keys are the Message ID alone, as usual.

``` php
<?php
return array(
    'green' => 'vert',
    'fast|speed' => 'rapide',
    'fast|go without food' => 'jeûner'
);
?>
```
