### PR TITLE
Add summary stats for CLI

### DIFF
--- a/test/templates/coverage.txt.php
+++ b/test/templates/coverage.txt.php
@@ -1,6 +1,10 @@
 {:heading}Code Coverage{:end}
 <?php
 
+	$summary = array(
+		'classes' => 0, 'executable' => 0, 'covered' => 0, 'uncovered' => 0, 'percentage' => 0
+	);
+
 	$colorMap = array(
 		'ignored' => 'white',
 		'covered' => 'success',
@@ -8,6 +12,12 @@
 	);
 
 	foreach ($data as $class => $coverage) {
+		$summary['classes']++;
+		$summary['executable'] += count($coverage['executable']);
+		$summary['covered'] += count($coverage['covered']);
+		$summary['uncovered'] += count($coverage['uncovered']);
+		$summary['percentage'] += $coverage['percentage'];
+
 		echo ($coverage['percentage'] >= 85 ? "{:success}" : "{:error}");
 		echo "{$class}{:end}: ";
 		echo count($coverage['covered']) . " of " . count($coverage['executable']);
@@ -31,4 +41,28 @@
 		echo "\n";
 	}
 
+$displayPercentage = function($raw) {
+    $percentage = round($raw);
+    echo ($percentage > 70) ? "{:success}" : "{:error}";
+    echo "$percentage{:end}";
+};
 ?>
+
+{:heading}Summary{:end}
+
+Classes Covered:   <?php echo $summary['classes'] ?>
+
+Executable Lines:  <?php echo $summary['executable'] ?>
+
+Lines Covered:     <?php echo $summary['covered'] ?>
+
+Lines Uncovered:   <?php echo $summary['uncovered'] ?>
+
+Total Coverage:    <?php
+	$percTotal = ($summary['covered'] / $summary['executable']) * 100;
+	$displayPercentage($percTotal);
+	?>%
+Average Per Class: <?php
+	$percPerClass = $summary['percentage'] / $summary['classes'];
+	$displayPercentage($percPerClass);
+	?>%


### PR DESCRIPTION
It is useful to have summary statistics for code coverage on the CLI as well as through a web browser

![screenshot 2014-07-28 09 39 46](https://cloud.githubusercontent.com/assets/205245/3723072/f7b53a66-166f-11e4-970f-46559308e6a8.png)
