### PR TITLE
Fix for deprecated MongoClient::$connected property

### DIFF
--- a/data/source/MongoDb.php
+++ b/data/source/MongoDb.php
@@ -283,7 +283,7 @@ class MongoDb extends \lithium\data\Source {
 	 * @return boolean Returns `true` the connection attempt was successful, otherwise `false`.
 	 */
 	public function connect() {
-		if ($this->server && !empty($this->server->getConnections()) && $this->connection) {
+		if ($this->server && count($this->server->getConnections()) > 0 && $this->connection) {
 			return $this->_isConnected = true;
 		}
 

--- a/data/source/MongoDb.php
+++ b/data/source/MongoDb.php
@@ -283,7 +283,7 @@ class MongoDb extends \lithium\data\Source {
 	 * @return boolean Returns `true` the connection attempt was successful, otherwise `false`.
 	 */
 	public function connect() {
-		if ($this->server && count($this->server->getConnections()) > 0 && $this->connection) {
+		if ($this->server && $this->server->getConnections() && $this->connection) {
 			return $this->_isConnected = true;
 		}
 

--- a/data/source/MongoDb.php
+++ b/data/source/MongoDb.php
@@ -283,7 +283,7 @@ class MongoDb extends \lithium\data\Source {
 	 * @return boolean Returns `true` the connection attempt was successful, otherwise `false`.
 	 */
 	public function connect() {
-		if ($this->server && $this->server->connected && $this->connection) {
+		if ($this->server && !empty($this->server->getConnections()) && $this->connection) {
 			return $this->_isConnected = true;
 		}
 


### PR DESCRIPTION
You know I thought this (https://github.com/UnionOfRAD/lithium/issues/698) was taken care of a while ago, but I think there were two issues (or now are). First was just the use of ```MongoClient``` instead of just ```Mongo``` which I see is in the dev branch. Second, the ```MongoClient::$connected``` property is now deprecated so checking it on ```connect()``` in the adapter is throwing deprecation warnings.

I discovered that ```MongoClient::getConnections()``` will solve the same problem, but return more reliable information (apparently connected boolean could be lying) and more of it. Should there not be any connections, this would return empty. See more here: http://php.net/manual/en/mongoclient.getconnections.php

So to resolve the deprecation warnings a simple switch on one line should do it.

This is a little awkward to test (and we're now testing PECL extension versions), but it seems to have worked and given what the change involved I imagine it's fine without breaking the call out to test? Without backward compatibility as well? Because ```getConnections()``` has been around since version 1.3.0 which was released in November of 2012. Though I recognize this may bump up a minimum requirement for the framework.

In the interim while this is sorted out, one could create their own Mongo adapter and extend the MongoDb class and add their own ```connect()``` method which would have nearly the same code, but with this small change. That is to say if this deprecation warning is problematic for you.

Hopefully this should clear some things up.