### PR TITLE
Ignore duplicate scripts, styles and head inserted via helpers and handlers

### DIFF
--- a/template/helper/Html.php
+++ b/template/helper/Html.php
@@ -177,6 +177,7 @@ class Html extends \lithium\template\Helper {
 		list($scope, $options) = $this->_options($defaults, $options);
 
 		if (is_array($path)) {
+			$path = array_unique($path);
 			foreach ($path as $i => $item) {
 				$path[$i] = $this->script($item, $scope);
 			}
@@ -222,6 +223,7 @@ class Html extends \lithium\template\Helper {
 		list($scope, $options) = $this->_options($defaults, $options);
 
 		if (is_array($path)) {
+			$path = array_unique($path);
 			foreach ($path as $i => $item) {
 				$path[$i] = $this->style($item, $scope);
 			}

--- a/template/view/Renderer.php
+++ b/template/view/Renderer.php
@@ -230,13 +230,13 @@ abstract class Renderer extends \lithium\core\Object {
 			'title'   => 'escape',
 			'value'   => 'escape',
 			'scripts' => function($scripts) use (&$ctx) {
-				return "\n\t" . join("\n\t", $ctx['scripts']) . "\n";
+				return "\n\t" . join("\n\t", array_unique($ctx['scripts'])) . "\n";
 			},
 			'styles' => function($styles) use (&$ctx) {
-				return "\n\t" . join("\n\t", $ctx['styles']) . "\n";
+				return "\n\t" . join("\n\t", array_unique($ctx['styles'])) . "\n";
 			},
 			'head' => function($head) use (&$ctx) {
-				return "\n\t" . join("\n\t", $ctx['head']) . "\n";
+				return "\n\t" . join("\n\t", array_unique($ctx['head'])) . "\n";
 			}
 		);
 		unset($this->_config['view']);

--- a/tests/cases/template/helper/HtmlTest.php
+++ b/tests/cases/template/helper/HtmlTest.php
@@ -376,7 +376,7 @@ class HtmlTest extends \lithium\test\Unit {
 	 * passing multiple scripts or styles to a single method call.
 	 */
 	public function testMultiNonInlineScriptsAndStyles() {
-		$result = $this->html->script(array('foo', 'bar'));
+		$result = $this->html->script(array('foo', 'bar', 'foo'));
 		$expected = array(
 			array('script' => array('type' => 'text/javascript', 'src' => 'regex:/.*\/foo\.js/')),
 			'/script',
@@ -386,6 +386,10 @@ class HtmlTest extends \lithium\test\Unit {
 		$this->assertTags($result, $expected);
 
 		$this->assertNull($this->html->script(array('foo', 'bar'), array('inline' => false)));
+		$result = $this->context->scripts();
+		$this->assertTags($result, $expected);
+
+		$this->html->script('foo', array('inline' => false));
 		$result = $this->context->scripts();
 		$this->assertTags($result, $expected);
 	}


### PR DESCRIPTION
Extended helpers and handlers for scripts, styles and head to ignore duplicate entries. Prevents a duplicate HTML tag from being inserted into the script, style or head contexts. Also works for inline.

Previously calling `$this->html->script(array('foo', 'bar', 'foo'));` would generate the following:

```
<script type="text/javascript" src="/js/foo.js"></script>
<script type="text/javascript" src="/js/bar.js"></script>
<script type="text/javascript" src="/js/foo.js"></script>
```

With this, the same call will only insert the foo and bar scripts once each, resulting in:

```
<script type="text/javascript" src="/js/foo.js"></script>
<script type="text/javascript" src="/js/bar.js"></script>
```

Also works with successive `$this->html->script('foo', array('inline' => false));` calls, resulting in only one `foo.js` script being generated.
