### PR TITLE
Changes behavior for encoding `null` body in JSON as an empty string.

### DIFF
--- a/net/http/Message.php
+++ b/net/http/Message.php
@@ -267,9 +267,14 @@ class Message extends \lithium\net\Message {
 		$default = array('buffer' => null, 'encode' => false, 'decode' => false);
 		$options += $default;
 
-		$this->body = array_merge((array) $this->body, (array) $data);
+		if ($data !== null) {
+			$this->body = array_merge((array) $this->body, (array) $data);
+		}
 		$body = $this->body;
 
+		if (empty($options['buffer']) && $body === null) {
+			return "";
+		}
 		if ($options['encode']) {
 			$body = $this->_encode($body);
 		}

--- a/tests/cases/net/http/MessageTest.php
+++ b/tests/cases/net/http/MessageTest.php
@@ -119,6 +119,12 @@ class MessageTest extends \lithium\test\Unit {
 
 	public function testEmptyEncodeInJson() {
 		$this->message->type("json");
+		$result = $this->message->body(null, array('encode' => true));
+		$this->assertIdentical("", $result);
+	}
+
+	public function testEmptyArrayEncodeInJson() {
+		$this->message->type("json");
 		$result = $this->message->body(array(), array('encode' => true));
 		$this->assertIdentical("[]", $result);
 	}


### PR DESCRIPTION
The former '[]' representation can't work for GET queries.
