### PR TITLE
Improve database encoding, refactor timezone and searchPath methods.

### DIFF
--- a/data/source/Database.php
+++ b/data/source/Database.php
@@ -126,11 +126,14 @@ abstract class Database extends \lithium\data\Source {
 	protected $_cachedNames = array();
 
 	/**
-	 * Getter/Setter for the connection's encoding
+	 * Getter/Setter for the connection's encoding.
 	 * Abstract. Must be defined by child class.
 	 *
-	 * @param mixed $encoding
-	 * @return mixed.
+	 * @param null|string $encoding Either `null` to retrieve the current encoding, or
+	 *        a string to set the current encoding to. For UTF-8 accepts any permutation.
+	 * @return string|boolean When $encoding is `null` returns the current encoding
+	 *         in effect, otherwise a boolean indicating if setting the encoding
+	 *         succeeded or failed. Returns `'UTF-8'` when this encoding is used.
 	 */
 	abstract public function encoding($encoding = null);
 
@@ -328,8 +331,8 @@ abstract class Database extends \lithium\data\Source {
 		}
 		$this->_isConnected = true;
 
-		if ($this->_config['encoding']) {
-			$this->encoding($this->_config['encoding']);
+		if ($this->_config['encoding'] && !$this->encoding($this->_config['encoding'])) {
+			return false;
 		}
 		return $this->_isConnected;
 	}

--- a/data/source/database/adapter/MySql.php
+++ b/data/source/database/adapter/MySql.php
@@ -238,28 +238,32 @@ class MySql extends \lithium\data\source\Database {
 	}
 
 	/**
-	 * Gets or sets the encoding for the connection.
+	 * Getter/Setter for the connection's encoding.
 	 *
-	 * @param $encoding
-	 * @return mixed If setting the encoding; returns true on success, else false.
-	 *         When getting, returns the encoding.
+	 * MySQL uses the string `utf8` to identify the UTF-8 encoding. In general `UTF-8` is used
+	 * to identify that encoding. This methods allows both strings to be used for _setting_ the
+	 * encoding (in lower and uppercase, with or without dash) and will transparently convert
+	 * to MySQL native format. When _getting_ the encoding, it is converted back into `UTF-8`.
+	 * So that this method should ever only return `UTF-8` when the encoding is used.
+	 *
+	 * @param null|string $encoding Either `null` to retrieve the current encoding, or
+	 *        a string to set the current encoding to. For UTF-8 accepts any permutation.
+	 * @return string|boolean When $encoding is `null` returns the current encoding
+	 *         in effect, otherwise a boolean indicating if setting the encoding
+	 *         succeeded or failed. Returns `'UTF-8'` when this encoding is used.
 	 */
 	public function encoding($encoding = null) {
-		$encodingMap = array('UTF-8' => 'utf8');
+		if ($encoding === null) {
+			$encoding = $this->connection
+				->query("SHOW VARIABLES LIKE 'character_set_client'")
+				->fetchColumn(1);
 
-		if (empty($encoding)) {
-			$query = $this->connection->query("SHOW VARIABLES LIKE 'character_set_client'");
-			$encoding = $query->fetchColumn(1);
-			return ($key = array_search($encoding, $encodingMap)) ? $key : $encoding;
+			return $encoding === 'utf8' ? 'UTF-8' : $encoding;
 		}
-		$encoding = isset($encodingMap[$encoding]) ? $encodingMap[$encoding] : $encoding;
-
-		try {
-			$this->connection->exec("SET NAMES '{$encoding}'");
-			return true;
-		} catch (PDOException $e) {
-			return false;
+		if (stripos($encoding, 'utf-8') !== false || stripos($encoding, 'utf8') !== false) {
+			$encoding = 'utf8';
 		}
+		return $this->connection->exec("SET NAMES '{$encoding}'") !== false;
 	}
 
 	/**

--- a/tests/integration/data/source/database/adapter/MySqlTest.php
+++ b/tests/integration/data/source/database/adapter/MySqlTest.php
@@ -103,10 +103,26 @@ class MySqlTest extends \lithium\tests\integration\data\Base {
 
 	public function testDatabaseEncoding() {
 		$this->assertTrue($this->_db->isConnected());
+
+		$this->assertTrue($this->_db->encoding('ascii'));
+		$this->assertEqual('ascii', $this->_db->encoding());
+
+		$this->assertTrue($this->_db->encoding('ASCII'));
+		$this->assertEqual('ascii', $this->_db->encoding());
+
+		$this->assertTrue($this->_db->encoding('LATIN2'));
+		$this->assertEqual('latin2',  $this->_db->encoding());
+
+		$this->assertTrue($this->_db->encoding('UTF8'));
+		$this->assertEqual('UTF-8', $this->_db->encoding());
+
 		$this->assertTrue($this->_db->encoding('utf8'));
 		$this->assertEqual('UTF-8', $this->_db->encoding());
 
 		$this->assertTrue($this->_db->encoding('UTF-8'));
+		$this->assertEqual('UTF-8', $this->_db->encoding());
+
+		$this->assertTrue($this->_db->encoding('utf-8'));
 		$this->assertEqual('UTF-8', $this->_db->encoding());
 	}
 

--- a/tests/integration/data/source/database/adapter/PostgreSqlTest.php
+++ b/tests/integration/data/source/database/adapter/PostgreSqlTest.php
@@ -104,10 +104,17 @@ class PostgreSqlTest extends \lithium\tests\integration\data\Base {
 
 	public function testDatabaseEncoding() {
 		$this->assertTrue($this->_db->isConnected());
+
+		$this->assertTrue($this->_db->encoding('UTF8'));
+		$this->assertEqual('UTF-8', $this->_db->encoding());
+
 		$this->assertTrue($this->_db->encoding('utf8'));
 		$this->assertEqual('UTF-8', $this->_db->encoding());
 
 		$this->assertTrue($this->_db->encoding('UTF-8'));
+		$this->assertEqual('UTF-8', $this->_db->encoding());
+
+		$this->assertTrue($this->_db->encoding('utf-8'));
 		$this->assertEqual('UTF-8', $this->_db->encoding());
 	}
 

--- a/tests/integration/data/source/database/adapter/Sqlite3Test.php
+++ b/tests/integration/data/source/database/adapter/Sqlite3Test.php
@@ -97,10 +97,17 @@ class Sqlite3Test extends \lithium\tests\integration\data\Base {
 
 	public function testDatabaseEncoding() {
 		$this->assertTrue($this->_db->isConnected());
+
+		$this->assertTrue($this->_db->encoding('UTF8'));
+		$this->assertEqual('UTF-8', $this->_db->encoding());
+
 		$this->assertTrue($this->_db->encoding('utf8'));
 		$this->assertEqual('UTF-8', $this->_db->encoding());
 
 		$this->assertTrue($this->_db->encoding('UTF-8'));
+		$this->assertEqual('UTF-8', $this->_db->encoding());
+
+		$this->assertTrue($this->_db->encoding('utf-8'));
 		$this->assertEqual('UTF-8', $this->_db->encoding());
 	}
 


### PR DESCRIPTION
Improve database encoding, timezone and searchPath methods. …
Changed: encoding(), timezone() and searchPath() may now throw exceptions
userland code needs try/catch if invoking these methods directly.

- Do not silence exceptions, allow exceptions to bubble up.
- Check return value of methods in connect.
- Refactored methods.
- Now all permutations of utf-8/UTF8 are allowed in encoding method.
- Add more encoding tests.