### PR TITLE
Update Mongo drivers (Closes #698).

### DIFF
--- a/tests/mocks/data/source/MockMongoConnection.php
+++ b/tests/mocks/data/source/MockMongoConnection.php
@@ -33,6 +33,14 @@ class MockMongoConnection {
 		return array();
 	}
 
+	public function getConnections() {
+		return array(array(
+			'hash' => 'localhost:27017;-;X;56052',
+			'server' => array(),
+			'connection' => array()
+		));
+	}
+
 	public function insert(array &$data, array $options = array()) {
 		$data['_id'] = new MongoId();
 		return $this->_record(__FUNCTION__, compact('data', 'options'));
@@ -41,7 +49,8 @@ class MockMongoConnection {
 	protected function _record($type, array $data = array()) {
 		$collection = $this->_collection;
 		$this->queries[] = compact('type', 'collection') + $data;
-		return array_pop($this->results);
+		$result = array_pop($this->results);
+		return $result === null ? false : $result;
 	}
 
 	public function update($conditions, $update, $options) {


### PR DESCRIPTION
- Update `Mongo` to `MongoCollection`
- Remove `'safe'` in flavour of `'w'` and `'wTimeoutMS'`
- Remove direct access to `'connected'` since it's [deprecated since mongo 1.5 drivers](https://jira.mongodb.org/browse/PHP-840)
