### PR TITLE
Adding failing tests to prove key overflow in form signing

### DIFF
--- a/tests/cases/security/validation/FormSignatureTest.php
+++ b/tests/cases/security/validation/FormSignatureTest.php
@@ -58,6 +58,24 @@ class FormSignatureTest extends \lithium\test\Unit {
 		)));
 		$this->assertTrue(FormSignature::check($request));
 	}
+
+	public function testFailsWithAddedFieldAndLocked() {
+		$data = array(
+			'fields' => array(
+				'email' => 'foo@baz',
+				'pass' => 'whatever',
+			),
+			'locked' => array(
+				'active' => 'true'
+			)
+		);
+		$signatures[] = FormSignature::key($data);
+
+		$data['fields']['invalidField'] = 'foo';
+		$signatures[] = FormSignature::key($data);
+
+		$this->assertNotEqual($signatures[0], $signatures[1]);
+	}
 }
 
 ?>

--- a/tests/cases/security/validation/FormSignatureTest.php
+++ b/tests/cases/security/validation/FormSignatureTest.php
@@ -76,6 +76,125 @@ class FormSignatureTest extends \lithium\test\Unit {
 
 		$this->assertNotEqual($signatures[0], $signatures[1]);
 	}
+
+	public function testFailsTamperedFieldsWithMany() {
+		for ($original = array(), $i = 0; $i < 100; $i++) {
+			$original['foo' . $i] = 'bar' . $i;
+		}
+		$signature0 = FormSignature::key(array(
+			'fields' => $original
+		));
+
+		$changed = $original;
+		$changed['foo10000'] = 'barAdded';
+		$signature1 = FormSignature::key(array(
+			'fields' => $changed
+		));
+		$this->assertNotIdentical($signature0, $signature1);
+
+		$changed = $original;
+		unset($changed['foo1']);
+		$signature1 = FormSignature::key(array(
+			'fields' => $changed
+		));
+		$this->assertNotIdentical($signature0, $signature1);
+	}
+
+	public function testFailsTamperedLockedWithMany() {
+		for ($original = array(), $i = 0; $i < 100; $i++) {
+			$original['foo' . $i] = 'bar' . $i;
+		}
+		$signature0 = FormSignature::key(array(
+			'locked' => $original
+		));
+
+		$changed = $original;
+		$changed['foo90'] = 'barChanged';
+		$signature1 = FormSignature::key(array(
+			'locked' => $changed
+		));
+		$this->assertNotIdentical($signature0, $signature1);
+
+		$changed = $original;
+		$changed['foo10000'] = 'barAdded';
+		$signature1 = FormSignature::key(array(
+			'locked' => $changed
+		));
+		$this->assertNotIdentical($signature0, $signature1);
+
+		$changed = $original;
+		unset($changed['foo1']);
+		$signature1 = FormSignature::key(array(
+			'locked' => $changed
+		));
+		$this->assertNotIdentical($signature0, $signature1);
+	}
+
+	public function testFailsTamperedFieldsAndLockedWithManyAndLockedChange() {
+		for ($originalFields = array(), $i = 0; $i < 20; $i++) {
+			$originalFields['fooa' . $i] = 'bara' . $i;
+		}
+		for ($originalLocked = array(), $i = 0; $i < 20; $i++) {
+			$originalLocked['foob' . $i] = 'barb' . $i;
+		}
+		$signature0 = FormSignature::key(array(
+			'fields' => $originalFields,
+			'locked' => $originalLocked
+		));
+
+		$changed = $originalLocked;
+		$changed['foo90'] = 'barChanged';
+		$signature1 = FormSignature::key(array(
+			'fields' => $originalFields,
+			'locked' => $changed
+		));
+		$this->assertNotIdentical($signature0, $signature1);
+
+		$changed = $originalLocked;
+		$changed['foo10000'] = 'barAdded';
+		$signature1 = FormSignature::key(array(
+			'fields' => $originalFields,
+			'locked' => $changed
+		));
+		$this->assertNotIdentical($signature0, $signature1);
+
+		$changed = $originalLocked;
+		unset($changed['foo1']);
+		$signature1 = FormSignature::key(array(
+			'fields' => $originalFields,
+			'locked' => $changed
+		));
+		$this->assertNotIdentical($signature0, $signature1);
+	}
+
+	public function testFailsTamperedFieldsAndLockedWithManyAndFieldsChange() {
+		for ($originalFields = array(), $i = 0; $i < 20; $i++) {
+			$originalFields['fooa' . $i] = 'bara' . $i;
+		}
+		for ($originalLocked = array(), $i = 0; $i < 20; $i++) {
+			$originalLocked['foob' . $i] = 'barb' . $i;
+		}
+		$signature0 = FormSignature::key(array(
+			'fields' => $originalFields,
+			'locked' => $originalLocked
+		));
+
+		$changed = $originalFields;
+		$changed['foo10000'] = 'barAdded';
+		$signature1 = FormSignature::key(array(
+			'fields' => $changed,
+			'locked' => $originalLocked
+		));
+		$this->assertNotIdentical($signature0, $signature1);
+
+		$changed = $originalFields;
+		unset($changed['foo1a']);
+		$signature1 = FormSignature::key(array(
+			'fields' => $changed,
+			'locked' => $originalLocked
+		));
+		$this->assertNotIdentical($signature0, $signature1);
+	}
 }
 
 ?>


### PR DESCRIPTION
Adds tests for 3 in #998. Supersedes PR #1130.

Refs #839. 