### PR TITLE
Change Entity::__set() signature to prevent STRICT warning

### DIFF
--- a/data/Entity.php
+++ b/data/Entity.php
@@ -177,7 +177,7 @@ class Entity extends \lithium\core\Object {
 	 * @param string $value Property value.
 	 * @return mixed Result.
 	 */
-	public function __set($name, $value = null) {
+	public function __set($name, $value) {
 		if (is_array($name) && !$value) {
 			return array_map(array(&$this, '__set'), array_keys($name), array_values($name));
 		}


### PR DESCRIPTION
The magic method `Entity::__set()` is currently breaking STRICT standards with the method signature described in http://www.php.net/manual/en/language.oop5.overloading.php#object.set.

While this normally produces no warning (there's no base class in PHP that actually declares this method) this STRICT warning will appear if you have child classes that implement the proper signature. This is particularly annoying when using Doctrine2 with lithium, as the model proxy classes extend the model classes (which also extend `lithium\data\Entity`), and they do implement the magic method with the proper signature. This obviously creates a STRICT error because the proper signature at the proxy class differs from lithium's.

This proposed fix simply corrects the `__set()` signature on `lithium\data\Entity`, without breaking backwards compatibility with legacy code.

Credits: @mariano
