### PR TITLE
Optimise assignTo call in DocumentSet::_set()

### DIFF
--- a/data/collection/DocumentSet.php
+++ b/data/collection/DocumentSet.php
@@ -124,7 +124,7 @@ class DocumentSet extends \lithium\data\Collection {
 		if (is_object($key)) {
 			$key = (string) $key;
 		}
-		if (method_exists($data, 'assignTo')) {
+		if (is_object($data) && method_exists($data, 'assignTo')) {
 			$data->assignTo($this);
 		}
 		$key !== null ? $this->_data[$key] = $data : $this->_data[] = $data;


### PR DESCRIPTION
Calling method_exists() against $data when it is not an object triggers an autoloader lookup, which in turn calls realpath().

When initialising large data sets, this can bring a heavy IO burden.

Since assignTo() is always called against an object instance, we can safely prevent a call to method_exists() if $data is not an object.
