### PR TITLE
BC Break, fixes JSON encoding & decoding for empty results.

### DIFF
--- a/net/http/Message.php
+++ b/net/http/Message.php
@@ -267,14 +267,9 @@ class Message extends \lithium\net\Message {
 		$default = array('buffer' => null, 'encode' => false, 'decode' => false);
 		$options += $default;
 
-		if (!empty($data)) {
-			$this->body = array_merge((array) $this->body, (array) $data);
-		}
+		$this->body = array_merge((array) $this->body, (array) $data);
 		$body = $this->body;
 
-		if (empty($options['buffer']) && empty($body)) {
-			return "";
-		}
 		if ($options['encode']) {
 			$body = $this->_encode($body);
 		}
@@ -297,7 +292,8 @@ class Message extends \lithium\net\Message {
 		$media = $this->_classes['media'];
 
 		if ($type = $media::type($this->_type)) {
-			$body = $media::encode($this->_type, $body) ?: $body;
+			$encoded = $media::encode($this->_type, $body);
+			$body = $encoded !== null ? $encoded : $body;
 		}
 		return $body;
 	}
@@ -313,7 +309,8 @@ class Message extends \lithium\net\Message {
 		$media = $this->_classes['media'];
 
 		if ($type = $media::type($this->_type)) {
-			return $media::decode($this->_type, $body) ?: $body;
+			$decoded = $media::decode($this->_type, $body);
+			$body = $decoded !== null ? $decoded : $body;
 		}
 		return $body;
 	}

--- a/tests/cases/net/http/MessageTest.php
+++ b/tests/cases/net/http/MessageTest.php
@@ -81,11 +81,31 @@ class MessageTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 	}
 
-	public function testReturnStringIfNoBufferAndEmptyBody() {
+	public function testReturnJsonIfNoBufferAndEmptyBody() {
 		$this->message->type("json");
 		$result = $this->message->body("", array('encode' => true));
-		$this->assertIdentical("", $result);
+		$this->assertIdentical('[""]', $result);
+	}
 
+	public function testReturnMergedJsonWithEmptyBody() {
+		$this->message->type("json");
+		$result = $this->message->body("", array('encode' => true));
+		$this->assertIdentical('[""]', $result);
+
+		$result = $this->message->body("", array('encode' => true));
+		$this->assertIdentical('["",""]', $result);
+	}
+
+	public function testReturnMergedJson() {
+		$this->message->type("json");
+		$result = $this->message->body(array("myvar1" => "val1"), array('encode' => true));
+		$this->assertIdentical('{"myvar1":"val1"}', $result);
+
+		$result = $this->message->body(array("myvar2" => "val2"), array('encode' => true));
+		$this->assertIdentical('{"myvar1":"val1","myvar2":"val2"}', $result);
+	}
+
+	public function testReturnJsonIfNoBufferAndArrayBody() {
 		$this->message->type("json");
 		$result = $this->message->body(array(""), array('encode' => true));
 		$this->assertIdentical('[""]', $result);
@@ -95,6 +115,24 @@ class MessageTest extends \lithium\test\Unit {
 		$this->message->type("json");
 		$result = $this->message->body(array("myvar" => ""), array('encode' => true));
 		$this->assertIdentical('{"myvar":""}', $result);
+	}
+
+	public function testEmptyEncodeInJson() {
+		$this->message->type("json");
+		$result = $this->message->body(array(), array('encode' => true));
+		$this->assertIdentical("[]", $result);
+	}
+
+	public function testEmptyJsonDecode() {
+		$this->message->type("json");
+		$result = $this->message->body("{}", array('decode' => true));
+		$this->assertIdentical(array(), $result);
+	}
+
+	public function testEmptyJsonArrayDecode() {
+		$this->message->type("json");
+		$result = $this->message->body("[]", array('decode' => true));
+		$this->assertIdentical(array(), $result);
 	}
 }
 


### PR DESCRIPTION
Empty json like '{}' produced the following data in `$request->data`.

```
array("0" => "{}")
```

which can potentially leads to some:

```
array(
    "$set" => array(
        "0" => "{}"
    )
}
```

if this data is used in a mongo context to update a record for example.
