### PR TITLE
Deprecate `Download` shorthand header.

### DIFF
--- a/action/Response.php
+++ b/action/Response.php
@@ -81,22 +81,6 @@ class Response extends \lithium\net\http\Response {
 	}
 
 	/**
-	 * Expands on `\net\http\Message::headers()` with some magic conversions for shorthand headers.
-	 *
-	 * @param string|array $key
-	 * @param mixed $value
-	 * @param boolean $replace
-	 * @return mixed
-	 */
-	public function headers($key = null, $value = null, $replace = true) {
-		if ($key === 'download' || $key === 'Download') {
-			$key = 'Content-Disposition';
-			$value = 'attachment; filename="' . $value . '"';
-		}
-		return parent::headers($key, $value, $replace);
-	}
-
-	/**
 	 * Controls how or whether the client browser and web proxies should cache this response.
 	 *
 	 * @param mixed $expires This can be a Unix timestamp indicating when the page expires, or a
@@ -207,6 +191,28 @@ class Response extends \lithium\net\http\Response {
 		foreach ((array) $headers as $header) {
 			$code ? header($header, false, $code) : header($header, false);
 		}
+	}
+
+	/**
+	 * Expands on `\net\http\Message::headers()` with some magic conversions for shorthand headers.
+	 *
+	 * @deprecated This method will be removed in a future version.
+	 * @param string|array $key
+	 * @param smixed $value
+	 * @param boolean $replace
+	 * @return mixed
+	 */
+	public function headers($key = null, $value = null, $replace = true) {
+		if ($key === 'download' || $key === 'Download') {
+			$message  = "Shorthand header `Download` with `<FILENAME>` has been deprecated ";
+			$message .= "because it's too magic. Please use `Content-Disposition` ";
+			$message .= "with `attachment; filename=\"<FILENAME>\"` instead.";
+			trigger_error($message, E_USER_DEPRECATED);
+
+			$key = 'Content-Disposition';
+			$value = 'attachment; filename="' . $value . '"';
+		}
+		return parent::headers($key, $value, $replace);
 	}
 }
 

--- a/tests/cases/action/ResponseTest.php
+++ b/tests/cases/action/ResponseTest.php
@@ -164,20 +164,28 @@ class ResponseTest extends \lithium\test\Unit {
 	}
 
 	/**
-	 * Tests location headers and custom header add-ons, like 'download'.
-	 *
-	 * @return void
+	 * Tests custom header add-ons, like 'download'.
 	 */
-	public function testHeaderTypes() {
-		$this->response->headers('download', 'report.csv');
+	public function testDownloadMagicHeader() {
+		$response = $this->response;
+
+		$this->assertException('/deprecated/', function() use ($response) {
+			$response->headers('download', 'report.csv');
+		});
+	}
+
+	/**
+	 * Tests location headers.
+	 */
+	public function testLocationHeader() {
+		$this->response = new MockResponse();
+		$this->response->status(301);
+		$this->response->headers('Location', '/');
 		ob_start();
 		$this->response->render();
 		ob_get_clean();
 
-		$headers = array(
-			'HTTP/1.1 200 OK',
-			'Content-Disposition: attachment; filename="report.csv"'
-		);
+		$headers = array('HTTP/1.1 301 Moved Permanently', 'Location: /');
 		$this->assertEqual($headers, $this->response->testHeaders);
 
 		$this->response = new MockResponse();
@@ -187,18 +195,6 @@ class ResponseTest extends \lithium\test\Unit {
 		ob_get_clean();
 
 		$headers = array('HTTP/1.1 302 Found', 'Location: /');
-		$this->assertEqual($headers, $this->response->testHeaders);
-	}
-
-	public function testLocationHeaderStatus() {
-		$this->response = new MockResponse();
-		$this->response->status(301);
-		$this->response->headers('Location', '/');
-		ob_start();
-		$this->response->render();
-		ob_get_clean();
-
-		$headers = array('HTTP/1.1 301 Moved Permanently', 'Location: /');
 		$this->assertEqual($headers, $this->response->testHeaders);
 
 		$this->response = new Response(array(


### PR DESCRIPTION
We should strive for as little magicness as possible. But when
we provide convenience methods they should entirely cover the case.

With forcing content download there's already some additional preparation to do
which we also didn't catch here i.e. setting Content-Type to application/octet-stream.

The magic Download header was never supported when passing headers as an array.

Updating tests; moving location test into other existing method.
