### PR TITLE
Model::save() should only save updated fields

### DIFF
--- a/data/source/Database.php
+++ b/data/source/Database.php
@@ -1331,6 +1331,15 @@ abstract class Database extends \lithium\data\Source {
 		if ($entity = $context->entity()) {
 			$export = $entity->export();
 			$increment = $export['increment'];
+			array_map(function($key) use (&$data, $export){
+				if (!empty($data[$key]) && $export['data'][$key] === $data[$key]) {
+					unset($data[$key]);
+				}
+			}, array_keys($export['data']));
+			if (!$data) {
+				$model = $context->model();
+				$data = $model::key($context->data());
+			}
 		}
 
 		foreach ($data as $field => $value) {

--- a/tests/cases/data/source/DatabaseTest.php
+++ b/tests/cases/data/source/DatabaseTest.php
@@ -533,9 +533,11 @@ class DatabaseTest extends \lithium\test\Unit {
 	public function testUpdate() {
 		$entity = new Record(array(
 			'model' => $this->_model,
-			'data' => array('id' => 1, 'title' => 'new post', 'body' => 'the body'),
+			'data' => array('id' => 1, 'title' => 'the post', 'body' => 'the body'),
 			'exists' => true
 		));
+		$entity->title = 'new post';
+		$entity->body = 'new body';
 		$query = new Query(compact('entity') + array('type' => 'update'));
 		$result = $this->_db->update($query);
 
@@ -543,14 +545,15 @@ class DatabaseTest extends \lithium\test\Unit {
 		$this->assertEqual(1, $query->entity()->id);
 
 		$expected = "UPDATE {mock_database_posts} SET";
-		$expected .= " {id} = 1, {title} = 'new post', {body} = 'the body' WHERE {id} = 1;";
+		$expected .= " {title} = 'new post', {body} = 'new body' WHERE {id} = 1;";
 		$this->assertEqual($expected, $this->_db->sql);
 
 		$entity = new Record(array(
 			'model' => $this->_model,
-			'data' => array('id' => 2, 'count' => (object) '{count} + 1'),
+			'data' => array('id' => 2, 'count' => 10),
 			'exists' => true
 		));
+		$entity->count = (object) '{count} + 1';
 		$query = new Query(compact('entity') + array('type' => 'update'));
 		$result = $this->_db->update($query);
 
@@ -558,7 +561,23 @@ class DatabaseTest extends \lithium\test\Unit {
 		$this->assertEqual(2, $query->entity()->id);
 
 		$expected = "UPDATE {mock_database_posts} SET";
-		$expected .= " {id} = 2, {count} = {count} + 1 WHERE {id} = 2;";
+		$expected .= " {count} = {count} + 1 WHERE {id} = 2;";
+		$this->assertEqual($expected, $this->_db->sql);
+
+		$entity = new Record(array(
+			'model' => $this->_model,
+			'data' => array('id' => 3, 'title' => 'the post', 'body' => 'the body'),
+			'exists' => true
+		));
+		$entity->title = 'the post';
+		$query = new Query(compact('entity') + array('type' => 'update'));
+		$result = $this->_db->update($query);
+
+		$this->assertTrue($result);
+		$this->assertEqual(3, $query->entity()->id);
+
+		$expected = "UPDATE {mock_database_posts} SET";
+		$expected .= " {id} = 3 WHERE {id} = 3;";
 		$this->assertEqual($expected, $this->_db->sql);
 
 		$query = new Query(array(
@@ -568,23 +587,6 @@ class DatabaseTest extends \lithium\test\Unit {
 		));
 		$sql = "UPDATE {mock_database_posts} SET {modified} = NOW();";
 		$this->assertEqual($sql, $this->_db->renderCommand($query));
-	}
-
-	public function testUpdateWithValueBySchema() {
-		$entity = new Record(array(
-			'model' => $this->_model,
-			'data' => array('id' => 1, 'title' => '007', 'body' => 'the body'),
-			'exists' => true
-		));
-		$query = new Query(compact('entity') + array('type' => 'update'));
-		$result = $this->_db->update($query);
-
-		$this->assertTrue($result);
-		$this->assertEqual(1, $query->entity()->id);
-
-		$expected = "UPDATE {mock_database_posts} SET";
-		$expected .= " {id} = 1, {title} = '007', {body} = 'the body' WHERE {id} = 1;";
-		$this->assertEqual($expected, $this->_db->sql);
 	}
 
 	public function testDelete() {
@@ -1730,21 +1732,21 @@ class DatabaseTest extends \lithium\test\Unit {
 		$entity->increment('balance', 10);
 		$query = new Query(compact('entity') + array('type' => 'update'));
 		$result = $this->_db->update($query);
-		$expected = "UPDATE {mock_database_posts} SET {id} = 1, {balance} = {balance} + 10 WHERE {id} = 1;";
+		$expected = "UPDATE {mock_database_posts} SET {balance} = {balance} + 10 WHERE {id} = 1;";
 		$this->assertEqual($expected, $this->_db->sql);
 
 		$entity->increment('balance', 10);
 		$entity->decrement('balance', 20);
 		$query = new Query(compact('entity') + array('type' => 'update'));
 		$result = $this->_db->update($query);
-		$expected = "UPDATE {mock_database_posts} SET {id} = 1, {balance} = {balance} + -10 WHERE {id} = 1;";
+		$expected = "UPDATE {mock_database_posts} SET {balance} = {balance} + -10 WHERE {id} = 1;";
 		$this->assertEqual($expected, $this->_db->sql);
 
 		$entity->increment('balance', 10);
 		$entity->balance = 20;
 		$query = new Query(compact('entity') + array('type' => 'update'));
 		$result = $this->_db->update($query);
-		$expected = "UPDATE {mock_database_posts} SET {id} = 1, {balance} = 20 WHERE {id} = 1;";
+		$expected = "UPDATE {mock_database_posts} SET {balance} = 20 WHERE {id} = 1;";
 		$this->assertEqual($expected, $this->_db->sql);
 
 		$this->expectException("Field 'name' cannot be incremented.");


### PR DESCRIPTION
hi, 

in updating entity data , all fields that are selected, even they which didn't change will embed into query and they will store their datas.

<b>It is dangerous risk !!</b>

to becoming more clear i explain this with belove sample.

<em>in controller A:</em>

``` php
$user = Users::find(1);
$user->balance = 10;
$user->save(); 
```

<em>in controller B:</em>

``` php
$user = Users::find(1);
$user->name = 'test';
$user->save(); 
```

<ol>
<li>Request for A : select user 1 (id = 1, balance = 0, name = 'your name')
<li>Request for B : select user 1 (id = 1, balance = 0, name = 'your name')
<li>Request for A : change balance and save data in database (balance = 10, name = 'your name')
<li>Request for B : change name and save data in database (balance = 0, name = 'test')
</ol>

in above sample, in item 4, request shouldn't change `balance` field because `balance` hasn't changed in this request.
