### PR TITLE
Let users influence the relationship mode in models

### DIFF
--- a/data/model/Relationship.php
+++ b/data/model/Relationship.php
@@ -98,6 +98,7 @@ class Relationship extends \lithium\core\Object {
 	 *          other database-native value. If an array, maps fields from the related object
 	 *          either to fields elsewhere, or to arbitrary expressions. In either case, _the
 	 *          values specified here will be literally interpreted by the database_.
+	 *        - `'mode'` _string_: Join mode to be used for this relationship.
 	 */
 	public function __construct(array $config = array()) {
 		$defaults = array(
@@ -134,11 +135,21 @@ class Relationship extends \lithium\core\Object {
 		}
 	}
 
-	public function data($key = null) {
-		if (!$key) {
+	/**
+	 * Getter/setter for configuration.
+	 *
+	 * @param  string  $key   Key you wish to retrieve, `null` if you want all.
+	 * @param  mixed   $value If provided, will set the value of `$key`.
+	 * @return mixed
+	 */
+	public function data($key = null, $value = false) {
+		if (!$key || !isset($this->_config[$key])) {
 			return $this->_config;
 		}
-		return isset($this->_config[$key]) ? $this->_config[$key] : null;
+		if ($value !== false) {
+			$this->_config[$key] = $value;
+		}
+		return $this->_config[$key];
 	}
 
 	public function __call($name, $args = array()) {

--- a/data/model/Relationship.php
+++ b/data/model/Relationship.php
@@ -109,7 +109,8 @@ class Relationship extends \lithium\core\Object {
 			'link' => static::LINK_KEY,
 			'fields' => true,
 			'fieldName' => null,
-			'constraints' => array()
+			'constraints' => array(),
+			'mode' => 'LEFT'
 		);
 		$config += $defaults;
 		if (!$config['type'] || !$config['fieldName']) {

--- a/data/source/Database.php
+++ b/data/source/Database.php
@@ -1491,8 +1491,9 @@ abstract class Database extends \lithium\data\Source {
 			$constraints = (array) $constraints;
 		}
 
-		$context->joins($toAlias, compact('constraints', 'model') + array(
-			'mode' => 'LEFT',
+		$mode = $rel->mode();
+
+		$context->joins($toAlias, compact('constraints', 'model', 'mode') + array(
 			'alias' => $toAlias
 		));
 	}

--- a/data/source/Database.php
+++ b/data/source/Database.php
@@ -212,12 +212,14 @@ abstract class Database extends \lithium\data\Source {
 						}
 
 						$constraints = array();
+						$mode = $rel->mode();
 						$alias = $name;
 						$relPath = $path ? $path . '.' . $name : $name;
 						if (isset($with[$relPath])) {
 							list($unallowed, $allowed) = Set::slice($with[$relPath], array(
 								'alias',
-								'constraints'
+								'constraints',
+								'mode',
 							));
 							if ($unallowed) {
 								$message = "Only `'alias'` and `'constraints'` are allowed in ";
@@ -227,6 +229,7 @@ abstract class Database extends \lithium\data\Source {
 							extract($with[$relPath]);
 						}
 						$to = $context->alias($alias, $relPath);
+						$mode = $rel->data('mode', $mode);
 
 						$deps[$to] = $deps[$from];
 						$deps[$to][] = $from;
@@ -236,7 +239,7 @@ abstract class Database extends \lithium\data\Source {
 								'type' => $rel->type(),
 								'model' => $rel->to(),
 								'fieldName' => $rel->fieldName(),
-								'alias' => $to
+								'alias' => $to,
 							));
 							$self->join($context, $rel, $from, $to, $constraints);
 						}

--- a/tests/cases/data/source/DatabaseTest.php
+++ b/tests/cases/data/source/DatabaseTest.php
@@ -877,7 +877,6 @@ class DatabaseTest extends \lithium\test\Unit {
 	}
 
 	public function testReadConditionsWithModel() {
-		$model = $this->_model;
 		$options = array(
 			'type' => 'read',
 			'model' => $this->_model,
@@ -1014,6 +1013,40 @@ class DatabaseTest extends \lithium\test\Unit {
 		$expected .= '{mock_database_comments} AS {MockDatabaseComment} ON ';
 		$expected .= '{MockDatabasePost}.{id} = {MockDatabaseComment}.{mock_database_post_id};';
 		$this->assertEqual($expected, $this->_db->sql);
+	}
+
+	public function testRelationshipModeOverwritten() {
+		$options = array(
+			'type' => 'read',
+			'model' => $this->_model,
+			'with' => array(
+				'MockDatabaseComment' => array(
+					'mode' => 'RIGHT',
+				),
+			),
+		);
+		$result = $this->_db->read(new Query($options), $options);
+		$expected = 'SELECT * FROM {mock_database_posts} AS {MockDatabasePost} RIGHT JOIN ';
+		$expected .= '{mock_database_comments} AS {MockDatabaseComment} ON ';
+		$expected .= '{MockDatabasePost}.{id} = {MockDatabaseComment}.{mock_database_post_id};';
+		$this->assertEqual($expected, $this->_db->sql);
+	}
+
+	public function testRelationshipModeSetInModel() {
+		$model = $this->_model;
+		$instance = $model::invokeMethod('_object');
+		$instance->hasMany['MockDatabaseComment']['mode'] = 'RIGHT';
+		$options = array(
+			'type' => 'read',
+			'model' => $this->_model,
+			'with' => array('MockDatabaseComment'),
+		);
+		$result = $this->_db->read(new Query($options), $options);
+		$expected = 'SELECT * FROM {mock_database_posts} AS {MockDatabasePost} RIGHT JOIN ';
+		$expected .= '{mock_database_comments} AS {MockDatabaseComment} ON ';
+		$expected .= '{MockDatabasePost}.{id} = {MockDatabaseComment}.{mock_database_post_id};';
+		$this->assertEqual($expected, $this->_db->sql);
+		$instance->hasMany['MockDatabaseComment']['mode'] = 'LEFT';
 	}
 
 	public function testReadWithRelationshipWithNullConstraint() {
@@ -1692,6 +1725,7 @@ class DatabaseTest extends \lithium\test\Unit {
 		$expected = "INSERT INTO {mock_database_posts} ({title}) VALUES ('{:foobar}');";
 		$this->assertEqual($expected, $this->_db->sql);
 	}
+
 }
 
 ?>

--- a/tests/mocks/data/model/MockDatabasePost.php
+++ b/tests/mocks/data/model/MockDatabasePost.php
@@ -11,7 +11,9 @@ namespace lithium\tests\mocks\data\model;
 class MockDatabasePost extends \lithium\data\Model {
 
 	public $hasMany = array(
-		'MockDatabaseComment',
+		'MockDatabaseComment' => array(
+			'mode' => 'LEFT',
+		),
 		'MockDatabasePostRevision' => array(
 			'constraints' => array('MockDatabasePostRevision.deleted' => null)
 		)


### PR DESCRIPTION
Now the `mode` can be defined on the relationship or at runtime. Two tests.