### PR TITLE
Improve access to methods using same configuration in adaptable classes 

### DIFF
--- a/core/Adaptable.php
+++ b/core/Adaptable.php
@@ -65,6 +65,36 @@ class Adaptable extends \lithium\core\StaticObject {
 	 */
 	protected static $_adapters = null;
 
+	protected $_config;
+
+	protected $_class;
+
+	protected static $_instances = array();
+
+	public function __construct($class, $name) {
+		$this->_config = $name;
+		$this->_class = $class;
+	}
+
+	public static function instance($name = null) {
+		if (!$name) {
+			if (!$names = array_keys(static::$_configurations)) {
+				return;
+			}
+			$name = $names[0];
+		}
+		if (!isset(static::$_instances[$name])) {
+			static::$_instances[$name] = new self(get_called_class(), $name);
+		}
+		return static::$_instances[$name];
+	}
+
+	public function __call($method, $params) {
+		array_unshift($params, $this->_config);
+		$class = $this->_class;
+		return $class::invokeMethod($method, $params);
+	}
+
 	/**
 	 * Sets configurations for a particular adaptable implementation, or returns the current
 	 * configuration settings.


### PR DESCRIPTION
In using Adaptable classes usually we use only one configuration at a time, but we always have to pass the first parameter to specify the desired config. So I have a suggestion to make this task less tedious using the following API (along with the current API):

```
$cache = Cache::instance('default');
$cache->read('key');
$cache->write('key', 'value');
$cache->delete('key');
```

Current API:

```
Cache::read('default', 'key');
Cache::write('default', 'key', 'value');
Cache::delete('default', 'key');
```

This pull request is a proof of concept and if you agree, I will write docs and tests for it.

Update: There was a bug in the implementation, now fixed and updated.
