### PR TITLE
error in save entity without all fields that is defined in model validate .

### DIFF
--- a/data/Model.php
+++ b/data/Model.php
@@ -1181,6 +1181,12 @@ class Model extends \lithium\core\StaticObject {
 	 *          Using this parameter, you can set up custom events in your rules as well, such
 	 *          as `'on' => 'login'`. Note that when defining validation rules, the `'on'` key
 	 *          can also be an array of multiple events.
+	 *        - `'required`' _mixed_: Represents whether the value is required to be present
+	 *          in `$values`. If `'required'` is set to `true`, the validation rule will be
+	 *          checked. if `'required'` is set to 'false' , the validation rule will be skipped
+	 *          if the corresponding key is not present. If don't set `'required'` or set this
+	 *          to `null`, the validation rule will be skipped if the corresponding key is not
+	 *          present in update and will be checked in insert. Defaults is set to `null`.
 	 * @return boolean Returns `true` if all validation rules on all fields succeed, otherwise
 	 *         `false`. After validation, the messages for any validation failures are assigned to
 	 *         the entity, and accessible through the `errors()` method of the entity object.
@@ -1190,9 +1196,14 @@ class Model extends \lithium\core\StaticObject {
 		$defaults = array(
 			'rules' => $this->validates,
 			'events' => $entity->exists() ? 'update' : 'create',
-			'model' => get_called_class()
+			'model' => get_called_class(),
+			'required' => null,
 		);
 		$options += $defaults;
+
+		if ($options['required'] === null) {
+			$options['required'] = !$entity->exists();
+		}
 		$self = static::_object();
 		$validator = $self->_classes['validator'];
 		$entity->errors(false);

--- a/tests/cases/data/ModelTest.php
+++ b/tests/cases/data/ModelTest.php
@@ -1125,6 +1125,53 @@ class ModelTest extends \lithium\test\Unit {
 		$this->assertEqual('MockPost', MockComment::relations('mock_post')->name());
 		$this->assertNull(MockPost::relations('undefined'));
 	}
+
+	public function testValidateWithRequiredFalse(){
+		$post = MockPost::create(array(
+			'title' => 'post title',
+		));
+		$post->validates(array('rules' => array(
+			'title' => 'A custom message here for empty titles.',
+			'email' => array(
+				array('notEmpty', 'message' => 'email is empty.', 'required' => false)
+			)
+		)));
+		$this->assertEmpty($post->errors());
+	}
+
+	public function testValidateWithRequiredTrue(){
+		$post = MockPost::create(array(
+			'title' => 'post title',
+		));
+		$post->sync(1);
+		$post->validates(array('rules' => array(
+			'title' => 'A custom message here for empty titles.',
+			'email' => array(
+				array('notEmpty', 'message' => 'email is empty.', 'required' => true)	
+			)
+		)));
+		$this->assertNotEmpty($post->errors());
+	}
+
+	public function testValidateWithRequiredNull(){
+		$validates = array(
+			'title' => 'A custom message here for empty titles.',
+			'email' => array(
+				array('notEmpty', 'message' => 'email is empty.', 'required' => null)
+			)
+		);
+
+		$post = MockPost::create(array(
+			'title' => 'post title',
+		));
+
+		$post->validates(array('rules' => $validates));
+		$this->assertNotEmpty($post->errors());
+
+		$post->sync(1);
+		$post->validates(array('rules' => $validates));
+		$this->assertEmpty($post->errors());
+	}
 }
 
 ?>

--- a/util/Validator.php
+++ b/util/Validator.php
@@ -484,6 +484,9 @@ class Validator extends \lithium\core\StaticObject {
 				$options['field'] = $field;
 
 				foreach ($rules as $key => $rule) {
+					if (array_key_exists('required', $rule) && $rule['required'] === null) {
+						unset($rule['required']);
+					}
 					$rule += $options + compact('values');
 					list($name) = $rule;
 


### PR DESCRIPTION
when you find entity model with fields parameter and this result don't include fields that has defined in model validate, you can't save it and you take validate error on not selected fields.
