### PR TITLE
Fix Collection reduce

### DIFF
--- a/data/Collection.php
+++ b/data/Collection.php
@@ -470,7 +470,7 @@ abstract class Collection extends \lithium\util\Collection implements \Serializa
 		if (!$this->closed()) {
 			while ($this->next()) {}
 		}
-		return parent::reduce($filter);
+		return parent::reduce($filter, $initial);
 	}
 
 	/**


### PR DESCRIPTION
lithium/data/Collection's `reduce` currently ignores the `$initial` parameter when invoking its parent.
