### PR TITLE
Improve database encoding methods.

### DIFF
--- a/data/source/Database.php
+++ b/data/source/Database.php
@@ -126,11 +126,14 @@ abstract class Database extends \lithium\data\Source {
 	protected $_cachedNames = array();
 
 	/**
-	 * Getter/Setter for the connection's encoding
+	 * Getter/Setter for the connection's encoding.
 	 * Abstract. Must be defined by child class.
 	 *
-	 * @param mixed $encoding
-	 * @return mixed.
+	 * @param null|string $encoding Either `null` to retrieve the current encoding, or
+	 *        a string to set the current encoding to. For UTF-8 accepts any permutation.
+	 * @return string|boolean When $encoding is `null` returns the current encoding
+	 *         in effect, otherwise a boolean indicating if setting the encoding
+	 *         succeeded or failed. Returns `'UTF-8'` when this encoding is used.
 	 */
 	abstract public function encoding($encoding = null);
 
@@ -328,8 +331,8 @@ abstract class Database extends \lithium\data\Source {
 		}
 		$this->_isConnected = true;
 
-		if ($this->_config['encoding']) {
-			$this->encoding($this->_config['encoding']);
+		if ($this->_config['encoding'] && !$this->encoding($this->_config['encoding'])) {
+			return false;
 		}
 		return $this->_isConnected;
 	}

--- a/data/source/database/adapter/MySql.php
+++ b/data/source/database/adapter/MySql.php
@@ -238,28 +238,32 @@ class MySql extends \lithium\data\source\Database {
 	}
 
 	/**
-	 * Gets or sets the encoding for the connection.
+	 * Getter/Setter for the connection's encoding.
 	 *
-	 * @param $encoding
-	 * @return mixed If setting the encoding; returns true on success, else false.
-	 *         When getting, returns the encoding.
+	 * MySQL uses the string `utf8` to identify the UTF-8 encoding. In general `UTF-8` is used
+	 * to identify that encoding. This methods allows both strings to be used for _setting_ the
+	 * encoding (in lower and uppercase, with or without dash) and will transparently convert
+	 * to MySQL native format. When _getting_ the encoding, it is converted back into `UTF-8`.
+	 * So that this method should ever only return `UTF-8` when the encoding is used.
+	 *
+	 * @param null|string $encoding Either `null` to retrieve the current encoding, or
+	 *        a string to set the current encoding to. For UTF-8 accepts any permutation.
+	 * @return string|boolean When $encoding is `null` returns the current encoding
+	 *         in effect, otherwise a boolean indicating if setting the encoding
+	 *         succeeded or failed. Returns `'UTF-8'` when this encoding is used.
 	 */
 	public function encoding($encoding = null) {
-		$encodingMap = array('UTF-8' => 'utf8');
+		if ($encoding == null) {
+			$encoding = $this->connection
+				->query("SHOW VARIABLES LIKE 'character_set_client'")
+				->fetchColumn(1);
 
-		if (empty($encoding)) {
-			$query = $this->connection->query("SHOW VARIABLES LIKE 'character_set_client'");
-			$encoding = $query->fetchColumn(1);
-			return ($key = array_search($encoding, $encodingMap)) ? $key : $encoding;
+			return $encoding === 'utf8' ? 'UTF-8' : $encoding;
 		}
-		$encoding = isset($encodingMap[$encoding]) ? $encodingMap[$encoding] : $encoding;
-
-		try {
-			$this->connection->exec("SET NAMES '{$encoding}'");
-			return true;
-		} catch (PDOException $e) {
-			return false;
+		if (stripos($encoding, 'utf-8') !== false || stripos($encoding, 'utf8') !== false) {
+			$encoding = 'utf8';
 		}
+		return $this->connection->exec("SET NAMES '{$encoding}'") !== false;
 	}
 
 	/**

--- a/data/source/database/adapter/PostgreSql.php
+++ b/data/source/database/adapter/PostgreSql.php
@@ -258,60 +258,54 @@ class PostgreSql extends \lithium\data\source\Database {
 	 */
 	public function searchPath($searchPath) {
 		if (empty($searchPath)) {
-			$query = $this->connection->query('SHOW search_path');
-			$searchPath = $query->fetchColumn(1);
-			return explode(",", $searchPath);
+			return explode(',', $this->connection->query('SHOW search_path')->fetchColumn(1));
 		}
-		try{
-			$this->connection->exec("SET search_path TO ${searchPath}");
-			return true;
-		} catch (PDOException $e) {
-			return false;
-		}
+		return $this->connection->exec("SET search_path TO {$searchPath}") !== false;
 	}
 
 	/**
-	 * Gets or sets the time zone for the connection
+	 * Getter/Setter for the connection's timezone.
 	 *
-	 * @param $timezone
-	 * @return mixed If setting the time zone; returns true on success, else false
-	 *         When getting, returns the time zone
+	 * @param null|string $timezone Either `null` to retrieve the current TZ, or
+	 *        a string to set the current TZ to.
+	 * @return string|boolean When $timezone is `null` returns the current TZ
+	 *         in effect, otherwise a boolean indicating if setting the TZ
+	 *         succeeded or failed.
 	 */
 	public function timezone($timezone = null) {
 		if (empty($timezone)) {
-			$query = $this->connection->query('SHOW TIME ZONE');
-			return $query->fetchColumn();
+			return $this->connection->query('SHOW TIME ZONE')->fetchColumn();
 		}
-		try {
-			$this->connection->exec("SET TIME ZONE '{$timezone}'");
-			return true;
-		} catch (PDOException $e) {
-			return false;
-		}
+		return $this->connection->exec("SET TIME ZONE '{$timezone}'") !== false;
 	}
 
 	/**
-	 * Gets or sets the encoding for the connection.
+	 * Getter/Setter for the connection's encoding.
 	 *
-	 * @param $encoding
-	 * @return mixed If setting the encoding; returns true on success, else false.
-	 *         When getting, returns the encoding.
+	 * PostgreSQL uses the string `UTF8` to identify the UTF-8 encoding. In general `UTF-8` is used
+	 * to identify that encoding. This methods allows both strings to be used for _setting_ the
+	 * encoding (in lower and uppercase, with or without dash) and will transparently convert
+	 * to PostgreSQL native format. When _getting_ the encoding, it is converted back into `UTF-8`.
+	 * So that this method should ever only return `UTF-8` when the encoding is used.
+	 *
+	 * @param null|string $encoding Either `null` to retrieve the current encoding, or
+	 *        a string to set the current encoding to. For UTF-8 accepts any permutation.
+	 * @return string|boolean When $encoding is `null` returns the current encoding
+	 *         in effect, otherwise a boolean indicating if setting the encoding
+	 *         succeeded or failed. Returns `'UTF-8'` when this encoding is used.
 	 */
 	public function encoding($encoding = null) {
-		$encodingMap = array('UTF-8' => 'UTF8');
+		if ($encoding == null) {
+			$encoding = $this->connection
+				->query('SHOW client_encoding')
+				->fetchColumn();
 
-		if (empty($encoding)) {
-			$query = $this->connection->query("SHOW client_encoding");
-			$encoding = $query->fetchColumn();
-			return ($key = array_search($encoding, $encodingMap)) ? $key : $encoding;
+			return $encoding === 'UTF8' ? 'UTF-8' : $encoding;
 		}
-		$encoding = isset($encodingMap[$encoding]) ? $encodingMap[$encoding] : $encoding;
-		try {
-			$this->connection->exec("SET NAMES '{$encoding}'");
-			return true;
-		} catch (PDOException $e) {
-			return false;
+		if (stripos($encoding, 'utf-8') !== false || stripos($encoding, 'utf8') !== false) {
+			$encoding = 'UTF8';
 		}
+		return $this->connection->exec("SET NAMES '{$encoding}'") !== false;
 	}
 
 	/**

--- a/data/source/database/adapter/Sqlite3.php
+++ b/data/source/database/adapter/Sqlite3.php
@@ -249,29 +249,32 @@ class Sqlite3 extends \lithium\data\source\Database {
 	}
 
 	/**
-	 * Gets or sets the encoding for the connection.
+	 * Getter/Setter for the connection's encoding.
 	 *
-	 * @param string $encoding If setting the encoding, this is the name of the encoding to set,
-	 *               i.e. `'utf8'` or `'UTF-8'` (both formats are valid).
-	 * @return mixed If setting the encoding; returns `true` on success, or `false` on
-	 *         failure. When getting, returns the encoding as a string.
+	 * Sqlite uses the string `utf8` to identify the UTF-8 encoding. In general `UTF-8` is used
+	 * to identify that encoding. This methods allows both strings to be used for _setting_ the
+	 * encoding (in lower and uppercase, with or without dash) and will transparently convert
+	 * to Sqlite native format. When _getting_ the encoding, it is converted back into `UTF-8`.
+	 * So that this method should ever only return `UTF-8` when the encoding is used.
+	 *
+	 * @param null|string $encoding Either `null` to retrieve the current encoding, or
+	 *        a string to set the current encoding to. For UTF-8 accepts any permutation.
+	 * @return string|boolean When $encoding is `null` returns the current encoding
+	 *         in effect, otherwise a boolean indicating if setting the encoding
+	 *         succeeded or failed. Returns `'UTF-8'` when this encoding is used.
 	 */
 	public function encoding($encoding = null) {
-		$encodingMap = array('UTF-8' => 'utf8');
+		if ($encoding == null) {
+			$encoding = $this->connection
+				->query('PRAGMA encoding')
+				->fetchColumn();
 
-		if (!$encoding) {
-			$query = $this->connection->query('PRAGMA encoding');
-			$encoding = $query->fetchColumn();
-			return ($key = array_search($encoding, $encodingMap)) ? $key : $encoding;
+			return $encoding === 'utf8' ? 'UTF-8' : $encoding;
 		}
-		$encoding = isset($encodingMap[$encoding]) ? $encodingMap[$encoding] : $encoding;
-
-		try {
-			$this->connection->exec("PRAGMA encoding = \"{$encoding}\"");
-			return true;
-		} catch (PDOException $e) {
-			return false;
+		if (stripos($encoding, 'utf-8') !== false || stripos($encoding, 'utf8') !== false) {
+			$encoding = 'utf8';
 		}
+		return $this->connection->exec("PRAGMA encoding = \"{$encoding}\"") !== false;
 	}
 
 	/**

--- a/tests/integration/data/source/database/adapter/MySqlTest.php
+++ b/tests/integration/data/source/database/adapter/MySqlTest.php
@@ -103,10 +103,26 @@ class MySqlTest extends \lithium\tests\integration\data\Base {
 
 	public function testDatabaseEncoding() {
 		$this->assertTrue($this->_db->isConnected());
+
+		$this->assertTrue($this->_db->encoding('ascii'));
+		$this->assertEqual('ascii', $this->_db->encoding());
+
+		$this->assertTrue($this->_db->encoding('ASCII'));
+		$this->assertEqual('ascii', $this->_db->encoding());
+
+		$this->assertTrue($this->_db->encoding('LATIN2'));
+		$this->assertEqual('latin2',  $this->_db->encoding());
+
+		$this->assertTrue($this->_db->encoding('UTF8'));
+		$this->assertEqual('UTF-8', $this->_db->encoding());
+
 		$this->assertTrue($this->_db->encoding('utf8'));
 		$this->assertEqual('UTF-8', $this->_db->encoding());
 
 		$this->assertTrue($this->_db->encoding('UTF-8'));
+		$this->assertEqual('UTF-8', $this->_db->encoding());
+
+		$this->assertTrue($this->_db->encoding('utf-8'));
 		$this->assertEqual('UTF-8', $this->_db->encoding());
 	}
 

--- a/tests/integration/data/source/database/adapter/PostgreSqlTest.php
+++ b/tests/integration/data/source/database/adapter/PostgreSqlTest.php
@@ -104,10 +104,17 @@ class PostgreSqlTest extends \lithium\tests\integration\data\Base {
 
 	public function testDatabaseEncoding() {
 		$this->assertTrue($this->_db->isConnected());
+
+		$this->assertTrue($this->_db->encoding('UTF8'));
+		$this->assertEqual('UTF-8', $this->_db->encoding());
+
 		$this->assertTrue($this->_db->encoding('utf8'));
 		$this->assertEqual('UTF-8', $this->_db->encoding());
 
 		$this->assertTrue($this->_db->encoding('UTF-8'));
+		$this->assertEqual('UTF-8', $this->_db->encoding());
+
+		$this->assertTrue($this->_db->encoding('utf-8'));
 		$this->assertEqual('UTF-8', $this->_db->encoding());
 	}
 

--- a/tests/integration/data/source/database/adapter/Sqlite3Test.php
+++ b/tests/integration/data/source/database/adapter/Sqlite3Test.php
@@ -97,10 +97,17 @@ class Sqlite3Test extends \lithium\tests\integration\data\Base {
 
 	public function testDatabaseEncoding() {
 		$this->assertTrue($this->_db->isConnected());
+
+		$this->assertTrue($this->_db->encoding('UTF8'));
+		$this->assertEqual('UTF-8', $this->_db->encoding());
+
 		$this->assertTrue($this->_db->encoding('utf8'));
 		$this->assertEqual('UTF-8', $this->_db->encoding());
 
 		$this->assertTrue($this->_db->encoding('UTF-8'));
+		$this->assertEqual('UTF-8', $this->_db->encoding());
+
+		$this->assertTrue($this->_db->encoding('utf-8'));
 		$this->assertEqual('UTF-8', $this->_db->encoding());
 	}
 


### PR DESCRIPTION
Changed: encoding() may now throw exceptions and needs try/catch in
userland if invoked directly.

- Do not silence exceptions, allow exceptions to buble up.
- Check return value of encoding in connect.
- Refactored methods.
- Now all permutations of utf-8/UTF8 are allowed.
- Add more encoding tests.