### PR TITLE
Fixing bug with non-sequential child records in hasMany relation

### DIFF
--- a/data/source/Database.php
+++ b/data/source/Database.php
@@ -1335,6 +1335,49 @@ abstract class Database extends \lithium\data\Source {
 	 * @return string Formatted clause.
 	 */
 	public function order($order, $context) {
+		$model = $context->model();
+		$return = $context->return();
+		$relations = $context->relationships();
+		$direction = 'ASC';
+
+		if (is_string($order)) {
+			if (preg_match('/^(.*?)\s+((?:A|DE)SC)$/i', $order, $match)) {
+				$order = $match[1];
+				$direction = $match[2];
+			}
+			$order = array($order => $direction);
+		}
+
+		if (is_array($order) && $relations && $model && (!$return || $return === 'item')) {
+			foreach ($relations as $relation) {
+				if ($relation['type'] !== 'hasMany') {
+					continue;
+				}
+				$orders = array(
+					'main' => array(),
+					'relations' => array()
+				);
+				$keyDirection = 'ASC';
+				$relPattern = '/^(' . implode('|', array_keys($relations)) . ')\./';
+				$keyPattern = '/^(' . $model::meta('name') . '\.)?' . $model::key() . '/';
+				foreach ($order as $column => $dir) {
+					if (is_int($column)) {
+						$column = $dir;
+						$dir = $direction;
+					}
+					if (preg_match($relPattern, $column)) {
+						$orders['relations'][$column] = $dir;
+					} elseif (preg_match($keyPattern, $column)) {
+						$keyDirection = $dir;
+					} else {
+						$orders['main'][$column] = $dir;
+					}
+				}
+				$orders['main'][$model::key()] = $keyDirection;
+				$order = array_merge($orders['main'], $orders['relations']);
+				break;
+			}
+		}
 		return $this->_sort($order, $context);
 	}
 
@@ -1363,10 +1406,6 @@ abstract class Database extends \lithium\data\Source {
 		$model = $context->model();
 
 		if (is_string($field)) {
-			if (preg_match('/^(.*?)\s+((?:A|DE)SC)$/i', $field, $match)) {
-				$field = $match[1];
-				$direction = $match[2];
-			}
 			$field = array($field => $direction);
 		}
 

--- a/tests/cases/data/model/QueryTest.php
+++ b/tests/cases/data/model/QueryTest.php
@@ -445,7 +445,7 @@ class QueryTest extends \lithium\test\Unit {
 		$expected = 'SELECT * FROM {foo} AS {MockQueryPost} LEFT JOIN {mock_query_comments} AS ';
 		$expected .= '{MockQueryComment} ON {MockQueryPost}.{id} = {MockQueryComment}';
 		$expected .= '.{mock_query_post_id} GROUP BY {MockQueryPost}.{author_id} ORDER BY ';
-		$expected .= '{MockQueryPost}.{author_id} ASC LIMIT 3;';
+		$expected .= '{MockQueryPost}.{author_id} ASC, {MockQueryPost}.{id} ASC LIMIT 3;';
 		$this->assertEqual($expected, $this->_db->renderCommand($query));
 	}
 

--- a/tests/cases/data/source/DatabaseTest.php
+++ b/tests/cases/data/source/DatabaseTest.php
@@ -654,13 +654,14 @@ class DatabaseTest extends \lithium\test\Unit {
 			'model' => $this->_model,
 			'with' => array('MockDatabaseComment')
 		));
+		$this->_db->schema($query);
 
 		$result = $this->_db->order('MockDatabaseComment.created DESC', $query);
-		$expected = 'ORDER BY {MockDatabaseComment}.{created} DESC';
+		$expected = 'ORDER BY {MockDatabasePost}.{id} ASC, {MockDatabaseComment}.{created} DESC';
 		$this->assertEqual($expected, $result);
 
 		$result = $this->_db->order(array('MockDatabaseComment.created' => 'DESC'), $query);
-		$expected = 'ORDER BY {MockDatabaseComment}.{created} DESC';
+		$expected = 'ORDER BY {MockDatabasePost}.{id} ASC, {MockDatabaseComment}.{created} DESC';
 		$this->assertEqual($expected, $result);
 
 		$result = $this->_db->order(
@@ -670,7 +671,8 @@ class DatabaseTest extends \lithium\test\Unit {
 			),
 			$query
 		);
-		$expected = 'ORDER BY {MockDatabasePost}.{title} ASC, {MockDatabaseComment}.{created} DESC';
+		$expected = 'ORDER BY {MockDatabasePost}.{title} ASC, ';
+		$expected .= '{MockDatabasePost}.{id} ASC, {MockDatabaseComment}.{created} DESC';
 		$this->assertEqual($expected, $result);
 
 		$result = $this->_db->order(
@@ -680,7 +682,70 @@ class DatabaseTest extends \lithium\test\Unit {
 			),
 			$query
 		);
-		$expected = 'ORDER BY {MockDatabasePost}.{title} ASC, {MockDatabaseComment}.{created} DESC';
+		$expected = 'ORDER BY {MockDatabasePost}.{title} ASC, ';
+		$expected .= '{MockDatabasePost}.{id} ASC, {MockDatabaseComment}.{created} DESC';
+		$this->assertEqual($expected, $result);
+
+		$result = $this->_db->order(
+			array(
+				'MockDatabaseComment.created' => 'DESC',
+				'title' => 'ASC',
+			),
+			$query
+		);
+		$expected = 'ORDER BY {MockDatabasePost}.{title} ASC, ';
+		$expected .= '{MockDatabasePost}.{id} ASC, {MockDatabaseComment}.{created} DESC';
+		$this->assertEqual($expected, $result);
+
+		$result = $this->_db->order(
+			array(
+				'id' => 'DESC',
+				'MockDatabaseComment.created' => 'DESC',
+			),
+			$query
+		);
+		$expected = 'ORDER BY {MockDatabasePost}.{id} DESC, {MockDatabaseComment}.{created} DESC';
+		$this->assertEqual($expected, $result);
+
+		$result = $this->_db->order(
+			array(
+				'MockDatabaseComment.created' => 'DESC',
+				'title' => 'ASC',
+				'id' => 'DESC',
+			),
+			$query
+		);
+		$expected = 'ORDER BY {MockDatabasePost}.{title} ASC, ';
+		$expected .= '{MockDatabasePost}.{id} DESC, {MockDatabaseComment}.{created} DESC';
+		$this->assertEqual($expected, $result);
+
+		$result = $this->_db->order(array('title'),	$query);
+		$expected = 'ORDER BY {MockDatabasePost}.{title} ASC, {MockDatabasePost}.{id} ASC';
+		$this->assertEqual($expected, $result);
+
+		$query = new Query(array(
+			'model' => $this->_model,
+			'with' => array('MockDatabaseComment'),
+			'return' => 'array'
+		));
+		$this->_db->schema($query);
+
+		$result = $this->_db->order('MockDatabaseComment.created DESC', $query);
+		$expected = 'ORDER BY {MockDatabaseComment}.{created} DESC';
+		$this->assertEqual($expected, $result);
+
+		$query = new Query(array(
+			'model' => 'lithium\tests\mocks\data\model\MockDatabaseComment',
+			'with' => array('MockDatabasePost'),
+		));
+		$this->_db->schema($query);
+
+		$result = $this->_db->order(array('MockDatabasePost.title' => 'DESC'), $query);
+		$expected = 'ORDER BY {MockDatabasePost}.{title} DESC';
+		$this->assertEqual($expected, $result);
+
+		$result = $this->_db->order(array('created'), $query);
+		$expected = 'ORDER BY {MockDatabaseComment}.{created} ASC';
 		$this->assertEqual($expected, $result);
 	}
 

