### PR TITLE
Bug in Router::match using scope

### DIFF
--- a/net/http/Route.php
+++ b/net/http/Route.php
@@ -336,6 +336,13 @@ class Route extends \lithium\core\Object {
 	protected function _matchKeys($options) {
 		$args = array('args' => 'args');
 
+		$scope = array();
+		if (!empty($options['scope'])) {
+			$scope = (array)$options['scope'] + array('params' => array());
+			$scope = array_flip($scope['params']);
+		}
+		unset($options['scope']);
+
 		if (array_intersect_key($options, $this->_match) != $this->_match) {
 			return false;
 		}
@@ -344,7 +351,7 @@ class Route extends \lithium\core\Object {
 				return false;
 			}
 		} else {
-			if (array_diff_key(array_diff_key($options, $this->_match), $this->_keys) !== array()) {
+			if (array_diff_key($options, $this->_match + $this->_keys + $scope)) {
 				return false;
 			}
 		}

--- a/net/http/Router.php
+++ b/net/http/Router.php
@@ -380,7 +380,7 @@ class Router extends \lithium\core\StaticObject {
 		$scope = $options['scope'];
 		if (isset(static::$_configurations[$scope])) {
 			foreach (static::$_configurations[$scope] as $route) {
-				if (!$match = $route->match($url, $context)) {
+				if (!$match = $route->match($url + array('scope' => static::attached($scope)), $context)) {
 					continue;
 				}
 				if ($route->canContinue()) {
@@ -456,7 +456,7 @@ class Router extends \lithium\core\StaticObject {
 
 			$base = isset($config['base']) ? '/' . $config['base'] : $defaults['base'];
 			$base = $base . ($config['prefix'] ? '/' . $config['prefix'] : '');
-			$config['base'] = $config['absolute'] ? '/' . trim($base, '/') : rtrim($base, '/');
+			$config['base'] = rtrim($config['absolute'] ? '/' . trim($base, '/') : $base, '/');
 			$defaults = $config + $defaults;
 		}
 		return $options + $defaults;

--- a/tests/cases/net/http/RouterTest.php
+++ b/tests/cases/net/http/RouterTest.php
@@ -1900,6 +1900,25 @@ class RouterTest extends \lithium\test\Unit {
 		));
 		$this->assertEqual($expected, $result);
 	}
+
+	public function testMatchWithAbsoluteScope() {
+		Router::attach('app', array(
+			'absolute' => true,
+			'host' => '{:domain}',
+		));
+
+		Router::scope('app', function(){
+			Router::connect('/hello', 'Posts::index');
+		});
+
+		$request = new Request(array('url' => '/hello', 'base' => ''));
+		$result = Router::process($request);
+
+		$expected = 'http://' . $result->params['domain'] . '/hello';
+		$result = Router::match($result->params, $request);
+
+		$this->assertEqual($expected, $result);
+	}
 }
 
 ?>


### PR DESCRIPTION
Router::match doesn't work as expected when an scope is attached with absolute parameter.
