### PR TITLE
Fix Database queryExport issue with related model's conditions

### DIFF
--- a/data/source/Database.php
+++ b/data/source/Database.php
@@ -613,7 +613,7 @@ abstract class Database extends \lithium\data\Source {
 					$data['limit'] = '';
 					$data['conditions'] = $this->conditions(array(
 						"{$name}.{$key}" => $ids
-					), $query);
+					) + $query->conditions(), $query);
 					return $data;
 				}
 			}


### PR DESCRIPTION
When using `limit` or using a `Find::('first')`, subsequent conditions are not applied in the query export array returned by `data\source\Database::_queryExport`.

Questions:
1. Should I add a new case to the integration tests? (`CrudTest.php`?)
2. Should I remove the conditions that begin with the same table/model name? They are redundant in the subsequent query.
