### PR TITLE
Allow continued manipulation in dispatcher rules

### DIFF
--- a/tests/cases/action/DispatcherTest.php
+++ b/tests/cases/action/DispatcherTest.php
@@ -168,6 +168,24 @@ class DispatcherTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result->params);
 	}
 
+	public function testRunWithContinuingRules() {
+		MockDispatcher::config(array('rules' => array(
+			'api' => array('action' => 'api_{:action}'),
+			'admin' => array('action' => 'admin_{:action}')
+		)));
+
+		Router::connect('/', array(
+			'controller' => 'test', 'action' => 'test', 'admin' => true, 'api' => true
+		));
+		MockDispatcher::run(new Request(array('url' => '/')));
+
+		$result = end(MockDispatcher::$dispatched);
+		$expected = array(
+			'action' => 'admin_api_test', 'controller' => 'Test', 'admin' => true, 'api' => true
+		);
+		$this->assertEqual($expected, $result->params);
+	}
+
 	public function testControllerLookupFail() {
 		Dispatcher::config(array('classes' => array('router' => __CLASS__)));
 


### PR DESCRIPTION
I have admin actions that are prefixed with `admin_` but I've also got `api_` prefixed actions for implementing and exposing my _API_. There's also the case where I've got admin api actions that should be prefixed `admin_api_`. 

Currently `Dispatcher::applyRules()` is maintaining a separate internal state, so that each rule during i.e. action prefixing did only get the original action name inside the template string as `{:action}`. This PR changes this and allows continuous manipulation of i.e. action names.