### PR TITLE
Fixing issue equal keys in FomrSignature although there are different fields.

### DIFF
--- a/security/validation/FormSignature.php
+++ b/security/validation/FormSignature.php
@@ -80,8 +80,8 @@ class FormSignature {
 		foreach (array('fields', 'excluded', 'locked') as $list) {
 			${$list} = urlencode(serialize(${$list}));
 		}
-		$hash = $classes['password']::hash($fields, static::$_salt);
-		$hash = $classes['password']::hash("{$locked}::{$excluded}::{$hash}", static::$_salt);
+		$hash = $classes['password']::hash(sha1($fields), static::$_salt);
+		$hash = $classes['password']::hash(sha1("{$locked}::{$excluded}::{$hash}"), static::$_salt);
 
 		return "{$locked}::{$excluded}::{$hash}";
 	}
@@ -95,12 +95,12 @@ class FormSignature {
 		}
 		$signature = $data['security']['signature'];
 		unset($data['security']);
-		$data = Set::flatten($data);
-		$fields = array_keys($data);
+		$fields = Set::flatten($data);
 
 		list($locked, $excluded, $hash) = explode('::', $signature, 3);
 		$locked = unserialize(urldecode($locked));
 		$excluded = unserialize(urldecode($excluded));
+		$fields = array_diff($fields, $locked);
 		$fields = array_diff($fields, $excluded);
 
 		if (array_intersect_assoc($data, $locked) != $locked) {

--- a/tests/cases/security/validation/FormSignatureTest.php
+++ b/tests/cases/security/validation/FormSignatureTest.php
@@ -21,7 +21,7 @@ class FormSignatureTest extends \lithium\test\Unit {
 		$components = array(
 			'a%3A1%3A%7Bs%3A6%3A%22active%22%3Bs%3A4%3A%22true%22%3B%7D',
 			'a%3A0%3A%7B%7D',
-			'$2a$10$NuNTOeXv4OHpPJtbdAmfReFiSmFw5hmc6sSy8qwns6/DWNSSOjR1y'
+			'$2a$10$NuNTOeXv4OHpPJtbdAmfReTIDGVK87uiQcWRIRvL2rvsl7DV4vzVa'
 		);
 		$signature = join('::', $components);
 
@@ -50,7 +50,7 @@ class FormSignatureTest extends \lithium\test\Unit {
 		$components = array(
 			'a%3A1%3A%7Bs%3A6%3A%22active%22%3Bs%3A4%3A%22true%22%3B%7D',
 			'a%3A0%3A%7B%7D',
-			'$2a$10$NuNTOeXv4OHpPJtbdAmfReFiSmFw5hmc6sSy8qwns6/DWNSSOjR1y'
+			'$2a$10$NuNTOeXv4OHpPJtbdAmfReTIDGVK87uiQcWRIRvL2rvsl7DV4vzVa'
 		);
 		$signature = join('::', $components);
 
@@ -59,6 +59,45 @@ class FormSignatureTest extends \lithium\test\Unit {
 			'pass' => 'whatever',
 			'active' => 'true',
 			'security' => compact('signature') + array('foo' => 'bar')
+		)));
+		$this->assertTrue(FormSignature::check($request));
+	}
+
+	public function testSignatureKeyForDifferentValues() {
+		$data = array(
+			'fields' => array(
+				'email' => 'foo@baz',
+				'pass' => 'whatever',
+			),
+			'locked' => array(
+				'active' => 'true'
+			)
+		);
+		$signatures[] = FormSignature::key($data);
+
+		$data['fields']['invalidField'] = 'foo';
+		$signatures[] = FormSignature::key($data);
+
+		$this->assertNotEqual($signatures[0], $signatures[1]);
+	}
+
+	public function testSignatureCheckWithLockedFields() {
+		$data = array(
+			'fields' => array(
+				'email' => 'foo@baz',
+				'pass' => 'whatever',
+			),
+			'locked' => array(
+				'active' => 'true'
+			)
+		);
+		$signature = FormSignature::key($data);
+
+		$request = new Request(array('data' => array(
+			'email' => 'foo@baz',
+			'pass' => 'whatever',
+			'active' => 'true',
+			'security' => compact('signature')
 		)));
 		$this->assertTrue(FormSignature::check($request));
 	}

--- a/tests/cases/template/helper/SecurityTest.php
+++ b/tests/cases/template/helper/SecurityTest.php
@@ -85,7 +85,7 @@ class SecurityTest extends \lithium\test\Unit {
 		$expected = array(
 			'a%3A1%3A%7Bs%3A6%3A%22active%22%3Bs%3A4%3A%22true%22%3B%7D',
 			'a%3A0%3A%7B%7D',
-			'$2a$10$NuNTOeXv4OHpPJtbdAmfReFiSmFw5hmc6sSy8qwns6/DWNSSOjR1y'
+			'$2a$10$NuNTOeXv4OHpPJtbdAmfReTIDGVK87uiQcWRIRvL2rvsl7DV4vzVa'
 		);
 		$this->assertEqual(join('::', $expected), $signature);
 


### PR DESCRIPTION
`FormSignature::key()` use Blowfish algorithm for signature.
In this algorithm only first 72 char will be crypt [see `Caution` in http://php.net/manual/en/function.crypt.php].
For this reason, when we use more fields (that serialize of this fields are more than 72 char), we can change the last name of fields without changing signature. (this issue mentioned in #998 & #1106)

other problems happened in other tests when i fixed above issue. So, i was forced to fix that problems in this commit.
