### PR TITLE
Bug/router match

### DIFF
--- a/action/Dispatcher.php
+++ b/action/Dispatcher.php
@@ -177,6 +177,7 @@ class Dispatcher extends \lithium\core\StaticObject {
 	 * @return array Returns the `$params` array with formatting rules applied to array values.
 	 */
 	public static function applyRules(&$params) {
+		$values = array();
 		$rules = static::$_rules;
 
 		if (!$params) {
@@ -197,31 +198,32 @@ class Dispatcher extends \lithium\core\StaticObject {
 					$controller = "{$params['library']}.{$controller}";
 				}
 			}
-			$params['controller'] = $controller;
+			$values = compact('controller');
 		}
+		$values += $params;
 
 		if (is_callable($rules)) {
 			$rules = $rules($params);
 		}
 		foreach ($rules as $rule => $value) {
-			if (!isset($params[$rule])) {
+			if (!isset($values[$rule])) {
 				continue;
 			}
 			foreach ($value as $k => $v) {
 				if (is_callable($v)) {
-					$params[$k] = $v($params);
+					$values[$k] = $v($values);
 					continue;
 				}
 				$match = preg_replace('/\{:\w+\}/', '@', $v);
 				$match = preg_replace('/@/', '.+', preg_quote($match, '/'));
 
-				if (preg_match('/' . $match . '/i', $params[$k])) {
+				if (preg_match('/' . $match . '/i', $values[$k])) {
 					continue;
 				}
-				$params[$k] = String::insert($v, $params);
+				$values[$k] = String::insert($v, $values);
 			}
 		}
-		return $params;
+		return $values;
 	}
 
 	/**

--- a/tests/cases/net/http/RouterTest.php
+++ b/tests/cases/net/http/RouterTest.php
@@ -11,6 +11,7 @@ namespace lithium\tests\cases\net\http;
 use lithium\action\Request;
 use lithium\net\http\Router;
 use lithium\action\Response;
+use lithium\tests\mocks\action\MockDispatcher;
 
 class RouterTest extends \lithium\test\Unit {
 
@@ -1939,6 +1940,21 @@ class RouterTest extends \lithium\test\Unit {
 		$result = Router::match($result->params, $request);
 
 		$this->assertEqual($expected, $result);
+	}
+
+	public function testMatchWithScopeAndWithoutController() {
+		Router::scope('app', function() {
+			Router::connect('/{:id}', 'Posts::index');
+		});
+
+		$request = new Request(array('url' => '/1', 'base' => ''));
+		MockDispatcher::run($request);
+
+		$result = Router::match(array(
+			'id' => 2
+		), $request);
+
+		$this->assertEqual('/2', $result);
 	}
 }
 


### PR DESCRIPTION
I fixed this bug that had created after merge of PR #1158 .
when we use ``Router::match`` without controller param and routers be inside scope, we get this error because controller change within params.
I changed ``dispatcher::applyRules`` like before PR #1158 but I didn't break feature (continue-dispatch-rules)  which had added in that PR.

@davidpersson @nateabele , If you think this change can be good for merge I can squash both commits together.