### PR TITLE
Enable custom error messages in form helper.

### DIFF
--- a/tests/cases/data/ModelTest.php
+++ b/tests/cases/data/ModelTest.php
@@ -534,7 +534,7 @@ class ModelTest extends \lithium\test\Unit {
 		$result = $post->errors();
 		$this->assertNotEmpty($result);
 
-		$expected = array('email' => array('email is not valid'));
+		$expected = array('email' => array(1 => 'email is not valid'));
 		$result = $post->errors();
 		$this->assertEqual($expected, $result);
 	}
@@ -576,9 +576,9 @@ class ModelTest extends \lithium\test\Unit {
 		$expected = array(
 			'title' => array('please enter a title'),
 			'email' => array(
-				'email is empty',
-				'email is not valid',
-				'email is not in 1st list'
+				0 => 'email is empty',
+				1 => 'email is not valid',
+				3 => 'email is not in 1st list'
 			)
 		);
 		$result = $post->errors();
@@ -610,10 +610,10 @@ class ModelTest extends \lithium\test\Unit {
 		$expected = array(
 			'title' => array('please enter a title'),
 			'email' => array(
-				'email is empty',
-				'email is not valid',
-				'email is not in 1st list',
-				'email is not in 2nd list'
+				0 => 'email is empty',
+				1 => 'email is not valid',
+				3 => 'email is not in 1st list',
+				4 => 'email is not in 2nd list'
 			)
 		);
 		$result = $post->errors();
@@ -633,7 +633,7 @@ class ModelTest extends \lithium\test\Unit {
 		$this->assertNotEmpty($result);
 
 		$expected = array(
-			'email' => array('email is not in 2nd list')
+			'email' => array(4 => 'email is not in 2nd list')
 		);
 		$result = $post->errors();
 		$this->assertEqual($expected, $result);
@@ -844,10 +844,10 @@ class ModelTest extends \lithium\test\Unit {
 		$expected = array(
 			'title' => array('please enter a title'),
 			'email' => array(
-				'email is empty',
-				'email is not valid',
-				'email is not in 1st list',
-				'email is not in 2nd list'
+				0 => 'email is empty',
+				1 => 'email is not valid',
+				3 => 'email is not in 1st list',
+				4 => 'email is not in 2nd list'
 			)
 		);
 		$result = $post->errors();

--- a/tests/cases/template/helper/FormTest.php
+++ b/tests/cases/template/helper/FormTest.php
@@ -1224,6 +1224,64 @@ class FormTest extends \lithium\test\Unit {
 		));
 	}
 
+	public function testFormFieldErrorSurpressed() {
+		$record = new Record(array('model' => $this->_model));
+		$record->errors(array('name' => array('notEmpty' => 'Please enter a name')));
+		$this->form->create($record);
+
+		$result = $this->form->field('name', array(
+			'error' => false
+		));
+		$this->assertTags($result, array(
+			'<div', 'label' => array('for' => 'MockFormPostName'), 'Name', '/label',
+			'input' => array('type' => "text", 'name' => 'name', 'id' => 'MockFormPostName'),
+			 '/div'
+		));
+	}
+
+	public function testFormFieldErrorWithCustomStringMessage() {
+		$record = new Record(array('model' => $this->_model));
+		$record->errors(array('name' => array('notEmpty' => 'Please enter a name')));
+		$this->form->create($record);
+
+		$result = $this->form->field('name', array(
+			'error' => 'Nothing.'
+		));
+		$this->assertTags($result, array(
+			'<div', 'label' => array('for' => 'MockFormPostName'), 'Name', '/label',
+			'input' => array('type' => "text", 'name' => 'name', 'id' => 'MockFormPostName'),
+			'div' => array('class' => "error"), 'Nothing.', '/div', '/div'
+		));
+	}
+
+	public function testFormFieldErrorWithCustomArrayMessages() {
+		$record = new Record(array('model' => $this->_model));
+		$record->errors(array('name' => array('notEmpty' => 'Please enter a name')));
+		$this->form->create($record);
+
+		$result = $this->form->field('name', array(
+			'error' => array(
+				'notEmpty' => 'Nothing.'
+			)
+		));
+		$this->assertTags($result, array(
+			'<div', 'label' => array('for' => 'MockFormPostName'), 'Name', '/label',
+			'input' => array('type' => "text", 'name' => 'name', 'id' => 'MockFormPostName'),
+			'div' => array('class' => "error"), 'Nothing.', '/div', '/div'
+		));
+
+		$result = $this->form->field('name', array(
+			'error' => array(
+				'default' => 'Nothing.'
+			)
+		));
+		$this->assertTags($result, array(
+			'<div', 'label' => array('for' => 'MockFormPostName'), 'Name', '/label',
+			'input' => array('type' => "text", 'name' => 'name', 'id' => 'MockFormPostName'),
+			'div' => array('class' => "error"), 'Nothing.', '/div', '/div'
+		));
+	}
+
 	/**
 	 * Tests that the string template form `Form::field()` can be overridden.
 	 */

--- a/tests/cases/util/ValidatorTest.php
+++ b/tests/cases/util/ValidatorTest.php
@@ -989,6 +989,19 @@ class ValidatorTest extends \lithium\test\Unit {
 		$this->assertEmpty($result);
 	}
 
+	public function testNamedRules() {
+		$rules = array(
+			'title' => array(
+				'one' => array('notEmpty', 'message' => 'please enter a title')
+			)
+		);
+		$data = array();
+
+		$expected = array('title' => array('one' => 'please enter a title'));
+		$result = Validator::check($data, $rules);
+		$this->assertEqual($expected, $result);
+	}
+
 	public function testCheckSkipEmpty() {
 		$rules = array(
 			'email' => array('email', 'skipEmpty' => true, 'message' => 'email is not valid')
@@ -1068,8 +1081,8 @@ class ValidatorTest extends \lithium\test\Unit {
 
 		// result:
 		$errors = array(
-			'title' => array('please enter a title'),
-			'email' => array('email is not valid')
+			'title' => array(0 => 'please enter a title'),
+			'email' => array(1 => 'email is not valid')
 		);
 		$this->assertNotEmpty($result);
 		$this->assertEqual($errors, $result);
@@ -1087,7 +1100,7 @@ class ValidatorTest extends \lithium\test\Unit {
 		$result = Validator::check($data, $rules);
 		$this->assertNotEmpty($result);
 
-		$expected = array('email' => array('email is not valid'));
+		$expected = array('email' => array(1 => 'email is not valid'));
 		$this->assertEqual($expected, $result);
 	}
 

--- a/util/Validator.php
+++ b/util/Validator.php
@@ -495,7 +495,7 @@ class Validator extends \lithium\core\StaticObject {
 					}
 					if (!array_key_exists($field, $values)) {
 						if ($rule['required']) {
-							$errors[$field][] = $rule['message'] ?: $key;
+							$errors[$field][$key] = $rule['message'] ?: $key;
 						}
 						if ($rule['last']) {
 							break;
@@ -507,7 +507,7 @@ class Validator extends \lithium\core\StaticObject {
 					}
 
 					if (!$self::rule($name, $values[$field], $rule['format'], $rule + $options)) {
-						$errors[$field][] = $rule['message'] ?: $key;
+						$errors[$field][$key] = $rule['message'] ?: $key;
 
 						if ($rule['last']) {
 							break;


### PR DESCRIPTION
This feature allows to provide messages for validation error inside the template.
This allows easier translation of messages and customization in case there is no
control over the model (i.e. developing a "theme" for a customer without changing
the basic functionality).

- Support named rules by updating Validator to return errors keyed by offending rule name.
- Adding and updating tests.
- Documenting new feature.

Documentation has been added here https://github.com/UnionOfRAD/manual/commit/c594cc64fdc2c5105e352fb033515af4d743b0c5