### PR TITLE
Adding support for type JS views by extending media handler types

### DIFF
--- a/net/http/Media.php
+++ b/net/http/Media.php
@@ -913,6 +913,7 @@ class Media extends \lithium\core\StaticObject {
 				)
 			),
 			'html' => array(),
+			'js'   => array(),
 			'json' => array(
 				'cast' => true,
 				'encode' => 'json_encode',


### PR DESCRIPTION
In order to render views that are of type javascript, there is a missing component in media. 

In order to switch type, you must declare the type as you normally would in Router::Connect

Router::connect('/route', array(
    'controller'=>'Ctrl',
    'action'=>'method',
    'type'=>'js'
));

and include paths for views/layouts/&lt;layout&gt;.js.php
as well as the template views/&lt;action&gt;/<method>.js.php 
- of course you can be implicit of those values in your route config or method calls. 

However, these steps still fail because the type is not recognized in type resolution in media. Therefore
even though we support response type of text/javascript with a $type="js" it does not render templates 
with .js extensions because "js" is not an include type in handlers. 

This small change allows you to overcome that limitation. 
