### PR TITLE
Feature/action filters

### DIFF
--- a/action/Controller.php
+++ b/action/Controller.php
@@ -126,6 +126,43 @@ class Controller extends \lithium\core\Object {
 	 */
 	protected $_autoConfig = array('render' => 'merge', 'classes' => 'merge');
 
+	/**
+	 * A filter is executed before the current action.
+	 *
+	 * For an filter to always be executed before all actions:
+	 * {{{
+	 * public $beforeFilters = array('findUser');
+	 * }}}
+	 *
+	 * For a filter to be executed before every action except `show` and `index`:
+	 * {{{
+	 * public $beforeFilters = array(
+	 *     'findUser' => array(
+	 *         'except' => array('show', 'index'),
+	 *     )
+	 * );
+	 * }}}
+	 *
+	 * For a filter to be executed only before `show` and `index` actions:
+	 * {{{
+	 * public $beforeFilters = array(
+	 *     'findUser' => array(
+	 *         'only' => array('show', 'index'),
+	 *     )
+	 * );
+	 * }}}
+	 * @var array
+	 */
+	public $beforeFilters = array();
+
+	/**
+	 * Filters to be executed after the current action.
+	 *
+	 * @see lithium\action\Controller::$beforeFilters For examples.
+	 * @var array
+	 */
+	public $afterFilters = array();
+
 	public function __construct(array $config = array()) {
 		$defaults = array(
 			'request' => null, 'response' => array(), 'render' => array(), 'classes' => array()
@@ -194,13 +231,15 @@ class Controller extends \lithium\core\Object {
 			}
 			$render['template'] = $render['template'] ?: $action;
 
+			$self->callFilters($action, $self->beforeFilters);
 			if ($result = $self->invokeMethod($action, $args)) {
+				if (is_array($result)) {
+					$self->set($result);
+				}
+				$self->callFilters($action, $self->afterFilters);
 				if (is_string($result)) {
 					$self->render(array('text' => $result));
 					return $self->response;
-				}
-				if (is_array($result)) {
-					$self->set($result);
 				}
 			}
 
@@ -209,6 +248,82 @@ class Controller extends \lithium\core\Object {
 			}
 			return $self->response;
 		});
+	}
+
+	/**
+	 * Calls the given filters based on the current action.
+	 *
+	 * @param  string $action
+	 * @param  array  $filters
+	 * @return void
+	 */
+	public function callFilters($action, $filters) {
+		foreach ($filters as $key => $value) {
+			$data = $this->_parseFilter($key, $value);
+			if ($this->_usableFilter($action, $data['options'])) {
+				$this->{$data['method']}();
+			}
+		}
+		return;
+	}
+
+	/**
+	 * Determines if a filter can be called on this action.
+	 *
+	 * @param  string $action  Current action.
+	 * @param  array  $options Can contain none or all of the following:
+	 *        - `'only'` _array_: Actions the filter should ONLY be applied on.
+	 *        - `'except'` _array_: Actions the filter should NOT be applied on.
+	 * @return bool
+	 */
+	protected function _usableFilter($action, $options) {
+		if (empty($options)) {
+			return true;
+		}
+		if (isset($options['only'])) {
+			return in_array($action, (array) $options['only']);
+		}
+		return !in_array($action, (array) $options['except']);
+	}
+
+	/**
+	 * Parses the current filter.
+	 *
+	 * {{{
+	 * $this->_parseFilter(0, 'name');
+	 * array(
+	 *     'method' => 'name',
+	 *     'options' => array(),
+	 * )
+	 * }}}
+	 *
+	 * {{{
+	 * $this->_parseFilter('foobar', array(
+	 *     'only' => array('index'),
+	 * ));
+	 * array(
+	 *     'method' => 'foobar',
+	 *     'options' => array(
+	 *         'only' => array('index'),
+	 *     ),
+	 * )
+	 * }}}
+	 *
+	 * @param  mixed $key
+	 * @param  mixed $value
+	 * @return array
+	 */
+	protected function _parseFilter($key, $value) {
+		if (is_int($key)) {
+			return array(
+				'method' => $value,
+				'options' => array(),
+			);
+		}
+		return array(
+			'method' => $key,
+			'options' => $value,
+		);
 	}
 
 	/**

--- a/test/Mocker.php
+++ b/test/Mocker.php
@@ -486,7 +486,7 @@ class Mocker {
 
 		$reflectedClass = new ReflectionClass($mocker);
 		$reflecedMethods = $reflectedClass->getMethods();
-		$getByReference = false;
+		$getByReference = true;
 		$staticApplyFilter = true;
 		$constructor = false;
 		foreach ($reflecedMethods as $methodId => $method) {

--- a/tests/cases/action/ControllerTest.php
+++ b/tests/cases/action/ControllerTest.php
@@ -9,11 +9,18 @@
 namespace lithium\tests\cases\action;
 
 use lithium\action\Request;
+use lithium\test\Mocker;
 use lithium\tests\mocks\action\MockPostsController;
 use lithium\tests\mocks\action\MockRenderAltController;
 use lithium\tests\mocks\action\MockControllerRequest;
+use lithium\tests\mocks\action\mockPostsController\Mock as DoubleMockController;
 
 class ControllerTest extends \lithium\test\Unit {
+
+	public function setUp() {
+		Mocker::register();
+		Mocker::applyFilter(false);
+	}
 
 	/**
 	 * Tests that controllers can be instantiated with custom request objects.
@@ -378,6 +385,210 @@ class ControllerTest extends \lithium\test\Unit {
 		$controller->render();
 		$this->assertEqual('lithium', $controller->response->options['library']);
 	}
+
+	public function testParseFilterBasicString() {
+		$controller = new MockPostsController();
+		$expected = array(
+			'method' => 'foobar',
+			'options' => array(),
+		);
+		$results = $controller->invokeMethod('_parseFilter', array(0, 'foobar'));
+		$this->assertIdentical($expected, $results);
+	}
+
+	public function testParseFilterKeyWithArray() {
+		$controller = new MockPostsController();
+		$expected = array(
+			'method' => 'foobar',
+			'options' => array(
+				'only' => array('index'),
+			),
+		);
+		$results = $controller->invokeMethod('_parseFilter', array(
+			'foobar',
+			array('only' => array('index')),
+		));
+		$this->assertIdentical($expected, $results);
+	}
+
+	public function testUsableFilterWithEmptyOptions() {
+		$controller = new MockPostsController();
+		$result = $controller->invokeMethod('_usableFilter', array(
+			'fooAction',
+			array(),
+		));
+		$this->assertTrue($result);
+	}
+
+	public function testUsableFilterWithPositiveOnlyOptions() {
+		$controller = new MockPostsController();
+		$result = $controller->invokeMethod('_usableFilter', array(
+			'fooAction',
+			array(
+				'only' => array('fooAction'),
+			),
+		));
+		$this->assertTrue($result);
+	}
+
+	public function testUsableFilterWithNegativeOnlyOptions() {
+		$controller = new MockPostsController();
+		$result = $controller->invokeMethod('_usableFilter', array(
+			'fooAction',
+			array(
+				'only' => array('show'),
+			),
+		));
+		$this->assertFalse($result);
+	}
+
+	public function testUsableFilterWithPositiveOnlyOptionAsString() {
+		$controller = new MockPostsController();
+		$result = $controller->invokeMethod('_usableFilter', array(
+			'fooAction',
+			array(
+				'only' => 'fooAction',
+			),
+		));
+		$this->assertTrue($result);
+	}
+
+	public function testUsableFilterWithPositiveExceptOptions() {
+		$controller = new MockPostsController();
+		$result = $controller->invokeMethod('_usableFilter', array(
+			'fooAction',
+			array(
+				'except' => array('index'),
+			),
+		));
+		$this->assertTrue($result);
+	}
+
+	public function testUsableFilterWithNegativeExceptOptions() {
+		$controller = new MockPostsController();
+		$result = $controller->invokeMethod('_usableFilter', array(
+			'fooAction',
+			array(
+				'except' => array('fooAction'),
+			),
+		));
+		$this->assertFalse($result);
+	}
+
+	public function testUsableFilterWithPositiveExceptOptionAsString() {
+		$controller = new MockPostsController();
+		$result = $controller->invokeMethod('_usableFilter', array(
+			'fooAction',
+			array(
+				'except' => 'index',
+			),
+		));
+		$this->assertTrue($result);
+	}
+
+	public function testCallFiltersSimpleString() {
+		$controller = new DoubleMockController();
+		$controller->callFilters('index', array(
+			'type',
+		));
+		$this->assertTrue(Mocker::chain($controller)->called('type')->success());
+	}
+
+	public function testCallFiltersWithOnlySuccess() {
+		$controller = new DoubleMockController();
+		$controller->callFilters('index', array(
+			'type' => array(
+				'only' => array('index'),
+			),
+		));
+		$this->assertTrue(Mocker::chain($controller)->called('type')->success());
+	}
+
+	public function testCallFiltersWithOnlyFailure() {
+		$controller = new DoubleMockController();
+		$controller->callFilters('index', array(
+			'type' => array(
+				'only' => array('show'),
+			),
+		));
+		$this->assertFalse(Mocker::chain($controller)->called('type')->success());
+	}
+
+	public function testCallFiltersWithExceptSuccess() {
+		$controller = new DoubleMockController();
+		$controller->callFilters('index', array(
+			'type' => array(
+				'except' => array('show'),
+			),
+		));
+		$this->assertTrue(Mocker::chain($controller)->called('type')->success());
+	}
+
+	public function testCallFiltersWithExceptFailure() {
+		$controller = new DoubleMockController();
+		$controller->callFilters('index', array(
+			'type' => array(
+				'except' => array('index'),
+			),
+		));
+		$this->assertFalse(Mocker::chain($controller)->called('type')->success());
+	}
+
+	public function testBeforeFilterGetsCalled() {
+		$controller = new DoubleMockController();
+		$controller->beforeFilters = array('type');
+		$controller->__invoke(null, array('action' => 'index', 'args' => array()));
+		$this->assertTrue(Mocker::chain($controller)->called('type')->success());
+	}
+
+	public function testBeforeFilterGetsCalledBefore() {
+		$controller = new DoubleMockController();
+		$controller->beforeFilters = array('type');
+		$controller->applyFilter('type', function($self, $params, $chain) use($controller) {
+			$controller->set(array(
+				'name' => 'FooBar',
+			));
+		});
+		$controller->applyFilter('index', function($self, $params, $chain) use($controller) {
+			$controller->set(array(
+				'name' => 'FooBaz',
+			));
+		});
+		$controller->applyFilter('render', function($self, $params, $chain) use($controller) {
+			return;
+		});
+		$controller->__invoke(null, array('action' => 'index', 'args' => array()));
+		$this->assertIdentical('FooBaz', $controller->_render['data']['name']);
+	}
+
+	public function testAfterFilterGetsCalled() {
+		$controller = new DoubleMockController();
+		$controller->afterFilters = array('type');
+		$controller->__invoke(null, array('action' => 'index', 'args' => array()));
+		$this->assertTrue(Mocker::chain($controller)->called('type')->success());
+	}
+
+	public function testAfterFilterGetsCalledAfter() {
+		$controller = new DoubleMockController();
+		$controller->afterFilters = array('type');
+		$controller->applyFilter('type', function($self, $params, $chain) use($controller) {
+			$controller->set(array(
+				'name' => 'FooBar',
+			));
+		});
+		$controller->applyFilter('index', function($self, $params, $chain) use($controller) {
+			$controller->set(array(
+				'name' => 'FooBaz',
+			));
+			return true;
+		});
+		$controller->applyFilter('render', function($self, $params, $chain) use($controller) {
+			return;
+		});
+		$result = $controller->__invoke(null, array('action' => 'index', 'args' => array()));
+		$this->assertIdentical('FooBar', $controller->_render['data']['name']);
+	}
+
 }
 
 ?>


### PR DESCRIPTION
Quite often you have a bit of logic duplicated between various controller actions. It's not ideal to make a real lithium filter since then the logic itself would exist in another file, or the logic to call a new method would exist in another file.

It was possible before to do before filters generically by making a filter on `Dispatcher::_callable`, however an after filter was not possible. You could potentially play with the entire response object using `Dispatcher::_call` but you could not change things that were `$controller->set()` from earlier.