### PR TITLE
Adding drain option to disable auto stream reading in action request

### DIFF
--- a/action/Request.php
+++ b/action/Request.php
@@ -163,6 +163,10 @@ class Request extends \lithium\net\http\Request {
 	 *        - `'env'` _array_: Defaults to `array()`.
 	 *        - `'globals'` _boolean_: Use global variables for populating
 	 *          the request's environment and data; defaults to `true`.
+	 *        - `'drain'` _boolean_: Enables/disables automatic reading of streams.
+	 *          Defaults to `true`. Disable when you're dealing with large binary
+	 *          payloads. Note that this will also disable automatic content decoding
+	 *          of stream data.
 	 */
 	public function __construct(array $config = array()) {
 		$defaults = array(
@@ -172,7 +176,8 @@ class Request extends \lithium\net\http\Request {
 			'data' => array(),
 			'stream' => null,
 			'globals' => true,
-			'query' => array()
+			'drain' => true,
+			'query' => array(),
 		);
 		$config += $defaults;
 
@@ -259,7 +264,7 @@ class Request extends \lithium\net\http\Request {
 		$this->method = strtoupper($this->env('REQUEST_METHOD'));
 		$hasBody = in_array($this->method, array('POST', 'PUT', 'PATCH'));
 
-		if (!$this->body && $hasBody && $type !== 'html') {
+		if ($this->_config['drain'] && !$this->body && $hasBody && $type !== 'html') {
 			$this->_stream = $this->_stream ?: fopen('php://input', 'r');
 			$this->body = stream_get_contents($this->_stream);
 			fclose($this->_stream);

--- a/tests/cases/action/RequestTest.php
+++ b/tests/cases/action/RequestTest.php
@@ -608,6 +608,39 @@ class RequestTest extends \lithium\test\Unit {
 		$this->assertTrue(isset($request->action));
 	}
 
+	public function testDataStreamWithDrain() {
+		$stream = fopen('php://temp', 'r+');
+		fwrite($stream, '{ "foo": "bar" }');
+		rewind($stream);
+
+		$request = new Request(compact('stream') + array(
+			'env' => array(
+				'CONTENT_TYPE' => 'application/json; charset=UTF-8',
+				'REQUEST_METHOD' => 'POST'
+			)
+		));
+		$expected = array('foo' => 'bar');
+		$this->assertEqual($expected, $request->data);
+	}
+
+	public function testDataStreamNoDrain() {
+		$stream = fopen('php://temp', 'r+');
+		fwrite($stream, '{ "foo": "bar" }');
+		rewind($stream);
+
+		$request = new Request(compact('stream') + array(
+			'drain' => false,
+			'env' => array(
+				'CONTENT_TYPE' => 'application/json; charset=UTF-8',
+				'REQUEST_METHOD' => 'POST'
+			)
+		));
+		$this->assertEmpty($request->body);
+		$this->assertEmpty($request->data);
+
+		fclose($stream);
+	}
+
 	public function testSingleFileNormalization() {
 		$_FILES = array(
 			'file' => array(
@@ -1078,15 +1111,18 @@ class RequestTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 	}
 
-	public function testAutomaticContentDecoding() {
+	public function testStreamAutomaticContentDecoding() {
 		foreach (array('POST', 'PUT', 'PATCH') as $method) {
 			$stream = fopen('php://temp', 'r+');
 			fwrite($stream, '{ "foo": "bar" }');
 			rewind($stream);
-			$request = new Request(compact('stream') + array('env' => array(
-				'CONTENT_TYPE' => 'application/json; charset=UTF-8',
-				'REQUEST_METHOD' => $method
-			)));
+
+			$request = new Request(compact('stream') + array(
+				'env' => array(
+					'CONTENT_TYPE' => 'application/json; charset=UTF-8',
+					'REQUEST_METHOD' => $method
+				)
+			));
 			$this->assertEqual(array('foo' => 'bar'), $request->data);
 		}
 
@@ -1094,12 +1130,36 @@ class RequestTest extends \lithium\test\Unit {
 			$stream = fopen('php://temp', 'r+');
 			fwrite($stream, '{ "foo": "bar" }');
 			rewind($stream);
-			$request = new Request(compact('stream') + array('env' => array(
-				'CONTENT_TYPE' => 'application/json; charset=UTF-8',
-				'REQUEST_METHOD' => $method
-			)));
+
+			$request = new Request(compact('stream') + array(
+				'env' => array(
+					'CONTENT_TYPE' => 'application/json; charset=UTF-8',
+					'REQUEST_METHOD' => $method
+				)
+			));
+			$this->assertEmpty($request->data);
+
+			fclose($stream);
+		}
+	}
+
+	public function testStreamNoAutomaticContentDecodingNoDrain() {
+		$stream = fopen('php://temp', 'r+');
+		fwrite($stream, '{ "foo": "bar" }');
+
+		foreach (array('POST', 'PUT', 'PATCH') as $method) {
+			rewind($stream);
+
+			$request = new Request(compact('stream') + array(
+				'drain' => false,
+				'env' => array(
+					'CONTENT_TYPE' => 'application/json; charset=UTF-8',
+					'REQUEST_METHOD' => $method
+				)
+			));
 			$this->assertEmpty($request->data);
 		}
+		fclose($stream);
 	}
 
 	public function testRequestTypeFromHeader() {


### PR DESCRIPTION
Adding drain option to action request to allow disabling auto stream reading.

Future versions may disable draining by default.

When the drain option is disabled will not drain stream when stream data was sent.
This reduces memory usage and enables streaming very large files (i.e. uploading
video content). You must read than read stream data manually:

```
$stream = fopen('php://input', 'r');
// Do something with $stream.
fclose($stream);
```

When drain is disabled automatic content decoding is not supported anymore. It must
be manually decoded as follows.

```
// ...
$data = Media::decode($request->type, stream_get_contents($stream));
// ...
```
    
