### PR TITLE
Fixed case of assertNulL() method call

### DIFF
--- a/tests/cases/template/helper/HtmlTest.php
+++ b/tests/cases/template/helper/HtmlTest.php
@@ -385,7 +385,7 @@ class HtmlTest extends \lithium\test\Unit {
 		);
 		$this->assertTags($result, $expected);
 
-		$this->assertNulL($this->html->script(array('foo', 'bar'), array('inline' => false)));
+		$this->assertNull($this->html->script(array('foo', 'bar'), array('inline' => false)));
 		$result = $this->context->scripts();
 		$this->assertTags($result, $expected);
 	}


### PR DESCRIPTION
Fixed case of `$this->assertNulL()` to be consistent with PSR-1 camelCase method naming convention.
