### PR TITLE
Validator Any Fix

### DIFF
--- a/tests/cases/util/ValidatorTest.php
+++ b/tests/cases/util/ValidatorTest.php
@@ -995,6 +995,15 @@ class ValidatorTest extends \lithium\test\Unit {
 		$this->assertNotEmpty($result);
 	}
 
+	/**
+	 * Verifies that if validating with _any_, any format for
+	 * a rule will match. See issue #888 for more information.
+	 */
+	public function testCheckAny() {
+		$this->assertTrue(Validator::isCreditCard('4242424242424242', 'visa'));
+		$this->assertTrue(Validator::isCreditCard('4242424242424242'));
+	}
+
 	public function testCheckMultipleHasErrors() {
 		$rules = array(
 			'title' => 'please enter a title',

--- a/util/Validator.php
+++ b/util/Validator.php
@@ -658,14 +658,11 @@ class Validator extends \lithium\core\StaticObject {
 				$regexPassed = (is_string($check) && preg_match($check, $value));
 				$closurePassed = (is_object($check) && $check($value, $format, $options));
 
-				if (!$options['all'] && ($regexPassed || $closurePassed)) {
+				if ($regexPassed || $closurePassed) {
 					return true;
 				}
-				if ($options['all'] && (!$regexPassed && !$closurePassed)) {
-					return false;
-				}
 			}
-			return $options['all'];
+			return false;
 		};
 	}
 }


### PR DESCRIPTION
This PR fixes Validator::_checkFormat when used with the `any` option.

The method (using the any option) would before return false and break
out the loop if any of the given formats didn't match.

This behavior has been changed, so that if any format matches true
is returned. Only in the case none matched false is returned.

Please verify if this PR doesn't introduce any unwanted side effects. As far as I can see there are none and all existing tests still pass. But I may have missed an edge case. So it would be good to at least have another pair of eyes on this.

This PR references #888.
