### PR TITLE
Adding file_exists because is_uploaded_file have problems with Windows

### DIFF
--- a/data/source/MongoDb.php
+++ b/data/source/MongoDb.php
@@ -433,8 +433,9 @@ class MongoDb extends \lithium\data\Source {
 		$method = null;
 
 		switch (true) {
-			case  (is_array($data['file']) && array_keys($data['file']) == $uploadKeys):
-				if (!$data['file']['error'] && is_uploaded_file($data['file']['tmp_name'])) {
+			case (is_array($data['file']) && array_keys($data['file']) == $uploadKeys):
+				if (!$data['file']['error']
+				(file_exists($data['file']['tmp_name']) || is_uploaded_file($data['file']['tmp_name']))){
 					$method = 'storeFile';
 					$file = $data['file']['tmp_name'];
 					$data['filename'] = $data['file']['name'];


### PR DESCRIPTION
My case: using fs.grid, trying to upload some external file, the switch case always returns `$method = 'storeBytes';` regardless of the first case.

This was caused because Windows interprets paths in a really different way in comparation with Unix (http://faculty.cs.byu.edu/~jay/plt-doc/reference/windowspaths.html).
