### PR TITLE
count()/iterating on empty result from MongoDB throws an exception

### DIFF
--- a/data/source/mongo_db/Result.php
+++ b/data/source/mongo_db/Result.php
@@ -9,6 +9,7 @@
 namespace lithium\data\source\mongo_db;
 
 use MongoGridFSFile;
+use Exception;
 
 class Result extends \lithium\data\source\Result {
 
@@ -30,7 +31,7 @@ class Result extends \lithium\data\source\Result {
 			try{
 		            $result = $this->_resource->getNext();
 		        }
-			catch (\Exception $e){
+			catch (Exception $e){
 		            return false;
 		        }
 			$isFile = ($result instanceof MongoGridFSFile);


### PR DESCRIPTION
catch exception: BadValue bad skip value in query.
When I query and it returns the empty result, if I try to call `count()` or apply a `foreach` loop, it throw out that exception.
I have no idea why the `$this->_resource->hasNext()` function return true, but `$this->_resource->getNext();` throw out exception.

Example:

``` php
$users = Users::find('all', array('conditions'=>array('email'=>'abc@xyz.com')));
if($users->count()){ //exception throw out if no user has that email
    //do something here
}
```
