### PR TITLE
Advanced cache key generation

### DIFF
--- a/analysis/logger/adapter/Cache.php
+++ b/analysis/logger/adapter/Cache.php
@@ -81,11 +81,13 @@ class Cache extends \lithium\core\Object {
 		$config = $this->_config + $this->_classes;
 
 		return function($self, $params) use ($config) {
-			$params += array('timestamp' => strtotime('now'));
-			$key = $config['key'];
-			$key = is_callable($key) ? $key($params) : String::insert($key, $params);
-
 			$cache = $config['cache'];
+			$params += array('timestamp' => strtotime('now'));
+
+			if (!is_callable($key = $config['key'])) {
+				$key = function($data) use ($key) { return String::insert($key, $data); };
+			}
+			$key = $cache::key($config['config'], $key, $params);
 			return $cache::write($config['config'], $key, $params['message'], $config['expiry']);
 		};
 	}

--- a/storage/Cache.php
+++ b/storage/Cache.php
@@ -101,7 +101,7 @@ class Cache extends \lithium\core\Adaptable {
 	 * an optimized way dependending on the type of data.
 	 *
 	 * Simple usage (in this case noop):
-	 * {{{
+	 * ```
 	 * Cache::key('default', 'post');
 	 * // returns `'post'`
 	 *
@@ -110,17 +110,17 @@ class Cache extends \lithium\core\Adaptable {
 	 *
 	 * Cache::key('default', array('posts' => 'foo', 'banners' => 'bar));
 	 * // returns `array('posts' => 'foo', 'banners' => 'bar')`
-	 * }}}
+	 * ```
 	 *
 	 * Make a key safe to use with adapter (exact result depends
 	 * on key constraints enforced by the selected adapter:
-	 * {{{
+	 * ```
 	 * Cache::key('default', 'posts for Helgi Þorbjörnsson');
 	 * // returns `'posts_for_Helgi__orbj_rnsson_c7f8433a'`
-	 * }}}
+	 * ```
 	 *
 	 * Using additional scalar or non-scalar data to generate key:
-	 * {{{
+	 * ```
 	 * Cache::key('default', 'post', 2);
 	 * // returns `'post:1ad5be0d'`
 	 *
@@ -132,10 +132,10 @@ class Cache extends \lithium\core\Adaptable {
 	 *
 	 * Cache::key('default', array('posts' => 'foo', 'banners' => 'bar'), 'json');
 	 * // returns `array('posts:38ec40e5' => 'foo', 'banners:38ec40e5' => 'bar')`
-	 * }}}
+	 * ```
 	 *
 	 * Or with a resuable key generator function:
-	 * {{{
+	 * ```
 	 * $posts[0] = array('id' => 1);
 	 * $posts[1] = array('id' => 2);
 	 *
@@ -143,16 +143,16 @@ class Cache extends \lithium\core\Adaptable {
 	 *
 	 * Cache::key('default', $key, $post[0]); // returns `'post:1'`
 	 * Cache::key('default', $key, $post[1]); // returns `'post:2'`
-	 * }}}
+	 * ```
 	 *
 	 * This example shows a key mutating generator function:
-	 * {{{
+	 * ```
 	 * $base = 'post';
 	 * $key  = function($id) use (&base) { return $base .= ":{$id}"; };
 	 *
 	 * Cache::key('default', $key, 1); // returns `'post:1'`
 	 * Cache::key('default', $key, 2); // returns `'post:1:2'`
-	 * }}}
+	 * ```
 	 *
 	 * @param string $name Configuration to be used for generating key/s.
 	 * @param mixed $key String or an array of strings that will be used as the cache key/s.

--- a/storage/Cache.php
+++ b/storage/Cache.php
@@ -154,7 +154,7 @@ class Cache extends \lithium\core\Adaptable {
 	 * Cache::key('default', $key, 2); // returns `'post:1:2'`
 	 * }}}
 	 *
-	 * @param string $name Configuration to be used for generating key/s. Currently unused.
+	 * @param string $name Configuration to be used for generating key/s.
 	 * @param mixed $key String or an array of strings that will be used as the cache key/s.
 	 *              Also accepts associative arrays where the key part will be modified, but
 	 *              the value left untouched. Also accepts a key generator function that

--- a/storage/Cache.php
+++ b/storage/Cache.php
@@ -96,16 +96,85 @@ class Cache extends \lithium\core\Adaptable {
 	protected static $_strategies = 'strategy.storage.cache';
 
 	/**
-	 * Generates the cache key.
+	 * Generates one or multiple safe cache keys optionally adding a suffix
+	 * with a hash over the provided data. The hash value is generated in
+	 * an optimized way dependending on the type of data.
 	 *
-	 * @param mixed $key A string (or lambda/closure that evaluates to a string)
-	 *                    that will be used as the cache key.
-	 * @param array $data If a lambda/closure is used as a key and requires arguments,
-	 *                    pass them in here.
-	 * @return string The generated cache key.
+	 * Simple usage (in this case noop):
+	 * {{{
+	 * Cache::key('default', 'post');
+	 * // returns `'post'`
+	 *
+	 * Cache::key('default', array('posts', 'banners'));
+	 * // returns `array('posts', 'banners')`
+	 *
+	 * Cache::key('default', array('posts' => 'foo', 'banners' => 'bar));
+	 * // returns `array('posts' => 'foo', 'banners' => 'bar')`
+	 * }}}
+	 *
+	 * Make a key safe to use with adapter (exact result depends
+	 * on key constraints enforced by the selected adapter:
+	 * {{{
+	 * Cache::key('default', 'posts for bjœrn');
+	 * // returns `'posts_for_bj_rn_fdf03955'`
+	 *
+	 * Cache::key('default', 'posts for Helgi Þorbjörnsson');
+	 * // returns `'posts_for_Helgi__orbj_rnsson_c7f8433a'`
+	 * }}}
+	 *
+	 * Using additional scalar or non-scalar data to generate key:
+	 * {{{
+	 * Cache::key('default', 'post', 2);
+	 * // returns `'post_1ad5be0d'`
+	 *
+	 * Cache::key('default', 'post', array(2, 'json'));
+	 * // returns `'post_723f0e19'`
+	 *
+	 * Cache::key('default', array('posts', 'banners'), 'json');
+	 * // returns `array('posts_6b072545', 'banners_6b072545')`
+	 *
+	 * Cache::key('default', array('posts' => 'foo', 'banners' => 'bar'), 'json');
+	 * // returns `array('posts_38ec40e5' => 'foo', 'banners_38ec40e5' => 'bar')`
+	 * }}}
+	 *
+	 * Or with a resuable key generator function:
+	 * {{{
+	 * $posts[0] = array('id' => 1);
+	 * $posts[1] = array('id' => 2);
+	 *
+	 * $key = function($data) { return 'post_' . $data['id']};
+	 *
+	 * Cache::key('default', $key, $post[0]); // returns `'post_1'`
+	 * Cache::key('default', $key, $post[1]); // returns `'post_2'`
+	 * }}}
+	 *
+	 * @param string $name Configuration to be used for generating key/s. Currently unused.
+	 * @param mixed $key String or an array of strings that will be used as the cache key/s.
+	 *              Also accepts associative arrays where the key part will be modified, but
+	 *              the value left untouched. Also accepts a key generator function that
+	 *              is passed $data and must return a string that will be used as the key.
+	 * @param mixed $data Additional data to use when generating key. Can be any kind of type except
+	 *              a resource. The method will calculate a hash of the data and append that to
+	 *              the key/s. When $key is a function the data is passed to it instead.
+	 * @return string|array The generated cache key/s.
 	 */
-	public static function key($key, $data = array()) {
-		return is_object($key) ? $key($data) : $key;
+	public static function key($name, $key, $data = null) {
+		$adapter = static::adapter($name);
+
+		if (is_callable($key)) {
+			return current($adapter->key(array($key($data))));
+		}
+		$keys = ($isMulti = is_array($key)) ? $key : array($key);
+		$keys = ($hasData = !is_integer(key($keys))) ? array_keys($keys) : $keys;
+
+		if ($data !== null) {
+			$data = hash('crc32b', is_scalar($data) ? $data : serialize($data));
+			$keys = array_map(function($key) use ($data) { return $key .= "_{$data}"; }, $keys);
+		}
+		$keys = $adapter->key($keys);
+		$keys = $hasData ? array_combine($keys, array_values((array) $key)) : $keys;
+
+		return $isMulti ? $keys : current($keys);
 	}
 
 	/**
@@ -160,7 +229,6 @@ class Cache extends \lithium\core\Adaptable {
 		} catch (ConfigException $e) {
 			return false;
 		}
-		$key = static::key($key, $data);
 
 		if (is_array($key)) {
 			$keys = $key;
@@ -231,7 +299,6 @@ class Cache extends \lithium\core\Adaptable {
 		} catch (ConfigException $e) {
 			return false;
 		}
-		$key = static::key($key);
 
 		if ($isMulti = is_array($key)) {
 			$keys = $key;
@@ -298,7 +365,6 @@ class Cache extends \lithium\core\Adaptable {
 		} catch (ConfigException $e) {
 			return false;
 		}
-		$key = static::key($key);
 
 		if (is_array($key)) {
 			$keys = $key;
@@ -336,7 +402,6 @@ class Cache extends \lithium\core\Adaptable {
 		} catch (ConfigException $e) {
 			return false;
 		}
-		$key = static::key($key);
 		$params = compact('key', 'offset');
 
 		return static::_filter(__FUNCTION__, $params, function($self, $params) use ($adapter) {
@@ -368,7 +433,6 @@ class Cache extends \lithium\core\Adaptable {
 		} catch (ConfigException $e) {
 			return false;
 		}
-		$key = static::key($key);
 		$params = compact('key', 'offset');
 
 		return static::_filter(__FUNCTION__, $params, function($self, $params) use ($adapter) {

--- a/storage/Cache.php
+++ b/storage/Cache.php
@@ -145,6 +145,15 @@ class Cache extends \lithium\core\Adaptable {
 	 * Cache::key('default', $key, $post[1]); // returns `'post:2'`
 	 * }}}
 	 *
+	 * This example shows a key mutating generator function:
+	 * {{{
+	 * $base = 'post';
+	 * $key  = function($id) use (&base) { return $base .= ":{$id}"; };
+	 *
+	 * Cache::key('default', $key, 1); // returns `'post:1'`
+	 * Cache::key('default', $key, 2); // returns `'post:1:2'`
+	 * }}}
+	 *
 	 * @param string $name Configuration to be used for generating key/s. Currently unused.
 	 * @param mixed $key String or an array of strings that will be used as the cache key/s.
 	 *              Also accepts associative arrays where the key part will be modified, but

--- a/storage/Cache.php
+++ b/storage/Cache.php
@@ -115,9 +115,6 @@ class Cache extends \lithium\core\Adaptable {
 	 * Make a key safe to use with adapter (exact result depends
 	 * on key constraints enforced by the selected adapter:
 	 * {{{
-	 * Cache::key('default', 'posts for bjœrn');
-	 * // returns `'posts_for_bj_rn_fdf03955'`
-	 *
 	 * Cache::key('default', 'posts for Helgi Þorbjörnsson');
 	 * // returns `'posts_for_Helgi__orbj_rnsson_c7f8433a'`
 	 * }}}

--- a/storage/Cache.php
+++ b/storage/Cache.php
@@ -122,16 +122,16 @@ class Cache extends \lithium\core\Adaptable {
 	 * Using additional scalar or non-scalar data to generate key:
 	 * {{{
 	 * Cache::key('default', 'post', 2);
-	 * // returns `'post_1ad5be0d'`
+	 * // returns `'post:1ad5be0d'`
 	 *
 	 * Cache::key('default', 'post', array(2, 'json'));
-	 * // returns `'post_723f0e19'`
+	 * // returns `'post:723f0e19'`
 	 *
 	 * Cache::key('default', array('posts', 'banners'), 'json');
-	 * // returns `array('posts_6b072545', 'banners_6b072545')`
+	 * // returns `array('posts:6b072545', 'banners:6b072545')`
 	 *
 	 * Cache::key('default', array('posts' => 'foo', 'banners' => 'bar'), 'json');
-	 * // returns `array('posts_38ec40e5' => 'foo', 'banners_38ec40e5' => 'bar')`
+	 * // returns `array('posts:38ec40e5' => 'foo', 'banners:38ec40e5' => 'bar')`
 	 * }}}
 	 *
 	 * Or with a resuable key generator function:
@@ -139,10 +139,10 @@ class Cache extends \lithium\core\Adaptable {
 	 * $posts[0] = array('id' => 1);
 	 * $posts[1] = array('id' => 2);
 	 *
-	 * $key = function($data) { return 'post_' . $data['id']};
+	 * $key = function($data) { return 'post:' . $data['id']};
 	 *
-	 * Cache::key('default', $key, $post[0]); // returns `'post_1'`
-	 * Cache::key('default', $key, $post[1]); // returns `'post_2'`
+	 * Cache::key('default', $key, $post[0]); // returns `'post:1'`
+	 * Cache::key('default', $key, $post[1]); // returns `'post:2'`
 	 * }}}
 	 *
 	 * @param string $name Configuration to be used for generating key/s. Currently unused.
@@ -166,7 +166,7 @@ class Cache extends \lithium\core\Adaptable {
 
 		if ($data !== null) {
 			$data = hash('crc32b', is_scalar($data) ? $data : serialize($data));
-			$keys = array_map(function($key) use ($data) { return $key .= "_{$data}"; }, $keys);
+			$keys = array_map(function($key) use ($data) { return $key .= ":{$data}"; }, $keys);
 		}
 		$keys = $adapter->key($keys);
 		$keys = $hasData ? array_combine($keys, array_values((array) $key)) : $keys;

--- a/storage/cache/Adapter.php
+++ b/storage/cache/Adapter.php
@@ -34,6 +34,16 @@ namespace lithium\storage\cache;
 abstract class Adapter extends \lithium\core\Object {
 
 	/**
+	 * Generates safe cache keys.
+	 *
+	 * @param array $keys The original keys.
+	 * @return array Keys modified and safe to use with adapter.
+	 */
+	public function key(array $keys) {
+		return $keys;
+	}
+
+	/**
 	 * Write values to the cache. All items to be cached will receive an
 	 * expiration time of `$expiry`.
 	 *

--- a/storage/cache/adapter/File.php
+++ b/storage/cache/adapter/File.php
@@ -73,6 +73,36 @@ class File extends \lithium\storage\cache\Adapter {
 	}
 
 	/**
+	 * Generates safe cache keys.
+	 *
+	 * Keys should be safe to be used as filename. So we conservatively disallalow
+	 * any non alphanumeric characters with the exception of dash und underscore.
+	 *
+	 * We also limit to max. 255 characters. The limit is actually lowered
+	 * to 255 minus the length of an crc32b hash minus separator (246)
+	 * minus scope length minus separator (246 - x).
+	 *
+	 * 255 was chosen as most commonly used filesystems (ext2-4, HFS+,
+	 * NTFS, XFS, FAT32, btrfs) limit filename characters to a length of
+	 * 255.
+	 *
+	 * @link https://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits
+	 * @param array $keys The original keys.
+	 * @return array Keys modified and safe to use with adapter.
+	 */
+	public function key(array $keys) {
+		$length = 246 - ($this->_config['scope'] ? strlen($this->_config['scope']) + 1 : 0);
+
+		return array_map(
+			function($key) use ($length) {
+				$result = substr(preg_replace('/[^a-z0-9_\-]/iu', '_', $key), 0, $length);
+				return $result !== $key ? $result . '_' . hash('crc32b', $key) : $result;
+			},
+			$keys
+		);
+	}
+
+	/**
 	 * Write values to the cache. All items to be cached will receive an
 	 * expiration time of `$expiry`.
 	 *

--- a/tests/cases/storage/CacheTest.php
+++ b/tests/cases/storage/CacheTest.php
@@ -55,26 +55,68 @@ class CacheTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 	}
 
-	public function testkeyNoContext() {
+	public function testKeyNoop() {
+		Cache::config(array('default' => array('adapter' => 'Memory')));
+
 		$key = 'this is a cache key';
 
-		$result = Cache::key($key);
+		$result = Cache::key('default', $key);
 		$expected = 'this is a cache key';
 		$this->assertIdentical($expected, $result);
 
 		$key = '1120-cache éë';
 
-		$result = Cache::key($key);
+		$result = Cache::key('default', $key);
 		$expected = '1120-cache éë';
+		$this->assertIdentical($expected, $result);
+
+		$result = Cache::key('default', 'foo');
+		$expected = 'foo';
+		$this->assertIdentical($expected, $result);
+
+		$result = Cache::key('default', array('foo', 'bar'));
+		$expected = array('foo', 'bar');
+		$this->assertIdentical($expected, $result);
+
+		$result = Cache::key('default', array('foo' => 'bar', 'baz' => 'boo'));
+		$expected = array('foo' => 'bar', 'baz' => 'boo');
 		$this->assertIdentical($expected, $result);
 	}
 
-	public function testKeyWithLambda() {
+	public function testKeyWithDataHash() {
+		Cache::config(array('default' => array('adapter' => 'Memory')));
+
+		$result = Cache::key('default', 'post', 2);
+		$expected = 'post_1ad5be0d';
+		$this->assertIdentical($expected, $result);
+
+		$result = Cache::key('default', 'post', array(2, 'json'));
+		$expected = 'post_723f0e19';
+		$this->assertIdentical($expected, $result);
+
+		$result = Cache::key('default', array('posts', 'banners'), 'json');
+		$expected = array(
+			'posts_6b072545',
+			'banners_6b072545'
+		);
+		$this->assertIdentical($expected, $result);
+
+		$result = Cache::key('default', array('posts' => 'foo', 'banners' => 'bar'), 'json');
+		$expected = array(
+			'posts_6b072545' => 'foo',
+			'banners_6b072545' => 'bar'
+		);
+		$this->assertIdentical($expected, $result);
+	}
+
+	public function testKeyWithGeneratorLambda() {
+		Cache::config(array('default' => array('adapter' => 'Memory')));
+
 		$key = function() {
 			return 'lambda_key';
 		};
 
-		$result = Cache::key($key);
+		$result = Cache::key('default', $key);
 		$expected = 'lambda_key';
 		$this->assertIdentical($expected, $result);
 
@@ -82,7 +124,7 @@ class CacheTest extends \lithium\test\Unit {
 			return 'lambda key';
 		};
 
-		$result = Cache::key($key);
+		$result = Cache::key('default', $key);
 		$expected = 'lambda key';
 		$this->assertIdentical($expected, $result);
 
@@ -92,19 +134,21 @@ class CacheTest extends \lithium\test\Unit {
 			return 'composed_key_with_' . $data['foo'] . '_' . $data['bar'];
 		};
 
-		$result = Cache::key($key, array('foo' => 'boo', 'bar' => 'far'));
+		$result = Cache::key('default', $key, array('foo' => 'boo', 'bar' => 'far'));
 		$expected = 'composed_key_with_boo_far';
 		$this->assertIdentical($expected, $result);
 	}
 
-	public function testKeyWithClosure() {
+	public function testKeyWithGeneratorClosure() {
+		Cache::config(array('default' => array('adapter' => 'Memory')));
+
 		$value = 5;
 
 		$key = function() use ($value) {
 			return "closure key {$value}";
 		};
 
-		$result = Cache::key($key);
+		$result = Cache::key('default', $key);
 		$expected = 'closure key 5';
 		$this->assertIdentical($expected, $result);
 
@@ -115,20 +159,22 @@ class CacheTest extends \lithium\test\Unit {
 			return $reference;
 		};
 
-		$result = Cache::key($key);
+		$result = Cache::key('default', $key);
 		$expected = 'mutable key';
 		$this->assertIdentical($expected, $result);
 		$this->assertIdentical('mutable key', $reference);
 	}
 
-	public function testKeyWithClosureAndArguments() {
+	public function testKeyWithGeneratorClosureAndArguments() {
+		Cache::config(array('default' => array('adapter' => 'Memory')));
+
 		$value = 'closure argument';
 
 		$key = function($value) {
 			return $value;
 		};
 
-		$result = Cache::key($key($value));
+		$result = Cache::key('default', $key($value));
 		$expected = 'closure argument';
 		$this->assertIdentical($expected, $result);
 	}

--- a/tests/cases/storage/CacheTest.php
+++ b/tests/cases/storage/CacheTest.php
@@ -87,24 +87,24 @@ class CacheTest extends \lithium\test\Unit {
 		Cache::config(array('default' => array('adapter' => 'Memory')));
 
 		$result = Cache::key('default', 'post', 2);
-		$expected = 'post_1ad5be0d';
+		$expected = 'post:1ad5be0d';
 		$this->assertIdentical($expected, $result);
 
 		$result = Cache::key('default', 'post', array(2, 'json'));
-		$expected = 'post_723f0e19';
+		$expected = 'post:723f0e19';
 		$this->assertIdentical($expected, $result);
 
 		$result = Cache::key('default', array('posts', 'banners'), 'json');
 		$expected = array(
-			'posts_6b072545',
-			'banners_6b072545'
+			'posts:6b072545',
+			'banners:6b072545'
 		);
 		$this->assertIdentical($expected, $result);
 
 		$result = Cache::key('default', array('posts' => 'foo', 'banners' => 'bar'), 'json');
 		$expected = array(
-			'posts_6b072545' => 'foo',
-			'banners_6b072545' => 'bar'
+			'posts:6b072545' => 'foo',
+			'banners:6b072545' => 'bar'
 		);
 		$this->assertIdentical($expected, $result);
 	}
@@ -131,11 +131,11 @@ class CacheTest extends \lithium\test\Unit {
 		$key = function($data = array()) {
 			$defaults = array('foo' => 'foo', 'bar' => 'bar');
 			$data += $defaults;
-			return 'composed_key_with_' . $data['foo'] . '_' . $data['bar'];
+			return 'composed_key_with:' . $data['foo'] . ':' . $data['bar'];
 		};
 
 		$result = Cache::key('default', $key, array('foo' => 'boo', 'bar' => 'far'));
-		$expected = 'composed_key_with_boo_far';
+		$expected = 'composed_key_with:boo:far';
 		$this->assertIdentical($expected, $result);
 	}
 

--- a/tests/cases/storage/cache/adapter/FileTest.php
+++ b/tests/cases/storage/cache/adapter/FileTest.php
@@ -61,6 +61,48 @@ class FileTest extends \lithium\test\Unit {
 		$this->assertTrue($file::enabled());
 	}
 
+	public function testSanitzeKeys() {
+		$result = $this->File->key(array('posts for bjœrn'));
+		$expected = array('posts_for_bj_rn_fdf03955');
+		$this->assertEqual($expected, $result);
+
+		$result = $this->File->key(array('posts-for-bjoern'));
+		$expected = array('posts-for-bjoern');
+		$this->assertEqual($expected, $result);
+
+		$result = $this->File->key(array('posts for Helgi Þorbjörnsson'));
+		$expected = array('posts_for_Helgi__orbj_rnsson_c7f8433a');
+		$this->assertEqual($expected, $result);
+
+		$result = $this->File->key(array('libraries.cache'));
+		$expected = array('libraries_cache_38235880');
+		$this->assertEqual($expected, $result);
+
+		$key = 'post_';
+		for ($i = 0; $i <= 127; $i++) {
+			$key .= chr($i);
+		}
+		$result = $this->File->key(array($key));
+		$expected  = 'post______________________________________________-__0123456789_______ABCDEF';
+		$expected .= 'GHIJKLMNOPQRSTUVWXYZ______abcdefghijklmnopqrstuvwxyz______38676d3e';
+		$expected = array($expected);
+		$this->assertEqual($expected, $result);
+
+		$key = str_repeat('0', 300);
+		$result = $this->File->key(array($key));
+		$expected = array(str_repeat('0', 246) . '_9e1830ed');
+		$this->assertEqual($expected, $result);
+		$this->assertTrue(strlen($result[0]) <= 255);
+
+		$adapter = new File(array('scope' => 'foo'));
+
+		$key = str_repeat('0', 300);
+		$result = $adapter->key(array($key));
+		$expected = array(str_repeat('0', 246 - strlen('_foo')) . '_9e1830ed');
+		$this->assertEqual($expected, $result);
+		$this->assertTrue(strlen($result[0]) <= 255);
+	}
+
 	public function testWrite() {
 		$key = 'key';
 		$data = 'data';

--- a/tests/integration/storage/CacheTest.php
+++ b/tests/integration/storage/CacheTest.php
@@ -33,6 +33,26 @@ class CacheTest extends \lithium\test\Integration {
 		return ($directory->isDir() && $directory->isReadable() && $directory->isWritable());
 	}
 
+	public function testFileAdapterSanitzeKey() {
+		Cache::config(array('default' => array('adapter' => 'File')));
+
+		$result = Cache::key('default', 'posts for bjœrn');
+		$expected = 'posts_for_bj_rn_fdf03955';
+		$this->assertEqual($expected, $result);
+
+		$result = Cache::key('default', 'posts-for-bjoern');
+		$expected = 'posts-for-bjoern';
+		$this->assertEqual($expected, $result);
+
+		$result = Cache::key('default', 'posts for Helgi Þorbjörnsson');
+		$expected = 'posts_for_Helgi__orbj_rnsson_c7f8433a';
+		$this->assertEqual($expected, $result);
+
+		$result = Cache::key('default', array('posts for bjœrn'));
+		$expected = array('posts_for_bj_rn_fdf03955');
+		$this->assertEqual($expected, $result);
+	}
+
 	public function testFileAdapterCacheConfig() {
 		$result = Cache::config();
 		$this->assertEmpty($result);

--- a/tests/integration/storage/cache/adapter/MemcacheTest.php
+++ b/tests/integration/storage/cache/adapter/MemcacheTest.php
@@ -49,6 +49,49 @@ class MemcacheTest extends \lithium\test\Integration {
 		$this->assertTrue(Memcache::enabled());
 	}
 
+	public function testSanitzeKeys() {
+		$result = $this->memcache->key(array('posts for bjœrn'));
+		$expected = array('posts_for_bjœrn_fdf03955');
+		$this->assertEqual($expected, $result);
+
+		$result = $this->memcache->key(array('posts-for-bjoern'));
+		$expected = array('posts-for-bjoern');
+		$this->assertEqual($expected, $result);
+
+		$result = $this->memcache->key(array('posts for Helgi Þorbjörnsson'));
+		$expected = array('posts_for_Helgi_Þorbjörnsson_c7f8433a');
+		$this->assertEqual($expected, $result);
+
+		$result = $this->memcache->key(array('libraries.cache'));
+		$expected = array('libraries.cache');
+		$this->assertEqual($expected, $result);
+
+		$key = 'post_';
+		for ($i = 0; $i <= 127; $i++) {
+			$key .= chr($i);
+		}
+		$result = $this->memcache->key(array($key));
+		$expected  = 'post__________________________________!"#$%&\'()*+,-./0123456789:;';
+		$expected .= '<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|';
+		$expected .= '}~__38676d3e';
+		$expected = array($expected);
+		$this->assertEqual($expected, $result);
+
+		$key = str_repeat('0', 300);
+		$result = $this->memcache->key(array($key));
+		$expected = array(str_repeat('0', 241) . '_9e1830ed');
+		$this->assertEqual($expected, $result);
+		$this->assertTrue(strlen($result[0]) <= 250);
+
+		$adapter = new Memcache(array('scope' => 'foo'));
+
+		$key = str_repeat('0', 300);
+		$result = $adapter->key(array($key));
+		$expected = array(str_repeat('0', 241 - strlen('_foo')) . '_9e1830ed');
+		$this->assertEqual($expected, $result);
+		$this->assertTrue(strlen($result[0]) <= 250);
+	}
+
 	public function testSimpleWrite() {
 		$key = 'key';
 		$data = 'value';


### PR DESCRIPTION
Repurposing `Cache::key()`. It now deals with advanced cache key generation
and also makes keys safe to use with given adapter configuration.

BC break: Method signature of `Cache::key()` changed. This method
was probably used seldom because of its very limited featureset.

BC break of undocumented feature: key generator functions
cannot be passed to `Cache::{read,write,delete,increment,decrement}()`
anymore. See explanation below.

- Method signature of `Cache::key()` changed. The first
  parameter is now - as in other cache methods - the name
  of the cache configuration to use.

  ```
  Cache::key('post', $data); // old
  Cache::key('default', 'post', $data); // new
  ```

- Decoupling cache key generation.

  Advanced key generation has been moved out of
  `Cache::{read,write,delete,increment,decrement}()`. Key generator
  functions may not be passed to these methods anymore. Instead generate
  the key beforehand using the new `Cache::key()`.

  Key generator functions for read and delete needed to be implemented
  in a different way then those for i.e. write as data could not be
  passed to them in any case.

  ```
  $data = array('id' => 23);

  // old: removed
  Cache::write('default', function($data) { // ... }, $data);

  // new: 2 step process
  $key = Cache::key('default', function($data) { // ... }, $data);
  Cache::write('default', $key, $data);
  ```

- The method can now be used to generate safe cache keys.

- The method can now be used to suffix cache keys with
  hashes of data.

- Adding `keys()` method for adapters.

- Adding tests.

- Adding documentation.