--- a/tests/fixture/model/gallery/export/testHasManyWithOrder.php
+++ b/tests/fixture/model/gallery/export/testHasManyWithOrder.php
@@ -1,0 +1,62 @@
+<?php
+return array(
+	1 => array(
+		'id' => '1',
+		'name' => 'Foo Gallery',
+		'active' => '1',
+		'created' => '2007-06-20 21:02:27',
+		'modified' => '2009-12-14 22:36:09',
+		'images' => array(
+			2 => array(
+				'id' => '2',
+				'gallery_id' => '1',
+				'image' => 'image.jpg',
+				'title' => 'Srinivasa Ramanujan',
+				'created' => '2009-01-05 08:39:27',
+				'modified' => '2009-03-14 05:42:07',
+			),
+			3 => array(
+				'id' => '3',
+				'gallery_id' => '1',
+				'image' => 'photo.jpg',
+				'title' => 'Las Vegas',
+				'created' => '2010-08-11 23:12:03',
+				'modified' => '2010-09-24 04:45:14',
+			),
+			1 => array(
+				'id' => '1',
+				'gallery_id' => '1',
+				'image' => 'someimage.png',
+				'title' => 'Amiga 1200',
+				'created' => '2011-05-22 10:43:13',
+				'modified' => '2012-11-30 18:38:10',
+			),
+		),
+	),
+	2 => array(
+		'id' => '2',
+		'name' => 'Bar Gallery',
+		'active' => '1',
+		'created' => '2008-08-22 16:12:42',
+		'modified' => '2008-08-22 16:12:42',
+		'images' => array(
+			5 => array(
+				'id' => '5',
+				'gallery_id' => '2',
+				'image' => 'unknown.gif',
+				'title' => 'Unknown',
+				'created' => '2011-02-12 08:32:10',
+				'modified' => '2012-04-16 14:18:52'
+			),
+			4 => array(
+				'id' => '4',
+				'gallery_id' => '2',
+				'image' => 'picture.jpg',
+				'title' => 'Silicon Valley',
+				'created' => '2008-08-22 17:55:10',
+				'modified' => '2008-08-22 17:55:10'
+			),
+		),
+	),
+);
+?>

--- a/tests/integration/data/DatabaseTest.php
+++ b/tests/integration/data/DatabaseTest.php
@@ -246,6 +246,29 @@ class DatabaseTest extends \lithium\tests\integration\data\Base {
 		}
 	}
 
+	public function testOrderWithHasMany() {
+		$expected = include $this->_export . '/testHasManyWithOrder.php';
+
+		$galleries = Galleries::find('all', array(
+			'order' => 'Images.title DESC',
+			'with' => 'Images',
+		));
+
+		$this->assertCount(2, $galleries);
+		$this->assertEqual($expected, $galleries->to('array'));
+
+		$galleries = Galleries::find('all', array(
+			'order' => array(
+				'name' => 'DESC',
+				'Images.title' => 'DESC'
+			),
+			'with' => 'Images',
+		));
+
+		$this->assertCount(2, $galleries);
+		$this->assertEqual(array_reverse($expected, true), $galleries->to('array'));
+	}
+
 	public function testGroup() {
 		$field = $this->_db->name('Images.id');
 		$galleries = Galleries::find('all', array(


### PR DESCRIPTION
Here is a bug in hasMany relation when we use relation with order params .
I don't sure about this way resolved but I couldn't find better solution for this problem.
If you have better solution, please give me your opinion.
