### PR TITLE
Fixed. Initial session read always throw the MissingSignatureException.

### DIFF
--- a/storage/Session.php
+++ b/storage/Session.php
@@ -107,7 +107,7 @@ class Session extends \lithium\core\Adaptable {
 		$filters = $settings['filters'] ?: array();
 		$result = static::_filter(__FUNCTION__, compact('key', 'options'), $method, $filters);
 
-		if ($options['strategies']) {
+		if ($result && $options['strategies']) {
 			$options += array('key' => $key, 'mode' => 'LIFO', 'class' => __CLASS__);
 			return static::applyStrategies(__FUNCTION__, $name, $result, $options);
 		}


### PR DESCRIPTION
Able to encounter this issue when we try to apply HMAC for session (cookie) in one of our deployed site.
