### PR TITLE
Implementing cache key scoping.

### DIFF
--- a/storage/Cache.php
+++ b/storage/Cache.php
@@ -37,6 +37,16 @@ namespace lithium\storage;
  * );
  * }}}
  *
+ * Adapter configurations can be scoped, adapters will then handle the
+ * namespacing of the keys transparently for you:
+ *
+ * {{{
+ * Cache::config(array(
+ *     'primary'   => array('adapter' => 'Apc', 'scope' => 'primary'),
+ *     'secondary' => array('adapter' => 'Apc', 'scope' => 'secondary')
+ * );
+ * }}}
+ *
  * Cache adapters differ in the functionality they provide and how the provide it. To see
  * if an adapter meets your requirement and for more information on the specifics
  * (i.e. atomicity of operations), consult the documentation the adapter first.

--- a/storage/cache/Adapter.php
+++ b/storage/cache/Adapter.php
@@ -115,6 +115,46 @@ abstract class Adapter extends \lithium\core\Object {
 	public static function enabled() {
 		return true;
 	}
+
+	/**
+	 * Adds scope prefix to keys using separator.
+	 *
+	 * @param string $scope Scope to use when prefixing.
+	 * @param array $keys Array of keys either with or without mapping to values.
+	 * @param string $separator String to use when separating scope from key.
+	 * @return array Prefixed keys array.
+	 */
+	protected function _addScopePrefix($scope, array $keys, $separator = ':') {
+		$results = array();
+		$isMapped = !is_int(key($keys));
+
+		foreach ($keys as $key => $value) {
+			if ($isMapped) {
+				$results["{$scope}{$separator}{$key}"] = $value;
+			} else {
+				$results[$key] = "{$scope}{$separator}{$value}";
+			}
+		}
+		return $results;
+	}
+
+	/**
+	 * Removes scope prefix from keys.
+	 *
+	 * @param string $scope Scope initially used when prefixing.
+	 * @param array $keys Array of keys mapping to values.
+	 * @param string $separator Separator used when prefix keys initially.
+	 * @return array Keys array with prefix removed from each key.
+	 */
+	protected function _removeScopePrefix($scope, array $data, $separator = ':') {
+		$results = array();
+		$prefix = strlen("{$scope}{$separator}");
+
+		foreach ($data as $key => $value) {
+			$results[substr($key, $prefix)] = $value;
+		}
+		return $results;
+	}
 }
 
 ?>

--- a/storage/cache/adapter/Memory.php
+++ b/storage/cache/adapter/Memory.php
@@ -130,8 +130,7 @@ class Memory extends \lithium\storage\cache\Adapter {
 		$cache =& $this->_cache;
 
 		return function($self, $params) use (&$cache, $offset) {
-			extract($params);
-			return $cache[$key] -= 1;
+			return $cache[$params['key']] -= 1;
 		};
 	}
 
@@ -147,8 +146,7 @@ class Memory extends \lithium\storage\cache\Adapter {
 		$cache =& $this->_cache;
 
 		return function($self, $params) use (&$cache, $offset) {
-			extract($params);
-			return $cache[$key] += 1;
+			return $cache[$params['key']] += 1;
 		};
 	}
 

--- a/tests/cases/storage/CacheTest.php
+++ b/tests/cases/storage/CacheTest.php
@@ -504,7 +504,6 @@ class CacheTest extends \lithium\test\Unit {
 
 		$result = Cache::read('default', 'to delete');
 		$this->assertEmpty($result);
-
 	}
 
 	public function testClean() {

--- a/tests/cases/storage/cache/adapter/XCacheTest.php
+++ b/tests/cases/storage/cache/adapter/XCacheTest.php
@@ -214,6 +214,22 @@ class XCacheTest extends \lithium\test\Unit {
 		$closure($this->XCache, compact('keys', 'expiry'));
 	}
 
+	public function testWriteWithScope() {
+		$adapter = new XCache(array('scope' => 'primary'));
+
+		$keys = array('key1' => 'test1');
+		$expiry = '+1 minute';
+		$result = $adapter->write($keys, $expiry);
+		$result($adapter, compact('keys', 'expiry'));
+
+		$expected = 'test1';
+		$result = xcache_get('primary:key1');
+		$this->assertEqual($expected, $result);
+
+		$result = xcache_get('key1');
+		$this->assertNull($result);
+	}
+
 	public function testSimpleRead() {
 		$key = 'read_key';
 		$data = 'read data';
@@ -262,6 +278,19 @@ class XCacheTest extends \lithium\test\Unit {
 		$expected = array();
 		$result = $closure($this->XCache, compact('keys'));
 		$this->assertIdentical($expected, $result);
+	}
+
+	public function testReadWithScope() {
+		$adapter = new XCache(array('scope' => 'primary'));
+
+		xcache_set('primary:key1', 'test1', 60);
+		xcache_set('key1', 'test2', 60);
+
+		$keys = array('key1');
+		$expected = array('key1' => 'test1');
+		$result = $adapter->read($keys);
+		$result = $result($adapter, compact('keys'));
+		$this->assertEqual($expected, $result);
 	}
 
 	public function testReadMulti() {
@@ -355,6 +384,24 @@ class XCacheTest extends \lithium\test\Unit {
 
 		$params = compact('keys');
 		$result = $closure($this->XCache, $params);
+		$this->assertFalse($result);
+	}
+
+	public function testDeleteWithScope() {
+		$adapter = new XCache(array('scope' => 'primary'));
+
+		xcache_set('primary:key1', 'test1', 60);
+		xcache_set('key1', 'test2', 60);
+
+		$keys = array('key1');
+		$expected = array('key1' => 'test1');
+		$result = $adapter->delete($keys);
+		$result($adapter, compact('keys'));
+
+		$result = xcache_isset('key1');
+		$this->assertTrue($result);
+
+		$result = xcache_isset('primary:key1');
 		$this->assertFalse($result);
 	}
 
@@ -467,6 +514,24 @@ class XCacheTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 	}
 
+	public function testDecrementWithScope() {
+		$adapter = new XCache(array('scope' => 'primary'));
+
+		xcache_set('primary:key1', 1, 60);
+		xcache_set('key1', 1, 60);
+
+		$result = $adapter->decrement('key1');
+		$result($adapter, array('key' => 'key1'));
+
+		$expected = 1;
+		$result = xcache_get('key1');
+		$this->assertEqual($expected, $result);
+
+		$expected = 0;
+		$result = xcache_get('primary:key1');
+		$this->assertEqual($expected, $result);
+	}
+
 	public function testIncrement() {
 		$time = strtotime('+1 minute') - time();
 		$key = 'increment';
@@ -517,6 +582,24 @@ class XCacheTest extends \lithium\test\Unit {
 
 		$result = xcache_unset($key);
 		$this->assertTrue($result);
+	}
+
+	public function testIncrementWithScope() {
+		$adapter = new XCache(array('scope' => 'primary'));
+
+		xcache_set('primary:key1', 1, 60);
+		xcache_set('key1', 1, 60);
+
+		$result = $adapter->increment('key1');
+		$result($adapter, array('key' => 'key1'));
+
+		$expected = 1;
+		$result = xcache_get('key1');
+		$this->assertEqual($expected, $result);
+
+		$expected = 2;
+		$result = xcache_get('primary:key1');
+		$this->assertEqual($expected, $result);
 	}
 }
 


### PR DESCRIPTION
This allows to provide a `scope` on a per adapter
configuration basis. Namespacing/scoping of the keys
is then handled by the adapters transparently.

When multiple apps access the same cache store, scoping
can be used to prevent accidental overwriting of keys.
- Removing unused cache prefix option.
- Adding scoping docs to cache class.
- Adding helper methods to base adapter.
- Adding tests.
