### PR TITLE
Enable ZendOpcache for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   # Test compatiblity with opcode caches in isolation.
   - PHP_EXT=apc
   - PHP_EXT=xcache
+  - PHP_EXT=opcache
   # Test each database in isolation.
   - DB=mysql
   - DB=pgsql


### PR DESCRIPTION
This PR installs the zend opcache extension for PHP versions <5.5. and enables it for all versions. However I'm not entirely sure if we need this as we can expect the opcaching to work(?) and Zend's Opcache doesn't come with pure storage/caching features. 
