### PR TITLE
Cache strategy/filter cleanup

### DIFF
--- a/storage/Cache.php
+++ b/storage/Cache.php
@@ -174,9 +174,11 @@ class Cache extends \lithium\core\Adaptable {
 				));
 			}
 		}
-		$method = static::adapter($name)->write($keys, $expiry);
 		$params = compact('keys', 'expiry');
-		return static::_filter(__FUNCTION__, $params, $method, $settings[$name]['filters']);
+
+		return static::_filter(__FUNCTION__, $params, function($self, $params) use ($name) {
+			return $self::adapter($name)->write($params['keys'], $params['expiry']);
+		}, $settings[$name]['filters']);
 	}
 
 	/**
@@ -232,11 +234,11 @@ class Cache extends \lithium\core\Adaptable {
 		} else {
 			$keys = array($key);
 		}
-
-		$method = static::adapter($name)->read($keys);
 		$params = compact('keys');
-		$filters = $settings[$name]['filters'];
-		$results = static::_filter(__FUNCTION__, $params, $method, $filters);
+
+		$results = static::_filter(__FUNCTION__, $params, function($self, $params) use ($name) {
+			return $self::adapter($name)->read($params['keys']);
+		}, $settings[$name]['filters']);
 
 		if ($write = $options['write']) {
 			$write = is_callable($write) ? $write() : $write;
@@ -300,11 +302,9 @@ class Cache extends \lithium\core\Adaptable {
 		} else {
 			$keys = array($key);
 		}
-
-		$method = static::adapter($name)->delete($keys);
-		$filters = $settings[$name]['filters'];
-
-		return static::_filter(__FUNCTION__, compact('keys'), $method, $filters);
+		return static::_filter(__FUNCTION__, compact('keys'), function($self, $params) use ($name) {
+			return $self::adapter($name)->delete($params['keys']);
+		}, $settings[$name]['filters']);
 	}
 
 	/**
@@ -334,11 +334,11 @@ class Cache extends \lithium\core\Adaptable {
 		}
 
 		$key = static::key($key);
-		$method = static::adapter($name)->increment($key, $offset);
 		$params = compact('key', 'offset');
-		$filters = $settings[$name]['filters'];
 
-		return static::_filter(__FUNCTION__, $params, $method, $filters);
+		return static::_filter(__FUNCTION__, $params, function($self, $params) use ($name) {
+			return $self::adapter($name)->increment($params['key'], $params['offset']);
+		}, $settings[$name]['filters']);
 	}
 
 	/**
@@ -368,11 +368,11 @@ class Cache extends \lithium\core\Adaptable {
 		}
 
 		$key = static::key($key);
-		$method = static::adapter($name)->decrement($key, $offset);
 		$params = compact('key', 'offset');
-		$filters = $settings[$name]['filters'];
 
-		return static::_filter(__FUNCTION__, $params, $method, $filters);
+		return static::_filter(__FUNCTION__, $params, function($self, $params) use ($name) {
+			return $self::adapter($name)->decrement($params['key'], $params['offset']);
+		}, $settings[$name]['filters']);
 	}
 
 	/**

--- a/storage/cache/Adapter.php
+++ b/storage/cache/Adapter.php
@@ -40,7 +40,7 @@ abstract class Adapter extends \lithium\core\Object {
 	 * @param array $keys Key/value pairs with keys to uniquely identify the to-be-cached item.
 	 * @param string|integer $expiry A `strtotime()` compatible cache time or TTL in seconds.
 	 *                       To persist an item use `\lithium\storage\Cache::PERSIST`.
-	 * @return Closure Function returning boolean `true` on successful write, `false` otherwise.
+	 * @return boolean `true` on successful write, `false` otherwise.
 	 */
 	abstract public function write(array $keys, $expiry = null);
 
