### PR TITLE
Change links from lithify.me to li3.me

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,4 +10,4 @@ Here's what you need to stick to in order to have the best chance of getting you
  * **Maintainability**: code should pass existing tests, have adequate test coverage and should conform to our coding standards & QA guidelines
  * **Comprehensibility**: code should be concise and expressive, and should be accompanied by new documentation as appropriate, or updates to existing docs
 
-Please see the full documentation over at the [contribution guidelines](http://lithify.me/docs/manual/appendices/contributing.wiki) at [lithify.me](http://lithify.me/)
+Please see the full documentation over at the [contribution guidelines](http://li3.me/docs/manual/appendices/contributing.wiki) at [li3.me](http://li3.me/)

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "unionofrad/lithium",
 	"description": "The core library of the Lithium PHP framework",
 	"keywords": ["lithium", "framework"],
-	"homepage": "http://lithify.me",
+	"homepage": "http://li3.me",
 	"license": "BSD-3-Clause",
 	"authors": [
 		{

--- a/console/Request.php
+++ b/console/Request.php
@@ -174,7 +174,7 @@ class Request extends \lithium\core\Object {
 
 	/**
 	 * Sets or returns the current locale string. For more information, see
-	 * "[Globalization](http://lithify.me/docs/manual/07_globalization)" in the manual.
+	 * "[Globalization](http://li3.me/docs/manual/07_globalization)" in the manual.
 	 *
 	 * @param string $locale An optional locale string like `'en'`, `'en_US'` or `'de_DE'`. If
 	 *               specified, will overwrite the existing locale.

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ Lithium is the first framework to give you the best of both worlds, without comp
 
 #### Technology
 
-Lithium takes full advantage of the latest PHP 5.3 features, including namespaces, late static binding and closures. Lithium's innovative [method filter system](http://lithify.me/docs/lithium/util/collection/Filters) makes extensive use of closures and anonymous functions to allow application developers to "wrap" framework method calls, intercepting parameters before, and return values after.
+Lithium takes full advantage of the latest PHP 5.3 features, including namespaces, late static binding and closures. Lithium's innovative [method filter system](http://li3.me/docs/lithium/util/collection/Filters) makes extensive use of closures and anonymous functions to allow application developers to "wrap" framework method calls, intercepting parameters before, and return values after.
 
 Lithium also complies with the PHP 5.3 namespacing standard, allowing you to easily integrate other PHP 5.3 standard libraries and frameworks with Lithium applications, and vice-versa.
 

--- a/template/helper/Html.php
+++ b/template/helper/Html.php
@@ -160,7 +160,7 @@ class Html extends \lithium\template\Helper {
 	 * `'/'`, the path will be relative to the base path of your application.  Otherwise, the path
 	 * will be relative to your JavaScript path, usually `webroot/js`.
 	 *
-	 * @link http://lithify.me/docs/manual/handling-http-requests/views.wiki
+	 * @link http://li3.me/docs/manual/handling-http-requests/views.wiki
 	 * @param mixed $path String The name of a JavaScript file, or an array of names.
 	 * @param array $options Available options are:
 	 *              - `'inline'` _boolean_: Whether or not the `<script />` element should be output


### PR DESCRIPTION
Changed links that point to lithify.me to point to li3.me; only changed
the ones that are comments or readme docs.