@@ -49,9 +49,9 @@ abstract class Adapter extends \lithium\core\Object {
 	 * containing key/value pairs of the requested data.
 	 *
 	 * @param array $keys Keys to uniquely identify the cached items.
-	 * @return Closure Function returning cached values keyed by cache keys
-	 *                 on successful read, keys which could not be read will
-	 *                 not be included in the results array.
+	 * @return array Cached values keyed by cache keys on successful read,
+	 *               keys which could not be read will not be included in
+	 *               the results array.
 	 */
 	abstract public function read(array $keys);
 
@@ -59,27 +59,27 @@ abstract class Adapter extends \lithium\core\Object {
 	 * Will attempt to remove specified keys from the user space cache.
 	 *
 	 * @param array $keys Keys to uniquely identify the cached items.
-	 * @return Closure Function returning `true` on successful delete, `false` otherwise.
+	 * @return boolean `true` on successful delete, `false` otherwise.
 	 */
 	abstract public function delete(array $keys);
 
 	/**
 	 * Performs a decrement operation on specified numeric cache item.
 	 *
-	 * @param string $key Key of numeric cache item to decrement
-	 * @param integer $offset Offset to decrement - defaults to 1.
-	 * @return Closure Function returning item's new value on successful decrement, else `false`
+	 * @param string $key Key of numeric cache item to decrement.
+	 * @param integer $offset Offset to decrement - defaults to `1`.
+	 * @return integer The item's new value on successful decrement, else `false`.
 	 */
 	public function decrement($key, $offset = 1) {
 		return false;
 	}
 
 	/**
-	 * Performs a increment operation on specified numeric cache item.
+	 * Performs an increment operation on specified numeric cache item.
 	 *
 	 * @param string $key Key of numeric cache item to increment
-	 * @param integer $offset Offset to increment - defaults to 1.
-	 * @return Closure Function returning item's new value on successful increment, else `false`
+	 * @param integer $offset Offset to increment - defaults to `1`.
+	 * @return integer The item's new value on successful increment, else `false`.
 	 */
 	public function increment($key, $offset = 1) {
 		return false;

--- a/storage/cache/adapter/Memory.php
+++ b/storage/cache/adapter/Memory.php
@@ -60,23 +60,19 @@ class Memory extends \lithium\storage\cache\Adapter {
 	 * containing key/value pairs of the requested data.
 	 *
 	 * @param array $keys Keys to uniquely identify the cached items.
-	 * @return Closure Function returning cached values keyed by cache keys
-	 *                 on successful read, keys which could not be read will
-	 *                 not be included in the results array.
+	 * @return array Cached values keyed by cache keys on successful read,
+	 *               keys which could not be read will not be included in
+	 *               the results array.
 	 */
 	public function read(array $keys) {
-		$cache =& $this->_cache;
+		$results = array();
 
-		return function($self, $params) use (&$cache) {
-			$results = array();
-
-			foreach ($params['keys'] as $key) {
-				if (array_key_exists($key, $cache)) {
-					$results[$key] = $cache[$key];
-				}
+		foreach ($keys as $key) {
+			if (array_key_exists($key, $this->_cache)) {
+				$results[$key] = $this->_cache[$key];
 			}
-			return $results;
-		};
+		}
+		return $results;
 	}
 
 	/**
@@ -85,69 +81,51 @@ class Memory extends \lithium\storage\cache\Adapter {
 	 * @param array $keys Key/value pairs with keys to uniquely identify the to-be-cached item.
 	 * @param mixed $data The value to be cached.
 	 * @param null|string $expiry Unused.
-	 * @return Closure Function returning boolean `true` on successful write, `false` otherwise.
+	 * @return boolean `true` on successful write, `false` otherwise.
 	 */
 	public function write(array $keys, $expiry = null) {
-		$cache =& $this->_cache;
-
-		return function($self, $params) use (&$cache) {
-			foreach ($params['keys'] as $key => &$value) {
-				$cache[$key] = $value;
-			}
-			return true;
-		};
+		foreach ($keys as $key => &$value) {
+			$this->_cache[$key] = $value;
+		}
+		return true;
 	}
 
 	/**
 	 * Will attempt to remove specified keys from the user space cache.
 	 *
 	 * @param array $keys Keys to uniquely identify the cached items.
-	 * @return Closure Function returning `true` on successful delete, `false` otherwise.
+	 * @return boolean `true` on successful delete, `false` otherwise.
 	 */
 	public function delete(array $keys) {
-		$cache =& $this->_cache;
-
-		return function($self, $params) use (&$cache) {
-			foreach ($params['keys'] as $key) {
-				if (!isset($cache[$key])) {
-					return false;
-				}
-				unset($cache[$key]);
+		foreach ($keys as $key) {
+			if (!isset($this->_cache[$key])) {
+				return false;
 			}
-			return true;
-		};
+			unset($this->_cache[$key]);
+		}
+		return true;
 	}
 
 	/**
 	 * Performs a decrement operation on specified numeric cache item.
 	 *
 	 * @param string $key Key of numeric cache item to decrement.
-	 * @param integer $offset Offset to decrement - defaults to 1.
-	 * @return Closure Function returning item's new value on successful decrement,
-	 *         `false` otherwise.
+	 * @param integer $offset Offset to decrement - defaults to `1`.
+	 * @return integer The item's new value on successful decrement, else `false`.
 	 */
 	public function decrement($key, $offset = 1) {
-		$cache =& $this->_cache;
-
-		return function($self, $params) use (&$cache, $offset) {
-			return $cache[$params['key']] -= 1;
-		};
+		return $this->_cache[$key] -= 1;
 	}
 
 	/**
 	 * Performs an increment operation on specified numeric cache item.
 	 *
-	 * @param string $key Key of numeric cache item to increment.
-	 * @param integer $offset Offset to increment - defaults to 1.
-	 * @return Closure Function returning item's new value on successful increment,
-	 *         `false` otherwise.
+	 * @param string $key Key of numeric cache item to increment
+	 * @param integer $offset Offset to increment - defaults to `1`.
+	 * @return integer The item's new value on successful increment, else `false`.
 	 */
 	public function increment($key, $offset = 1) {
-		$cache =& $this->_cache;
-
-		return function($self, $params) use (&$cache, $offset) {
-			return $cache[$params['key']] += 1;
-		};
+		return $this->_cache[$key] += 1;
 	}
 
 	/**

--- a/tests/cases/storage/cache/adapter/ApcTest.php
+++ b/tests/cases/storage/cache/adapter/ApcTest.php
@@ -43,11 +43,7 @@ class ApcTest extends \lithium\test\Unit {
 		$keys = array($key => $data);
 		$expiry = '+5 seconds';
 
-		$closure = $this->Apc->write($keys, $expiry);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys', 'expiry');
-		$result = $closure($this->Apc, $params);
+		$result = $this->Apc->write($keys, $expiry);
 		$this->assertTrue($result);
 
 		$expected = $data;
@@ -62,12 +58,8 @@ class ApcTest extends \lithium\test\Unit {
 		$keys = array($key => $data);
 		$expiry = '+1 minute';
 
-		$closure = $this->Apc->write($keys, $expiry);
-		$this->assertInternalType('callable', $closure);
-
 		$expected = $keys;
-		$params = compact('keys', 'expiry');
-		$result = $closure($this->Apc, $params);
+		$result = $this->Apc->write($keys, $expiry);
 		$this->assertTrue($result);
 
 		$expected = $data;
@@ -90,8 +82,9 @@ class ApcTest extends \lithium\test\Unit {
 		$apc = new Apc(array('expiry' => '+5 seconds'));
 		$keys = array('key1' => 'data1');
 		$expiry = null;
-		$closure = $apc->write($keys, $expiry);
-		$closure($apc, compact('keys', 'expiry'));
+
+		$result = $apc->write($keys, $expiry);
+		$this->assertTrue($result);
 
 		$result = apc_exists('key1');
 		$this->assertTrue($result);
@@ -102,9 +95,7 @@ class ApcTest extends \lithium\test\Unit {
 
 		$apc = new Apc(array('expiry' => null));
 		$expiry = null;
-		$closure = $apc->write($keys, $expiry);
-
-		$result = $closure($apc, compact('keys', 'expiry'));
+		$result = $apc->write($keys, $expiry);
 		$this->assertTrue($result);
 
 		$result = apc_exists('key1');
@@ -115,8 +106,7 @@ class ApcTest extends \lithium\test\Unit {
 		$apc = new Apc(array('expiry' => Cache::PERSIST));
 		$expiry = Cache::PERSIST;
 
-		$closure = $apc->write($keys, $expiry);
-		$result = $closure($apc, compact('keys', 'expiry'));
+		$result = $apc->write($keys, $expiry);
 		$this->assertTrue($result);
 
 		$result = apc_exists('key1');
@@ -126,9 +116,7 @@ class ApcTest extends \lithium\test\Unit {
 
 		$apc = new Apc();
 		$expiry = Cache::PERSIST;
-		$closure = $apc->write($keys, $expiry);
-
-		$result = $closure($apc, compact('keys', 'expiry'));
+		$result = $apc->write($keys, $expiry);
 		$this->assertTrue($result);
 
 		$result = apc_exists('key1');
@@ -146,8 +134,7 @@ class ApcTest extends \lithium\test\Unit {
 	public function testWriteExpiryExpires() {
 		$keys = array('key1' => 'data1');
 		$expiry = '+5 seconds';
-		$closure = $this->Apc->write($keys, $expiry);
-		$closure($this->Apc, compact('keys', 'expiry'));
+		$this->Apc->write($keys, $expiry);
 
 		$result = apc_exists('key1');
 		$this->assertTrue($result);
@@ -164,8 +151,7 @@ class ApcTest extends \lithium\test\Unit {
 	public function testWriteExpiryTtl() {
 		$keys = array('key1' => 'data1');
 		$expiry = 5;
-		$closure = $this->Apc->write($keys, $expiry);
-		$closure($this->Apc, compact('keys', 'expiry'));
+		$this->Apc->write($keys, $expiry);
 
 		$result = apc_exists('key1');
 		$this->assertTrue($result);
@@ -178,8 +164,7 @@ class ApcTest extends \lithium\test\Unit {
 			'key2' => 'data2',
 			'key3' => 'data3'
 		);
-		$closure = $this->Apc->write($keys, $expiry);
-		$result = $closure($this->Apc, compact('keys', 'expiry'));
+		$result = $this->Apc->write($keys, $expiry);
 		$this->assertTrue($result);
 
 		$result = apc_fetch(array_keys($keys));
@@ -197,12 +182,8 @@ class ApcTest extends \lithium\test\Unit {
 		$result = apc_store($key, $data, 60);
 		$this->assertTrue($result);
 
-		$closure = $this->Apc->read($keys);
-		$this->assertInternalType('callable', $closure);
-
 		$expected = array($key => $data);
-		$params = compact('keys');
-		$result = $closure($this->Apc, $params);
+		$result = $this->Apc->read($keys);
 		$this->assertEqual($expected, $result);
 
 		$result = apc_delete($key);
@@ -215,12 +196,8 @@ class ApcTest extends \lithium\test\Unit {
 		$result = apc_store($key, $data, 60);
 		$this->assertTrue($result);
 
-		$closure = $this->Apc->read($keys);
-		$this->assertInternalType('callable', $closure);
-
 		$expected = array($key => $data);
-		$params = compact('keys');
-		$result = $closure($this->Apc, $params, null);
+		$result = $this->Apc->read($keys);
 		$this->assertEqual($expected, $result);
 
 		$result = apc_delete($key);
@@ -245,8 +222,7 @@ class ApcTest extends \lithium\test\Unit {
 			'key2',
 			'key3'
 		);
-		$closure = $this->Apc->read($keys);
-		$result = $closure($this->Apc, compact('keys'));
+		$result = $this->Apc->read($keys);
 		$this->assertEqual($expected, $result);
 
 		$result = apc_delete($keys);
@@ -256,10 +232,9 @@ class ApcTest extends \lithium\test\Unit {
 	public function testReadKeyThatDoesNotExist() {
 		$key = 'does_not_exist';
 		$keys = array($key);
-		$closure = $this->Apc->read($keys);
 
 		$expected = array();
-		$result = $closure($this->Apc, compact('keys'));
+		$result = $this->Apc->read($keys);
 		$this->assertIdentical($expected, $result);
 	}
 
@@ -272,7 +247,6 @@ class ApcTest extends \lithium\test\Unit {
 		$keys = array('key1');
 		$expected = array('key1' => 'test1');
 		$result = $adapter->read($keys);
-		$result = $result($adapter, compact('keys'));
 		$this->assertEqual($expected, $result);
 	}
 
@@ -282,11 +256,11 @@ class ApcTest extends \lithium\test\Unit {
 			'key1' => null
 		);
 		$result = $this->Apc->write($keys);
-		$this->assertTrue($result($this->Apc, compact('keys', 'expiry')));
+		$this->assertTrue($result);
 
 		$expected = $keys;
 		$result = $this->Apc->read(array_keys($keys));
-		$this->assertEqual($expected, $result($this->Apc, array('keys' => array_keys($keys))));
+		$this->assertEqual($expected, $result);
 	}
 
 	public function testWriteAndReadNullMulti() {
@@ -296,18 +270,18 @@ class ApcTest extends \lithium\test\Unit {
 			'key2' => 'data2'
 		);
 		$result = $this->Apc->write($keys);
-		$this->assertTrue($result($this->Apc, compact('keys', 'expiry')));
+		$this->assertTrue($result);
 
 		$expected = $keys;
 		$result = $this->Apc->read(array_keys($keys));
-		$this->assertEqual($expected, $result($this->Apc, array('keys' => array_keys($keys))));
+		$this->assertEqual($expected, $result);
 
 		$keys = array(
 			'key1' => null,
 			'key2' => null
 		);
 		$result = $this->Apc->write($keys);
-		$this->assertTrue($result($this->Apc, compact('keys', 'expiry')));
+		$this->assertTrue($result);
 	}
 
 	public function testWriteAndReadArray() {
@@ -316,11 +290,11 @@ class ApcTest extends \lithium\test\Unit {
 			'key1' => array('foo' => 'bar')
 		);
 		$result = $this->Apc->write($keys);
-		$this->assertTrue($result($this->Apc, compact('keys', 'expiry')));
+		$this->assertTrue($result);
 
 		$expected = $keys;
 		$result = $this->Apc->read(array_keys($keys));
-		$this->assertEqual($expected, $result($this->Apc, array('keys' => array_keys($keys))));
+		$this->assertEqual($expected, $result);
 	}
 
 	public function testWriteWithScope() {
@@ -328,8 +302,7 @@ class ApcTest extends \lithium\test\Unit {
 
 		$keys = array('key1' => 'test1');
 		$expiry = '+1 minute';
-		$result = $adapter->write($keys, $expiry);
-		$result($adapter, compact('keys', 'expiry'));
+		$adapter->write($keys, $expiry);
 
 		$expected = 'test1';
 		$result = apc_fetch('primary:key1');
@@ -347,11 +320,7 @@ class ApcTest extends \lithium\test\Unit {
 		$result = apc_store($key, $data, 60);
 		$this->assertTrue($result);
 
-		$closure = $this->Apc->delete($keys);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys');
-		$result = $closure($this->Apc, $params);
+		$result = $this->Apc->delete($keys);
 		$this->assertTrue($result);
 	}
 
@@ -369,8 +338,7 @@ class ApcTest extends \lithium\test\Unit {
 			'key2',
 			'key3'
 		);
-		$closure = $this->Apc->delete($keys);
-		$result = $closure($this->Apc, compact('keys'));
+		$result = $this->Apc->delete($keys);
 		$this->assertTrue($result);
 
 		$result = apc_delete($keys);
@@ -382,11 +350,7 @@ class ApcTest extends \lithium\test\Unit {
 		$data = 'data to delete';
 		$keys = array($key);
 
-		$closure = $this->Apc->delete($keys);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys');
-		$result = $closure($this->Apc, $params);
+		$result = $this->Apc->delete($keys);
 		$this->assertFalse($result);
 	}
 
@@ -398,8 +362,7 @@ class ApcTest extends \lithium\test\Unit {
 
 		$keys = array('key1');
 		$expected = array('key1' => 'test1');
-		$result = $adapter->delete($keys);
-		$result($adapter, compact('keys'));
+		$adapter->delete($keys);
 
 		$result = apc_exists('key1');
 		$this->assertTrue($result);
@@ -414,30 +377,18 @@ class ApcTest extends \lithium\test\Unit {
 		$keys = array($key => $data);
 		$expiry = '+5 seconds';
 
-		$closure = $this->Apc->write($keys, $expiry);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys', 'expiry');
-		$result = $closure($this->Apc, $params);
+		$result = $this->Apc->write($keys, $expiry);
 		$this->assertTrue($result);
 
 		$expected = $data;
 		$result = apc_fetch($key);
 		$this->assertEqual($expected, $result);
 
-		$closure = $this->Apc->read(array_keys($keys));
-		$this->assertInternalType('callable', $closure);
-
 		$expected = $keys;
-		$params = array('keys' => array($key));
-		$result = $closure($this->Apc, $params);
+		$result = $this->Apc->read(array_keys($keys));
 		$this->assertEqual($expected, $result);
 
-		$closure = $this->Apc->delete(array_keys($keys));
-		$this->assertInternalType('callable', $closure);
-
-		$params = array('keys' => array($key));
-		$result = $closure($this->Apc, $params);
+		$result = $this->Apc->delete(array_keys($keys));
 		$this->assertTrue($result);
 	}
 
@@ -465,11 +416,7 @@ class ApcTest extends \lithium\test\Unit {
 		$result = apc_store($key, $value, 60);
 		$this->assertTrue($result);
 
-		$closure = $this->Apc->decrement($key);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('key');
-		$result = $closure($this->Apc, $params, null);
+		$result = $this->Apc->decrement($key);
 		$this->assertEqual($value - 1, $result);
 
 		$result = apc_fetch($key);
@@ -486,11 +433,7 @@ class ApcTest extends \lithium\test\Unit {
 		$result = apc_store($key, $value, 60);
 		$this->assertTrue($result);
 
-		$closure = $this->Apc->decrement($key);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('key');
-		$result = $closure($this->Apc, $params, null);
+		$this->Apc->decrement($key);
 
 		$result = apc_fetch($key);
 		$this->assertEqual('no', $result);
@@ -505,8 +448,7 @@ class ApcTest extends \lithium\test\Unit {
 		apc_store('primary:key1', 1, 60);
 		apc_store('key1', 1, 60);
 
-		$result = $adapter->decrement('key1');
-		$result($adapter, array('key' => 'key1'));
+		$adapter->decrement('key1');
 
 		$expected = 1;
 		$result = apc_fetch('key1');
@@ -524,11 +466,7 @@ class ApcTest extends \lithium\test\Unit {
 		$result = apc_store($key, $value, 60);
 		$this->assertTrue($result);
 
-		$closure = $this->Apc->increment($key);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('key');
-		$result = $closure($this->Apc, $params, null);
+		$result = $this->Apc->increment($key);
 		$this->assertEqual($value + 1, $result);
 
 		$result = apc_fetch($key);
@@ -545,11 +483,7 @@ class ApcTest extends \lithium\test\Unit {
 		$result = apc_store($key, $value, 60);
 		$this->assertTrue($result);
 
-		$closure = $this->Apc->increment($key);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('key');
-		$result = $closure($this->Apc, $params, null);
+		$this->Apc->increment($key);
 
 		$result = apc_fetch($key);
 		$this->assertEqual('yes', $result);
@@ -564,8 +498,7 @@ class ApcTest extends \lithium\test\Unit {
 		apc_store('primary:key1', 1, 60);
 		apc_store('key1', 1, 60);
 
-		$result = $adapter->increment('key1');
-		$result($adapter, array('key' => 'key1'));
+		$adapter->increment('key1');
 
 		$expected = 1;
 		$result = apc_fetch('key1');

--- a/tests/cases/storage/cache/adapter/FileTest.php
+++ b/tests/cases/storage/cache/adapter/FileTest.php
@@ -71,12 +71,9 @@ class FileTest extends \lithium\test\Unit {
 		$expiry = "@{$time} +1 minute";
 		$time = $time + 60;
 
-		$closure = $this->File->write($keys, $expiry);
-		$this->assertInternalType('callable', $closure);
 
-		$params = compact('keys', 'expiry');
-		$result = $closure($this->File, $params, null);
 		$expected = 25;
+		$result = $this->File->write($keys, $expiry);
 		$this->assertEqual($expected, $result);
 
 		$this->assertFileExists(Libraries::get(true, 'resources') . "/tmp/cache/{$key}");
@@ -96,8 +93,7 @@ class FileTest extends \lithium\test\Unit {
 			'key2' => 'data2',
 			'key3' => 'data3'
 		);
-		$closure = $this->File->write($keys, $expiry);
-		$result = $closure($this->File, compact('keys', 'expiry'));
+		$result = $this->File->write($keys, $expiry);
 		$this->assertTrue($result);
 
 		foreach ($keys as $key => $data) {
@@ -117,12 +113,8 @@ class FileTest extends \lithium\test\Unit {
 		$keys = array($key => $data);
 		$time = $time + 60;
 
-		$closure = $file->write($keys);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys');
-		$result = $closure($file, $params, null);
 		$expected = 25;
+		$result = $file->write($keys);
 		$this->assertEqual($expected, $result);
 
 		$this->assertFileExists(Libraries::get(true, 'resources') . "/tmp/cache/{$key}");
@@ -142,8 +134,7 @@ class FileTest extends \lithium\test\Unit {
 		$adapter = new File(array('expiry' => null));
 		$expiry = null;
 
-		$closure = $adapter->write($keys, $expiry);
-		$result = $closure($adapter, compact('keys', 'expiry'));
+		$result = $adapter->write($keys, $expiry);
 		$this->assertTrue($result);
 
 		$expected = "{:expiry:0}\ndata1";
@@ -155,8 +146,7 @@ class FileTest extends \lithium\test\Unit {
 		$adapter = new File(array('expiry' => Cache::PERSIST));
 		$expiry = Cache::PERSIST;
 
-		$closure = $adapter->write($keys, $expiry);
-		$result = $closure($adapter, compact('keys', 'expiry'));
+		$result = $adapter->write($keys, $expiry);
 		$this->assertTrue($result);
 
 		$expected = "{:expiry:0}\ndata1";
@@ -168,8 +158,7 @@ class FileTest extends \lithium\test\Unit {
 		$adapter = new File();
 		$expiry = Cache::PERSIST;
 
-		$closure = $adapter->write($keys, $expiry);
-		$result = $closure($adapter, compact('keys', 'expiry'));
+		$result = $adapter->write($keys, $expiry);
 		$this->assertTrue($result);
 
 		$expected = "{:expiry:0}\ndata1";
@@ -185,8 +174,7 @@ class FileTest extends \lithium\test\Unit {
 		$keys = array('key1' => 'data1');
 		$time = $now + 5;
 		$expiry = "@{$now} +5 seconds";
-		$closure = $this->File->write($keys, $expiry);
-		$closure($this->File, compact('keys', 'expiry'));
+		$this->File->write($keys, $expiry);
 
 		$file = Libraries::get(true, 'resources') . '/tmp/cache/key1';
 
@@ -201,8 +189,7 @@ class FileTest extends \lithium\test\Unit {
 		$keys = array('key1' => 'data1');
 		$time = $now + 5;
 		$expiry = 5;
-		$closure = $this->File->write($keys, $expiry);
-		$closure($this->File, compact('keys', 'expiry'));
+		$this->File->write($keys, $expiry);
 
 		$file = Libraries::get(true, 'resources') . '/tmp/cache/key1';
 
@@ -222,8 +209,7 @@ class FileTest extends \lithium\test\Unit {
 		$keys = array(
 			'key1' => 'test1'
 		);
-		$result = $adapter->write($keys, $expiry);
-		$result($adapter, compact('keys', 'expiry'));
+		$adapter->write($keys, $expiry);
 
 		$file = Libraries::get(true, 'resources') . '/tmp/cache/primary_key1';
 
@@ -237,15 +223,12 @@ class FileTest extends \lithium\test\Unit {
 		$keys = array($key);
 		$time = time() + 60;
 
-		$closure = $this->File->read($keys);
-		$this->assertInternalType('callable', $closure);
-
 		$path = Libraries::get(true, 'resources') . "/tmp/cache/{$key}";
 		file_put_contents($path, "{:expiry:$time}\ndata");
 		$this->assertFileExists($path);
 
 		$params = compact('keys');
-		$result = $closure($this->File, $params, null);
+		$result = $this->File->read($keys);
 		$this->assertEqual(array($key => 'data'), $result);
 
 		unlink($path);
@@ -273,8 +256,7 @@ class FileTest extends \lithium\test\Unit {
 			'key2',
 			'key3'
 		);
-		$closure = $this->File->read($keys);
-		$result = $closure($this->File, compact('keys'));
+		$result = $this->File->read($keys);
 		$this->assertEqual($expected, $result);
 
 		$this->File->delete($keys);
@@ -285,8 +267,6 @@ class FileTest extends \lithium\test\Unit {
 		$keys = array($key);
 		$time = time() + 1;
 
-		$closure = $this->File->read($keys);
-		$this->assertInternalType('callable', $closure);
 		$path = Libraries::get(true, 'resources') . "/tmp/cache/{$key}";
 
 		file_put_contents($path, "{:expiry:$time}\ndata");
@@ -295,17 +275,16 @@ class FileTest extends \lithium\test\Unit {
 		sleep(2);
 
 		$expected = array();
-		$result = $closure($this->File, compact('keys'));
+		$result= $this->File->read($keys);
 		$this->assertIdentical($expected, $result);
 	}
 
 	public function testReadKeyThatDoesNotExist() {
 		$key = 'does_not_exist';
 		$keys = array($key);
-		$closure = $this->File->read($keys);
 
 		$expected = array();
-		$result = $closure($this->File, compact('keys'));
+		$result = $this->File->read($keys);
 		$this->assertIdentical($expected, $result);
 	}
 
@@ -325,7 +304,6 @@ class FileTest extends \lithium\test\Unit {
 		$keys = array('key1');
 		$expected = array('key1' => 'test1');
 		$result = $adapter->read($keys);
-		$result = $result($adapter, compact('keys'));
 		$this->assertEqual($expected, $result);
 	}
 
@@ -335,11 +313,11 @@ class FileTest extends \lithium\test\Unit {
 			'key1' => null
 		);
 		$result = $this->File->write($keys);
-		$this->assertTrue($result($this->File, compact('keys', 'expiry')));
+		$this->assertTrue($result);
 
 		$expected = $keys;
 		$result = $this->File->read(array_keys($keys));
-		$this->assertEqual($expected, $result($this->File, array('keys' => array_keys($keys))));
+		$this->assertEqual($expected, $result);
 	}
 
 	public function testWriteAndReadNullMulti() {
@@ -349,18 +327,18 @@ class FileTest extends \lithium\test\Unit {
 			'key2' => 'data2'
 		);
 		$result = $this->File->write($keys);
-		$this->assertTrue($result($this->File, compact('keys', 'expiry')));
+		$this->assertTrue($result);
 
 		$expected = $keys;
 		$result = $this->File->read(array_keys($keys));
-		$this->assertEqual($expected, $result($this->File, array('keys' => array_keys($keys))));
+		$this->assertEqual($expected, $result);
 
 		$keys = array(
 			'key1' => null,
 			'key2' => null
 		);
 		$result = $this->File->write($keys);
-		$this->assertTrue($result($this->File, compact('keys', 'expiry')));
+		$this->assertTrue($result);
 	}
 
 	public function testDelete() {
@@ -372,16 +350,14 @@ class FileTest extends \lithium\test\Unit {
 		file_put_contents($path, "{:expiry:$time}\ndata");
 		$this->assertFileExists($path);
 
-		$closure = $this->File->delete($keys);
-		$this->assertInternalType('callable', $closure);
 
-		$params = compact('keys');
-		$this->assertTrue($closure($this->File, $params));
+		$result = $this->File->delete($keys);
+		$this->assertTrue($result);
 
 		$key = 'non_existent';
 		$keys = array($key);
-		$params = compact('keys');
-		$this->assertFalse($closure($this->File, $params));
+		$result = $this->File->delete($keys);
+		$this->assertFalse($result);
 	}
 
 	public function testDeleteWithScope() {
@@ -398,8 +374,7 @@ class FileTest extends \lithium\test\Unit {
 		}
 
 		$keys = array('key1');
-		$result = $adapter->delete($keys);
-		$result($adapter, compact('keys'));
+		$adapter->delete($keys);
 
 		$file = Libraries::get(true, 'resources') . "/tmp/cache/key1";
 		$result = file_exists($file);

--- a/tests/cases/storage/cache/adapter/MemcacheTest.php
+++ b/tests/cases/storage/cache/adapter/MemcacheTest.php
@@ -56,8 +56,8 @@ class MemcacheTest extends \lithium\test\Unit {
 		$expiry = '+5 seconds';
 		$time = strtotime($expiry);
 
-		$closure = $this->memcache->write($keys, $expiry);
-		$this->assertEqual($keys, $closure($this->memcache, compact('keys', 'expiry')));
+		$result = $this->memcache->write($keys, $expiry);
+		$this->assertEqual($keys, $result);
 		$this->assertEqual($data, $this->_conn->get($key));
 
 		$result = $this->_conn->delete($key);
@@ -69,12 +69,8 @@ class MemcacheTest extends \lithium\test\Unit {
 		$expiry = '+1 minute';
 		$time = strtotime($expiry);
 
-		$closure = $this->memcache->write($keys, $expiry);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys', 'expiry');
-		$result = $closure($this->memcache, $params);
 		$expected = $keys;
+		$result = $this->memcache->write($keys, $expiry);
 		$this->assertEqual($expected, $result);
 
 		$expected = $data;
@@ -91,11 +87,7 @@ class MemcacheTest extends \lithium\test\Unit {
 		$data = 'value';
 		$keys = array($key => $data);
 
-		$closure = $memcache->write($keys);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys');
-		$result = $closure($memcache, $params);
+		$result = $memcache->write($keys);
 		$expected = $keys;
 		$this->assertEqual($expected, $result);
 
@@ -113,8 +105,7 @@ class MemcacheTest extends \lithium\test\Unit {
 		$adapter = new Memcache(array('expiry' => null));
 		$expiry = null;
 
-		$closure = $adapter->write($keys, $expiry);
-		$result = $closure($adapter, compact('keys', 'expiry'));
+		$result = $adapter->write($keys, $expiry);
 		$this->assertTrue($result);
 
 		$result = (boolean) $this->_conn->get('key1');
@@ -125,8 +116,7 @@ class MemcacheTest extends \lithium\test\Unit {
 		$adapter = new Memcache(array('expiry' => Cache::PERSIST));
 		$expiry = Cache::PERSIST;
 
-		$closure = $adapter->write($keys, $expiry);
-		$result = $closure($adapter, compact('keys', 'expiry'));
+		$result = $adapter->write($keys, $expiry);
 		$this->assertTrue($result);
 
 		$result = (boolean) $this->_conn->get('key1');
@@ -137,8 +127,7 @@ class MemcacheTest extends \lithium\test\Unit {
 		$adapter = new Memcache();
 		$expiry = Cache::PERSIST;
 
-		$closure = $adapter->write($keys, $expiry);
-		$result = $closure($adapter, compact('keys', 'expiry'));
+		$result = $adapter->write($keys, $expiry);
 		$this->assertTrue($result);
 
 		$result = (boolean) $this->_conn->get('key1');
@@ -150,8 +139,7 @@ class MemcacheTest extends \lithium\test\Unit {
 	public function testWriteExpiryExpires() {
 		$keys = array('key1' => 'data1');
 		$expiry = '+5 seconds';
-		$closure = $this->memcache->write($keys, $expiry);
-		$closure($this->memcache, compact('keys', 'expiry'));
+		$this->memcache->write($keys, $expiry);
 
 		$result = (boolean) $this->_conn->get('key1');
 		$this->assertTrue($result);
@@ -160,8 +148,7 @@ class MemcacheTest extends \lithium\test\Unit {
 
 		$keys = array('key1' => 'data1');
 		$expiry = '+1 second';
-		$closure = $this->memcache->write($keys, $expiry);
-		$closure($this->memcache, compact('keys', 'expiry'));
+		$this->memcache->write($keys, $expiry);
 
 		sleep(2);
 
@@ -172,8 +159,7 @@ class MemcacheTest extends \lithium\test\Unit {
 	public function testWriteExpiryTtl() {
 		$keys = array('key1' => 'data1');
 		$expiry = 5;
-		$closure = $this->memcache->write($keys, $expiry);
-		$closure($this->memcache, compact('keys', 'expiry'));
+		$this->memcache->write($keys, $expiry);
 
 		$result = (boolean) $this->_conn->get('key1');
 		$this->assertTrue($result);
@@ -182,8 +168,7 @@ class MemcacheTest extends \lithium\test\Unit {
 
 		$keys = array('key1' => 'data1');
 		$expiry = 1;
-		$closure = $this->memcache->write($keys, $expiry);
-		$closure($this->memcache, compact('keys', 'expiry'));
+		$this->memcache->write($keys, $expiry);
 
 		sleep(2);
 
@@ -200,11 +185,7 @@ class MemcacheTest extends \lithium\test\Unit {
 			'key3' => 'data3'
 		);
 
-		$closure = $this->memcache->write($keys, $expiry);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys', 'expiry');
-		$result = $closure($this->memcache, $params);
+		$result = $this->memcache->write($keys, $expiry);
 		$this->assertTrue($result);
 
 		$result = $this->_conn->getMulti(array_keys($keys));
@@ -222,8 +203,7 @@ class MemcacheTest extends \lithium\test\Unit {
 
 		$keys = array('key1' => 'test1');
 		$expiry = '+1 minute';
-		$result = $adapter->write($keys, $expiry);
-		$result($adapter, compact('keys', 'expiry'));
+		$adapter->write($keys, $expiry);
 
 		$expected = 'test1';
 		$result = $this->_conn->get('primary:key1');
@@ -242,12 +222,8 @@ class MemcacheTest extends \lithium\test\Unit {
 		$result = $this->_conn->set($key, $data, $time);
 		$this->assertTrue($result);
 
-		$closure = $this->memcache->read($keys);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys');
-		$result = $closure($this->memcache, $params);
 		$expected = array($key => $data);
+		$result = $this->memcache->read($keys);
 		$this->assertEqual($expected, $result);
 
 		$result = $this->_conn->delete($key);
@@ -261,12 +237,8 @@ class MemcacheTest extends \lithium\test\Unit {
 		$result = $this->_conn->set($key, $data, $time);
 		$this->assertTrue($result);
 
-		$closure = $this->memcache->read($keys);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys');
-		$result = $closure($this->memcache, $params);
 		$expected = array($key => $data);
+		$result = $this->memcache->read($keys);
 		$this->assertEqual($expected, $result);
 
 		$result = $this->_conn->delete($key);
@@ -285,11 +257,7 @@ class MemcacheTest extends \lithium\test\Unit {
 		$result = $this->_conn->setMulti($keys, $time);
 		$this->assertTrue($result);
 
-		$closure = $this->memcache->read(array_keys($keys));
-		$this->assertInternalType('callable', $closure);
-
-		$params = array('keys' => array_keys($keys));
-		$result = $closure($this->memcache, $params);
+		$result = $this->memcache->read(array_keys($keys));
 		$expected = array(
 			'key1' => 'data1',
 			'key2' => 'data2',
@@ -306,10 +274,9 @@ class MemcacheTest extends \lithium\test\Unit {
 	public function testReadKeyThatDoesNotExist() {
 		$key = 'does_not_exist';
 		$keys = array($key);
-		$closure = $this->memcache->read($keys);
 
 		$expected = array();
-		$result = $closure($this->memcache, compact('keys'));
+		$result = $this->memcache->read($keys);
 		$this->assertIdentical($expected, $result);
 	}
 
@@ -322,7 +289,6 @@ class MemcacheTest extends \lithium\test\Unit {
 		$keys = array('key1');
 		$expected = array('key1' => 'test1');
 		$result = $adapter->read($keys);
-		$result = $result($adapter, compact('keys'));
 		$this->assertEqual($expected, $result);
 	}
 
@@ -334,16 +300,14 @@ class MemcacheTest extends \lithium\test\Unit {
 		$this->_conn->set($key, $data, $time);
 
 		$expected = array($key => $data);
-		$reader = $this->memcache->read($keys);
-		$result = $reader($this->memcache, compact('keys'));
+		$result = $this->memcache->read($keys);
 		$this->assertEqual($expected, $result);
 
-		$delete = $this->memcache->delete($keys);
-		$this->assertInternalType('callable', $delete);
-		$this->assertTrue($delete($this->memcache, compact('keys')));
+		$result = $this->memcache->delete($keys);
+		$this->assertTrue($result);
 
 		$expected = array();
-		$result = $reader($this->memcache, compact('keys'));
+		$result = $this->memcache->read($keys);
 		$this->assertIdentical($expected, $result);
 	}
 
@@ -351,11 +315,8 @@ class MemcacheTest extends \lithium\test\Unit {
 		$key = 'delete_key';
 		$keys = array($key);
 
-		$closure = $this->memcache->delete($keys);
-		$this->assertInternalType('callable', $closure);
-
 		$params = compact('keys');
-		$result = $closure($this->memcache, $params);
+		$result = $this->memcache->delete($keys);
 		$this->assertFalse($result);
 	}
 
@@ -367,8 +328,7 @@ class MemcacheTest extends \lithium\test\Unit {
 
 		$keys = array('key1');
 		$expected = array('key1' => 'test1');
-		$result = $adapter->delete($keys);
-		$result($adapter, compact('keys'));
+		$adapter->delete($keys);
 
 		$result = (boolean) $this->_conn->get('key1');
 		$this->assertTrue($result);
@@ -415,23 +375,16 @@ class MemcacheTest extends \lithium\test\Unit {
 		$expiry = '+5 seconds';
 		$time = strtotime($expiry);
 
-		$writer = $this->memcache->write($keys, $expiry);
-		$this->assertEqual($data, $writer($this->memcache, compact('keys', 'expiry')));
+		$result = $this->memcache->write($keys, $expiry);
+		$this->assertEqual($data, $result);
 		$this->assertEqual($data, $this->_conn->get($key));
 
-		$closure = $this->memcache->read(array_keys($keys));
-		$this->assertInternalType('callable', $closure);
 
 		$expected = $keys;
-		$params = array('keys' => array_keys($keys));
-		$result = $closure($this->memcache, $params);
+		$result = $this->memcache->read(array_keys($keys));
 		$this->assertEqual($expected, $result);
 
-		$closure = $this->memcache->delete(array_keys($keys));
-		$this->assertInternalType('callable', $closure);
-
-		$params = array('keys' => array_keys($keys));
-		$result = $closure($this->memcache, $params);
+		$result = $this->memcache->delete(array_keys($keys));
 		$this->assertTrue($result);
 
 		$this->assertFalse($this->_conn->get($key));
@@ -443,11 +396,11 @@ class MemcacheTest extends \lithium\test\Unit {
 			'key1' => null
 		);
 		$result = $this->memcache->write($keys);
-		$this->assertTrue($result($this->memcache, compact('keys', 'expiry')));
+		$this->assertTrue($result);
 
 		$expected = $keys;
 		$result = $this->memcache->read(array_keys($keys));
-		$this->assertEqual($expected, $result($this->memcache, array('keys' => array_keys($keys))));
+		$this->assertEqual($expected, $result);
 	}
 
 	public function testWriteAndReadNullMulti() {
@@ -457,18 +410,18 @@ class MemcacheTest extends \lithium\test\Unit {
 			'key2' => 'data2'
 		);
 		$result = $this->memcache->write($keys);
-		$this->assertTrue($result($this->memcache, compact('keys', 'expiry')));
+		$this->assertTrue($result);
 
 		$expected = $keys;
 		$result = $this->memcache->read(array_keys($keys));
-		$this->assertEqual($expected, $result($this->memcache, array('keys' => array_keys($keys))));
+		$this->assertEqual($expected, $result);
 
 		$keys = array(
 			'key1' => null,
 			'key2' => null
 		);
 		$result = $this->memcache->write($keys);
-		$this->assertTrue($result($this->memcache, compact('keys', 'expiry')));
+		$this->assertTrue($result);
 	}
 
 	public function testClear() {
@@ -495,11 +448,7 @@ class MemcacheTest extends \lithium\test\Unit {
 		$result = $this->_conn->set($key, $value, $time);
 		$this->assertTrue($result);
 
-		$closure = $this->memcache->decrement($key);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('key');
-		$result = $closure($this->memcache, $params);
+		$result = $this->memcache->decrement($key);
 		$this->assertEqual($value - 1, $result);
 
 		$result = $this->_conn->get($key);
@@ -517,11 +466,7 @@ class MemcacheTest extends \lithium\test\Unit {
 		$result = $this->_conn->set($key, $value, $time);
 		$this->assertTrue($result);
 
-		$closure = $this->memcache->decrement($key);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('key');
-		$result = $closure($this->memcache, $params);
+		$this->memcache->decrement($key);
 
 		$result = $this->_conn->get($key);
 		$this->assertEqual(0, $result);
@@ -536,8 +481,7 @@ class MemcacheTest extends \lithium\test\Unit {
 		$this->_conn->set('primary:key1', 1, 60);
 		$this->_conn->set('key1', 1, 60);
 
-		$result = $adapter->decrement('key1');
-		$result($adapter, array('key' => 'key1'));
+		$adapter->decrement('key1');
 
 		$expected = 1;
 		$result = $this->_conn->get('key1');
@@ -555,10 +499,7 @@ class MemcacheTest extends \lithium\test\Unit {
 
 		$this->assertTrue($this->_conn->set($key, $value, $time));
 
-		$closure = $this->memcache->increment($key);
-		$this->assertInternalType('callable', $closure);
-
-		$result = $closure($this->memcache, compact('key'));
+		$result = $this->memcache->increment($key);
 		$this->assertEqual($value + 1, $result);
 		$this->assertEqual($value + 1, $this->_conn->get($key));
 
@@ -574,10 +515,7 @@ class MemcacheTest extends \lithium\test\Unit {
 		$result = $this->_conn->set($key, $value, $time);
 		$this->assertTrue($result);
 
-		$closure = $this->memcache->increment($key);
-		$this->assertInternalType('callable', $closure);
-
-		$result = $closure($this->memcache, compact('key'));
+		$this->memcache->increment($key);
 
 		$result = $this->_conn->get($key);
 		$this->assertEqual(0, $result);
@@ -592,8 +530,7 @@ class MemcacheTest extends \lithium\test\Unit {
 		$this->_conn->set('primary:key1', 1, 60);
 		$this->_conn->set('key1', 1, 60);
 
-		$result = $adapter->increment('key1');
-		$result($adapter, array('key' => 'key1'));
+		$adapter->increment('key1');
 
 		$expected = 1;
 		$result = $this->_conn->get('key1');

--- a/tests/cases/storage/cache/adapter/MemoryTest.php
+++ b/tests/cases/storage/cache/adapter/MemoryTest.php
@@ -31,19 +31,11 @@ class MemoryTest extends \lithium\test\Unit {
 		$keys = array($key => $data);
 		$expiry = null;
 
-		$closure = $this->Memory->write($keys, $expiry);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys', 'expiry');
-		$result = $closure($this->Memory, $params);
+		$result = $this->Memory->write($keys, $expiry);
 		$this->assertTrue($result);
 		$this->assertEqual($this->Memory->cache, $result);
 
-		$closure = $this->Memory->read($keys);
-		$this->assertInternalType('callable', $closure);
-
-		$params = array('keys' => array_keys($keys));
-		$result = $closure($this->Memory, $params);
+		$result = $this->Memory->read(array_keys($keys));
 		$this->assertEqual($keys, $result);
 		$this->assertEqual($this->Memory->cache, array($key => $data));
 	}
@@ -52,19 +44,11 @@ class MemoryTest extends \lithium\test\Unit {
 		$keys = array('write1' => 'value1', 'write2' => 'value2');
 		$expiry = null;
 
-		$closure = $this->Memory->write($keys, $expiry);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys', 'expiry');
-		$result = $closure($this->Memory, $params);
+		$result = $this->Memory->write($keys, $expiry);
 		$this->assertTrue($result);
 		$this->assertEqual($this->Memory->cache, $result);
 
-		$closure = $this->Memory->read(array_keys($keys));
-		$this->assertInternalType('callable', $closure);
-
-		$params = array('keys' => array_keys($keys));
-		$result = $closure($this->Memory, $params);
+		$result = $this->Memory->read(array_keys($keys));
 		$this->assertEqual($keys, $result);
 	}
 
@@ -74,11 +58,11 @@ class MemoryTest extends \lithium\test\Unit {
 			'key1' => null
 		);
 		$result = $this->Memory->write($keys);
-		$this->assertTrue($result($this->Memory, compact('keys', 'expiry')));
+		$this->assertTrue($result);
 
 		$expected = $keys;
 		$result = $this->Memory->read(array_keys($keys));
-		$this->assertEqual($expected, $result($this->Memory, array('keys' => array_keys($keys))));
+		$this->assertEqual($expected, $result);
 	}
 
 	public function testWriteAndReadNullMulti() {
@@ -88,18 +72,18 @@ class MemoryTest extends \lithium\test\Unit {
 			'key2' => 'data2'
 		);
 		$result = $this->Memory->write($keys);
-		$this->assertTrue($result($this->Memory, compact('keys', 'expiry')));
+		$this->assertTrue($result);
 
 		$expected = $keys;
 		$result = $this->Memory->read(array_keys($keys));
-		$this->assertEqual($expected, $result($this->Memory, array('keys' => array_keys($keys))));
+		$this->assertEqual($expected, $result);
 
 		$keys = array(
 			'key1' => null,
 			'key2' => null
 		);
 		$result = $this->Memory->write($keys);
-		$this->assertTrue($result($this->Memory, compact('keys', 'expiry')));
+		$this->assertTrue($result);
 	}
 
 	public function testWriteAndDelete() {
@@ -108,24 +92,15 @@ class MemoryTest extends \lithium\test\Unit {
 		$keys = array($key);
 		$expiry = null;
 
-		$closure = $this->Memory->write(array($key => $data), $expiry);
-		$this->assertInternalType('callable', $closure);
-
-		$params = array('keys' => array($key => $data));
-		$result = $closure($this->Memory, $params);
+		$result = $this->Memory->write(array($key => $data), $expiry);
 		$this->assertTrue($result);
 		$this->assertEqual($this->Memory->cache, $result);
 
-		$closure = $this->Memory->delete($keys);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys');
-		$result = $closure($this->Memory, $params, null);
+		$result = $this->Memory->delete($keys);
 		$this->assertTrue($result);
 
 		$keys = array('non_existent');
-		$params = compact('keys');
-		$result = $closure($this->Memory, $params, null);
+		$result = $this->Memory->delete($keys);
 		$this->assertFalse($result);
 	}
 
@@ -135,22 +110,14 @@ class MemoryTest extends \lithium\test\Unit {
 		$keys = array($key);
 		$expiry = null;
 
-		$closure = $this->Memory->write(array($key => $data), $expiry);
-		$this->assertInternalType('callable', $closure);
-
-		$params = array('keys' => array($key => $data));
-		$result = $closure($this->Memory, $params);
+		$result = $this->Memory->write(array($key => $data), $expiry);
 		$this->assertTrue($result);
 		$this->assertEqual($this->Memory->cache, $result);
 
 		$key2 = 'key2_to_clear';
 		$data2 = 'data to be cleared';
 
-		$closure = $this->Memory->write(array($key2 => $data2), $expiry);
-		$this->assertInternalType('callable', $closure);
-
-		$params = array('keys' => array($key2 => $data2));
-		$result = $closure($this->Memory, $params);
+		$result = $this->Memory->write(array($key2 => $data2), $expiry);
 		$this->assertTrue($result);
 		$this->assertEqual($this->Memory->cache, $result);
 
@@ -158,18 +125,13 @@ class MemoryTest extends \lithium\test\Unit {
 		$this->assertTrue($result);
 		$this->assertEqual(array(), $this->Memory->cache);
 
-		$closure = $this->Memory->write(array($key => $data), $expiry);
-		$this->assertInternalType('callable', $closure);
-
-		$params = array('keys' => array($key => $data));
-		$result = $closure($this->Memory, $params, null);
+		$result = $this->Memory->write(array($key => $data), $expiry);
 		$this->assertTrue($result);
 		$this->assertEqual($this->Memory->cache, $result);
 
 		$result = $this->Memory->clear();
 		$this->assertTrue($result);
 		$this->assertEqual(array(), $this->Memory->cache);
-
 	}
 
 	public function testIncrement() {
@@ -178,18 +140,11 @@ class MemoryTest extends \lithium\test\Unit {
 		$keys = array($key => $data);
 		$expiry = null;
 
-		$closure = $this->Memory->write($keys, $expiry);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys');
-		$result = $closure($this->Memory, $params, null);
+		$result = $this->Memory->write($keys, $expiry);
 		$this->assertTrue($result);
 		$this->assertEqual($this->Memory->cache, $result);
 
-		$closure = $this->Memory->increment($key);
-		$params = compact('key');
-
-		$result = $closure($this->Memory, $params, null);
+		$result = $this->Memory->increment($key);
 		$this->assertEqual($data + 1, $result);
 	}
 
@@ -199,28 +154,20 @@ class MemoryTest extends \lithium\test\Unit {
 		$keys = array($key => $data);
 		$expiry = null;
 
-		$closure = $this->Memory->write($keys, $expiry);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys');
-		$result = $closure($this->Memory, $params, null);
+		$result = $this->Memory->write($keys, $expiry);
 		$this->assertTrue($result);
 		$this->assertEqual($this->Memory->cache, $result);
 
-		$closure = $this->Memory->decrement($key);
-		$params = compact('key');
-
-		$result = $closure($this->Memory, $params, null);
+		$result = $this->Memory->decrement($key);
 		$this->assertEqual($data - 1, $result);
 	}
 
 	public function testReadKeyThatDoesNotExist() {
 		$key = 'does_not_exist';
 		$keys = array($key);
-		$closure = $this->Memory->read($keys);
 
 		$expected = array();
-		$result = $closure($this->Memory, compact('keys'));
+		$result = $this->Memory->read($keys);
 		$this->assertIdentical($expected, $result);
 	}
 

--- a/tests/cases/storage/cache/adapter/RedisTest.php
+++ b/tests/cases/storage/cache/adapter/RedisTest.php
@@ -75,12 +75,8 @@ class RedisTest extends \lithium\test\Unit {
 		$expiry = '+5 seconds';
 		$time = strtotime($expiry);
 
-		$closure = $this->redis->write($keys, $expiry);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys', 'expiry');
-		$result = $closure($this->redis, $params, null);
 		$expected = $keys;
+		$result = $this->redis->write($keys, $expiry);
 		$this->assertEqual($expected, $result);
 
 		$expected = $data;
@@ -99,12 +95,8 @@ class RedisTest extends \lithium\test\Unit {
 		$expiry = '+1 minute';
 		$time = strtotime($expiry);
 
-		$closure = $this->redis->write($keys, $expiry);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys', 'expiry');
-		$result = $closure($this->redis, $params, null);
 		$expected = $keys;
+		$result = $this->redis->write($keys, $expiry);
 		$this->assertEqual($expected, $result);
 
 		$expected = $data;
@@ -125,12 +117,8 @@ class RedisTest extends \lithium\test\Unit {
 		$keys = array($key => $data);
 		$time = strtotime('+5 seconds');
 
-		$closure = $redis->write($keys);
-		$this->assertInternalType('callable', $closure);
-
 		$expected = $data;
-		$params = compact('keys');
-		$result = $closure($redis, $params);
+		$result = $redis->write($keys);
 		$this->assertEqual($expected, $result);
 
 		$result = $this->_redis->get($key);
@@ -151,8 +139,7 @@ class RedisTest extends \lithium\test\Unit {
 		$redis = new Redis(array('expiry' => null));
 		$expiry = null;
 
-		$closure = $redis->write($keys, $expiry);
-		$result = $closure($redis, compact('keys', 'expiry'));
+		$result = $redis->write($keys, $expiry);
 		$this->assertTrue($result);
 
 		$result = $this->_redis->exists($key);
@@ -167,8 +154,7 @@ class RedisTest extends \lithium\test\Unit {
 		$redis = new Redis(array('expiry' => Cache::PERSIST));
 		$expiry = Cache::PERSIST;
 
-		$closure = $redis->write($keys, $expiry);
-		$result = $closure($redis, compact('keys', 'expiry'));
+		$result = $redis->write($keys, $expiry);
 		$this->assertTrue($result);
 
 		$result = $this->_redis->exists($key);
@@ -183,8 +169,7 @@ class RedisTest extends \lithium\test\Unit {
 		$redis = new Redis();
 		$expiry = Cache::PERSIST;
 
-		$closure = $redis->write($keys, $expiry);
-		$result = $closure($redis, compact('keys', 'expiry'));
+		$result = $redis->write($keys, $expiry);
 		$this->assertTrue($result);
 
 		$result = $this->_redis->exists($key);
@@ -200,8 +185,7 @@ class RedisTest extends \lithium\test\Unit {
 	public function testWriteExpiryExpires() {
 		$keys = array('key1' => 'data1');
 		$expiry = '+5 seconds';
-		$closure = $this->redis->write($keys, $expiry);
-		$closure($this->redis, compact('keys', 'expiry'));
+		$this->redis->write($keys, $expiry);
 
 		$result = $this->_redis->exists('key1');
 		$this->assertTrue($result);
@@ -210,8 +194,7 @@ class RedisTest extends \lithium\test\Unit {
 
 		$keys = array('key1' => 'data1');
 		$expiry = '+1 second';
-		$closure = $this->redis->write($keys, $expiry);
-		$closure($this->redis, compact('keys', 'expiry'));
+		$this->redis->write($keys, $expiry);
 
 		sleep(2);
 
@@ -222,8 +205,7 @@ class RedisTest extends \lithium\test\Unit {
 	public function testWriteExpiryTtl() {
 		$keys = array('key1' => 'data1');
 		$expiry = 5;
-		$closure = $this->redis->write($keys, $expiry);
-		$closure($this->redis, compact('keys', 'expiry'));
+		$this->redis->write($keys, $expiry);
 
 		$result = $this->_redis->exists('key1');
 		$this->assertTrue($result);
@@ -232,8 +214,7 @@ class RedisTest extends \lithium\test\Unit {
 
 		$keys = array('key1' => 'data1');
 		$expiry = 1;
-		$closure = $this->redis->write($keys, $expiry);
-		$closure($this->redis, compact('keys', 'expiry'));
+		$this->redis->write($keys, $expiry);
 
 		sleep(2);
 
@@ -246,8 +227,7 @@ class RedisTest extends \lithium\test\Unit {
 
 		$keys = array('key1' => 'test1');
 		$expiry = '+1 minute';
-		$result = $adapter->write($keys, $expiry);
-		$result($adapter, compact('keys', 'expiry'));
+		$adapter->write($keys, $expiry);
 
 		$expected = 'test1';
 		$result = $this->_redis->get('primary:key1');
@@ -265,12 +245,8 @@ class RedisTest extends \lithium\test\Unit {
 		$result = $this->_redis->set($key, $data);
 		$this->assertTrue($result);
 
-		$closure = $this->redis->read($keys);
-		$this->assertInternalType('callable', $closure);
-
 		$expected = array($key => $data);
-		$params = compact('keys');
-		$result = $closure($this->redis, $params);
+		$result = $this->redis->read($keys);
 		$this->assertEqual($expected, $result);
 
 		$result = $this->_redis->delete($key);
@@ -288,12 +264,9 @@ class RedisTest extends \lithium\test\Unit {
 		$result = $this->_redis->ttl($key);
 		$this->assertTrue($result == $expiry || $result == $expiry - 1);
 
-		$closure = $this->redis->read($keys);
-		$this->assertInternalType('callable', $closure);
 
 		$expected = array($key => $data);
-		$params = compact('keys');
-		$result = $closure($this->redis, $params, null);
+		$result = $this->redis->read($keys);
 		$this->assertEqual($expected, $result);
 
 		$result = $this->_redis->delete($key);
@@ -305,12 +278,8 @@ class RedisTest extends \lithium\test\Unit {
 		$result = $this->_redis->mset($data);
 		$this->assertTrue($result);
 
-		$closure = $this->redis->read(array_keys($data));
-		$this->assertInternalType('callable', $closure);
-
-		$params = array('keys' => array_keys($data));
-		$result = $closure($this->redis, $params, null);
 		$expected = $data;
+		$result = $this->redis->read(array_keys($data));
 		$this->assertEqual($expected, $result);
 
 		foreach ($data as $k => $v) {
@@ -324,11 +293,7 @@ class RedisTest extends \lithium\test\Unit {
 		$expiry = '+5 seconds';
 		$time = strtotime($expiry);
 
-		$closure = $this->redis->write($keys, $expiry);
-		$this->assertInternalType('callable', $closure);
-
-		$params = array('keys' => $keys, 'expiry' => null);
-		$result = $closure($this->redis, $params, null);
+		$result = $this->redis->write($keys, $expiry);
 		$this->assertTrue($result);
 
 		$result = $this->_redis->getMultiple(array_keys($keys));
@@ -339,10 +304,9 @@ class RedisTest extends \lithium\test\Unit {
 	public function testReadKeyThatDoesNotExist() {
 		$key = 'does_not_exist';
 		$keys = array($key);
-		$closure = $this->redis->read($keys);
 
 		$expected = array();
-		$result = $closure($this->redis, compact('keys'));
+		$result = $this->redis->read($keys);
 		$this->assertIdentical($expected, $result);
 	}
 
@@ -352,11 +316,11 @@ class RedisTest extends \lithium\test\Unit {
 			'key1' => null
 		);
 		$result = $this->redis->write($keys);
-		$this->assertTrue($result($this->redis, compact('keys', 'expiry')));
+		$this->assertTrue($result);
 
 		$expected = $keys;
 		$result = $this->redis->read(array_keys($keys));
-		$this->assertEqual($expected, $result($this->redis, array('keys' => array_keys($keys))));
+		$this->assertEqual($expected, $result);
 	}
 
 	public function testWriteAndReadNullMulti() {
@@ -366,18 +330,18 @@ class RedisTest extends \lithium\test\Unit {
 			'key2' => 'data2'
 		);
 		$result = $this->redis->write($keys);
-		$this->assertTrue($result($this->redis, compact('keys', 'expiry')));
+		$this->assertTrue($result);
 
 		$expected = $keys;
 		$result = $this->redis->read(array_keys($keys));
-		$this->assertEqual($expected, $a = $result($this->redis, array('keys' => array_keys($keys))));
+		$this->assertEqual($expected, $result);
 
 		$keys = array(
 			'key1' => '',
 			'key2' => 'data2'
 		);
 		$result = $this->redis->write($keys);
-		$this->assertTrue($result($this->redis, compact('keys', 'expiry')));
+		$this->assertTrue($result);
 	}
 
 	public function testReadWithScope() {
@@ -389,7 +353,6 @@ class RedisTest extends \lithium\test\Unit {
 		$keys = array('key1');
 		$expected = array('key1' => 'test1');
 		$result = $adapter->read($keys);
-		$result = $result($adapter, compact('keys'));
 		$this->assertEqual($expected, $result);
 	}
 
@@ -402,11 +365,7 @@ class RedisTest extends \lithium\test\Unit {
 		$result = $this->_redis->set($key, $data);
 		$this->assertTrue($result);
 
-		$closure = $this->redis->delete($keys);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys');
-		$result = $closure($this->redis, $params);
+		$result = $this->redis->delete($keys);
 		$this->assertTrue($result);
 
 		$this->assertEqual(0, $this->_redis->delete($key));
@@ -415,11 +374,8 @@ class RedisTest extends \lithium\test\Unit {
 	public function testDeleteNonExistentKey() {
 		$key = 'delete_key';
 		$keys = array($key);
-		$closure = $this->redis->delete($keys);
-		$this->assertInternalType('callable', $closure);
 
-		$params = compact('keys');
-		$result = $closure($this->redis, $params, null);
+		$result = $this->redis->delete($keys);
 		$this->assertFalse($result);
 	}
 
@@ -431,8 +387,7 @@ class RedisTest extends \lithium\test\Unit {
 
 		$keys = array('key1');
 		$expected = array('key1' => 'test1');
-		$result = $adapter->delete($keys);
-		$result($adapter, compact('keys'));
+		$adapter->delete($keys);
 
 		$result = (boolean) $this->_redis->get('key1');
 		$this->assertTrue($result);
@@ -448,31 +403,19 @@ class RedisTest extends \lithium\test\Unit {
 		$expiry = '+5 seconds';
 		$time = strtotime($expiry);
 
-		$closure = $this->redis->write($keys, $expiry);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys', 'expiry');
-		$result = $closure($this->redis, $params);
 		$expected = $keys;
+		$result = $this->redis->write($keys, $expiry);
 		$this->assertEqual($expected, $result);
 
 		$expected = $data;
 		$result = $this->_redis->get($key);
 		$this->assertEqual($expected, $result);
 
-		$closure = $this->redis->read(array_keys($keys));
-		$this->assertInternalType('callable', $closure);
-
-		$params = array('keys' => array_keys($keys));
-		$result = $closure($this->redis, $params);
 		$expected = $keys;
+		$result = $this->redis->read(array_keys($keys));
 		$this->assertEqual($expected, $result);
 
-		$closure = $this->redis->delete(array_keys($keys));
-		$this->assertInternalType('callable', $closure);
-
-		$params = array('keys' => array_keys($keys));
-		$result = $closure($this->redis, $params);
+		$result = $this->redis->delete(array_keys($keys));
 		$this->assertTrue($result);
 
 		$this->assertFalse($this->_redis->get($key));
@@ -499,11 +442,7 @@ class RedisTest extends \lithium\test\Unit {
 		$result = $this->_redis->set($key, $value);
 		$this->assertTrue($result);
 
-		$closure = $this->redis->decrement($key);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('key');
-		$result = $closure($this->redis, $params, null);
+		$result = $this->redis->decrement($key);
 		$this->assertEqual($value - 1, $result);
 
 		$result = $this->_redis->get($key);
@@ -520,11 +459,7 @@ class RedisTest extends \lithium\test\Unit {
 		$result = $this->_redis->set($key, $value);
 		$this->assertTrue($result);
 
-		$closure = $this->redis->decrement($key);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('key');
-		$result = $closure($this->redis, $params, null);
+		$result = $this->redis->decrement($key);
 		$this->assertFalse($result);
 
 		$result = $this->_redis->get($key);
@@ -540,8 +475,7 @@ class RedisTest extends \lithium\test\Unit {
 		$this->_redis->set('primary:key1', 1, 60);
 		$this->_redis->set('key1', 1, 60);
 
-		$result = $adapter->decrement('key1');
-		$result($adapter, array('key' => 'key1'));
+		$adapter->decrement('key1');
 
 		$expected = 1;
 		$result = $this->_redis->get('key1');
@@ -559,11 +493,7 @@ class RedisTest extends \lithium\test\Unit {
 		$result = $this->_redis->set($key, $value);
 		$this->assertTrue($result);
 
-		$closure = $this->redis->increment($key);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('key');
-		$result = $closure($this->redis, $params, null);
+		$result = $this->redis->increment($key);
 		$this->assertEqual($value + 1, $result);
 
 		$result = $this->_redis->get($key);
@@ -580,11 +510,7 @@ class RedisTest extends \lithium\test\Unit {
 		$result = $this->_redis->set($key, $value);
 		$this->assertTrue($result);
 
-		$closure = $this->redis->increment($key);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('key');
-		$result = $closure($this->redis, $params, null);
+		$result = $this->redis->increment($key);
 		$this->assertFalse($result);
 
 		$result = $this->_redis->get($key);
@@ -600,8 +526,7 @@ class RedisTest extends \lithium\test\Unit {
 		$this->_redis->set('primary:key1', 1, 60);
 		$this->_redis->set('key1', 1, 60);
 
-		$result = $adapter->increment('key1');
-		$result($adapter, array('key' => 'key1'));
+		$adapter->increment('key1');
 
 		$expected = 1;
 		$result = $this->_redis->get('key1');

--- a/tests/cases/storage/cache/adapter/XCacheTest.php
+++ b/tests/cases/storage/cache/adapter/XCacheTest.php
@@ -54,11 +54,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$expiry = '+5 seconds';
 		$time = strtotime($expiry);
 
-		$closure = $this->XCache->write($keys, $expiry);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys', 'expiry');
-		$result = $closure($this->XCache, $params);
+		$result = $this->XCache->write($keys, $expiry);
 		$this->assertTrue($result);
 
 		$expected = $data;
@@ -74,11 +70,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$expiry = '+1 minute';
 		$time = strtotime($expiry);
 
-		$closure = $this->XCache->write($keys, $expiry);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys', 'expiry');
-		$result = $closure($this->XCache, $params);
+		$result = $this->XCache->write($keys, $expiry);
 		$this->assertTrue($result);
 
 		$expected = $data;
@@ -96,8 +88,7 @@ class XCacheTest extends \lithium\test\Unit {
 			'key2' => 'data2',
 			'key3' => 'data3'
 		);
-		$closure = $this->XCache->write($keys, $expiry);
-		$result = $closure($this->XCache, compact('keys', 'expiry'));
+		$result = $this->XCache->write($keys, $expiry);
 		$this->assertTrue($result);
 
 		foreach ($keys as $key => $data) {
@@ -116,11 +107,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$keys = array($key => $data);
 		$time = strtotime('+5 seconds');
 
-		$closure = $xCache->write($keys);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys');
-		$result = $closure($xCache, $params);
+		$result = $xCache->write($keys);
 		$this->assertTrue($result);
 
 		$expected = $data;
@@ -137,8 +124,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$adapter = new XCache(array('expiry' => null));
 		$expiry = null;
 
-		$closure = $adapter->write($keys, $expiry);
-		$result = $closure($adapter, compact('keys', 'expiry'));
+		$result = $adapter->write($keys, $expiry);
 		$this->assertTrue($result);
 
 		$result = xcache_isset('key1');
@@ -149,8 +135,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$adapter = new XCache(array('expiry' => Cache::PERSIST));
 		$expiry = Cache::PERSIST;
 
-		$closure = $adapter->write($keys, $expiry);
-		$result = $closure($adapter, compact('keys', 'expiry'));
+		$result = $adapter->write($keys, $expiry);
 		$this->assertTrue($result);
 
 		$result = xcache_isset('key1');
@@ -161,8 +146,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$adapter = new XCache();
 		$expiry = Cache::PERSIST;
 
-		$closure = $adapter->write($keys, $expiry);
-		$result = $closure($adapter, compact('keys', 'expiry'));
+		$result = $adapter->write($keys, $expiry);
 		$this->assertTrue($result);
 
 		$result = xcache_isset('key1');
@@ -180,8 +164,7 @@ class XCacheTest extends \lithium\test\Unit {
 	public function testWriteExpiryExpires() {
 		$keys = array('key1' => 'data1');
 		$expiry = '+5 seconds';
-		$closure = $this->XCache->write($keys, $expiry);
-		$closure($this->XCache, compact('keys', 'expiry'));
+		$this->XCache->write($keys, $expiry);
 
 		$result = xcache_isset('key1');
 		$this->assertTrue($result);
@@ -200,8 +183,7 @@ class XCacheTest extends \lithium\test\Unit {
 	public function testWriteExpiryTtl() {
 		$keys = array('key1' => 'data1');
 		$expiry = 5;
-		$closure = $this->XCache->write($keys, $expiry);
-		$closure($this->XCache, compact('keys', 'expiry'));
+		$this->XCache->write($keys, $expiry);
 
 		$result = xcache_isset('key1');
 		$this->assertTrue($result);
@@ -210,8 +192,7 @@ class XCacheTest extends \lithium\test\Unit {
 
 		$keys = array('key1' => 'data1');
 		$expiry = 1;
-		$closure = $this->XCache->write($keys, $expiry);
-		$closure($this->XCache, compact('keys', 'expiry'));
+		$this->XCache->write($keys, $expiry);
 	}
 
 	public function testWriteWithScope() {
@@ -219,8 +200,7 @@ class XCacheTest extends \lithium\test\Unit {
 
 		$keys = array('key1' => 'test1');
 		$expiry = '+1 minute';
-		$result = $adapter->write($keys, $expiry);
-		$result($adapter, compact('keys', 'expiry'));
+		$adapter->write($keys, $expiry);
 
 		$expected = 'test1';
 		$result = xcache_get('primary:key1');
@@ -239,12 +219,8 @@ class XCacheTest extends \lithium\test\Unit {
 		$result = xcache_set($key, $data, 60);
 		$this->assertTrue($result);
 
-		$closure = $this->XCache->read($keys);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys');
-		$result = $closure($this->XCache, $params);
 		$expected = array($key => $data);
+		$result = $this->XCache->read($keys);
 		$this->assertEqual($expected, $result);
 
 		$result = xcache_unset($key);
@@ -258,12 +234,8 @@ class XCacheTest extends \lithium\test\Unit {
 		$result = xcache_set($key, $data, 60);
 		$this->assertTrue($result);
 
-		$closure = $this->XCache->read($keys);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys');
-		$result = $closure($this->XCache, $params);
 		$expected = array($key => $data);
+		$result = $this->XCache->read($keys);
 		$this->assertEqual($expected, $result);
 
 		$result = xcache_unset($key);
@@ -273,10 +245,9 @@ class XCacheTest extends \lithium\test\Unit {
 	public function testReadKeyThatDoesNotExist() {
 		$key = 'does_not_exist';
 		$keys = array($key);
-		$closure = $this->XCache->read($keys);
 
 		$expected = array();
-		$result = $closure($this->XCache, compact('keys'));
+		$result = $this->XCache->read($keys);
 		$this->assertIdentical($expected, $result);
 	}
 
@@ -289,7 +260,6 @@ class XCacheTest extends \lithium\test\Unit {
 		$keys = array('key1');
 		$expected = array('key1' => 'test1');
 		$result = $adapter->read($keys);
-		$result = $result($adapter, compact('keys'));
 		$this->assertEqual($expected, $result);
 	}
 
@@ -313,8 +283,7 @@ class XCacheTest extends \lithium\test\Unit {
 			'key2',
 			'key3'
 		);
-		$closure = $this->XCache->read($keys);
-		$result = $closure($this->XCache, compact('keys'));
+		$result = $this->XCache->read($keys);
 		$this->assertEqual($expected, $result);
 
 		foreach ($keys as $key) {
@@ -328,11 +297,11 @@ class XCacheTest extends \lithium\test\Unit {
 			'key1' => null
 		);
 		$result = $this->XCache->write($keys);
-		$this->assertTrue($result($this->XCache, compact('keys', 'expiry')));
+		$this->assertTrue($result);
 
 		$expected = $keys;
 		$result = $this->XCache->read(array_keys($keys));
-		$this->assertEqual($expected, $result($this->XCache, array('keys' => array_keys($keys))));
+		$this->assertEqual($expected, $result);
 	}
 
 	public function testWriteAndReadNullMulti() {
@@ -342,18 +311,18 @@ class XCacheTest extends \lithium\test\Unit {
 			'key2' => 'data2'
 		);
 		$result = $this->XCache->write($keys);
-		$this->assertTrue($result($this->XCache, compact('keys', 'expiry')));
+		$this->assertTrue($result);
 
 		$expected = $keys;
 		$result = $this->XCache->read(array_keys($keys));
-		$this->assertEqual($expected, $result($this->XCache, array('keys' => array_keys($keys))));
+		$this->assertEqual($expected, $result);
 
 		$keys = array(
 			'key1' => null,
 			'key2' => null
 		);
 		$result = $this->XCache->write($keys);
-		$this->assertTrue($result($this->XCache, compact('keys', 'expiry')));
+		$this->assertTrue($result);
 	}
 
 	public function testDelete() {
@@ -365,11 +334,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$result = xcache_set($key, $data, 60);
 		$this->assertTrue($result);
 
-		$closure = $this->XCache->delete($keys);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys');
-		$result = $closure($this->XCache, $params);
+		$result = $this->XCache->delete($keys);
 		$this->assertTrue($result);
 	}
 
@@ -379,11 +344,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$keys = array($key);
 		$time = strtotime('+1 minute');
 
-		$closure = $this->XCache->delete($keys);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys');
-		$result = $closure($this->XCache, $params);
+		$result = $this->XCache->delete($keys);
 		$this->assertFalse($result);
 	}
 
@@ -396,7 +357,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$keys = array('key1');
 		$expected = array('key1' => 'test1');
 		$result = $adapter->delete($keys);
-		$result($adapter, compact('keys'));
+		$this->assertEual($expected, $result);
 
 		$result = xcache_isset('key1');
 		$this->assertTrue($result);
@@ -412,11 +373,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$expiry = '+5 seconds';
 		$time = strtotime($expiry);
 
-		$closure = $this->XCache->write($keys, $expiry);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys', 'expiry');
-		$result = $closure($this->XCache, $params);
+		$result = $this->XCache->write($keys, $expiry);
 		$this->assertTrue($result);
 
 		$expected = $data;
@@ -425,19 +382,11 @@ class XCacheTest extends \lithium\test\Unit {
 
 		$keys = array($key);
 
-		$closure = $this->XCache->read($keys);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys');
-		$result = $closure($this->XCache, $params, null);
 		$expected = array($key => $data);
+		$result = $this->XCache->read($keys);
 		$this->assertEqual($expected, $result);
 
-		$closure = $this->XCache->delete($keys);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('keys');
-		$result = $closure($this->XCache, $params);
+		$result = $this->XCache->delete($keys);
 		$this->assertTrue($result);
 	}
 
@@ -470,11 +419,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$result = xcache_set($key, $value, $time);
 		$this->assertTrue($result);
 
-		$closure = $this->XCache->decrement($key);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('key');
-		$result = $closure($this->XCache, $params, null);
+		$result = $this->XCache->decrement($key);
 		$this->assertEqual($value - 1, $result);
 
 		$result = xcache_get($key);
@@ -492,20 +437,12 @@ class XCacheTest extends \lithium\test\Unit {
 		$result = xcache_set($key, $value, $time);
 		$this->assertTrue($result);
 
-		$closure = $this->XCache->decrement($key);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('key');
-		$result = $closure($this->XCache, $params, null);
+		$this->XCache->decrement($key);
 
 		$result = xcache_get($key);
 		$this->assertEqual(-1, $result);
 
-		$closure = $this->XCache->decrement($key);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('key');
-		$result = $closure($this->XCache, $params, null);
+		$this->XCache->decrement($key);
 
 		$result = xcache_get($key);
 		$this->assertEqual(-2, $result);
@@ -520,8 +457,7 @@ class XCacheTest extends \lithium\test\Unit {
 		xcache_set('primary:key1', 1, 60);
 		xcache_set('key1', 1, 60);
 
-		$result = $adapter->decrement('key1');
-		$result($adapter, array('key' => 'key1'));
+		$adapter->decrement('key1');
 
 		$expected = 1;
 		$result = xcache_get('key1');
@@ -540,11 +476,7 @@ class XCacheTest extends \lithium\test\Unit {
 		$result = xcache_set($key, $value, $time);
 		$this->assertTrue($result);
 
-		$closure = $this->XCache->increment($key);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('key');
-		$result = $closure($this->XCache, $params, null);
+		$result = $this->XCache->increment($key);
 		$this->assertEqual($value + 1, $result);
 
 		$result = xcache_get($key);
@@ -562,20 +494,12 @@ class XCacheTest extends \lithium\test\Unit {
 		$result = xcache_set($key, $value, $time);
 		$this->assertTrue($result);
 
-		$closure = $this->XCache->increment($key);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('key');
-		$result = $closure($this->XCache, $params, null);
+		$this->XCache->increment($key);
 
 		$result = xcache_get($key);
 		$this->assertEqual(1, $result);
 
-		$closure = $this->XCache->increment($key);
-		$this->assertInternalType('callable', $closure);
-
-		$params = compact('key');
-		$result = $closure($this->XCache, $params, null);
+		$this->XCache->increment($key);
 
 		$result = xcache_get($key);
 		$this->assertEqual(2, $result);
@@ -590,8 +514,7 @@ class XCacheTest extends \lithium\test\Unit {
 		xcache_set('primary:key1', 1, 60);
 		xcache_set('key1', 1, 60);
 
-		$result = $adapter->increment('key1');
-		$result($adapter, array('key' => 'key1'));
+		$adapter->increment('key1');
 
 		$expected = 1;
 		$result = xcache_get('key1');


### PR DESCRIPTION
This PR moves filtering from cache adapters into the cache manager class as well as removing unused strategy features with Cache::delete. 

Functionality should not be needed to repeated in adapters and
handled by the manager class if possible.

Also adapter methods themselves were never filterable on the
adapter classes. It was always (parts of) the manager class'
methods that were filterable.

That's why filters already in use with the cache manager class
will continue to work as is.

BC Break: This change requires any cache adapters implemented in
userland to not return closures for read/write/delete/increment/decrement
anymore. Please update your code accordingly.

When using the standard lithium adapters no change is required
any code will continue to work as is.
