### PR TITLE
Update Request::accepts() to return boolean when type is provided.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,4 +95,7 @@
   before the APC adapter. Normally this should happen automatically and no updates are needed. However
   if you use an old bootstrap file, the base adapter may not been loaded before the apc one. 
   A deprecation notice will then be triggered. 
-
+- When used with a parameter `lithium\action\Request::accepts()` now returns a boolean.
+  It previously was returning i.e. `'json'` when `application/json` was in accepted content types 
+  and invoked with `Request::accepts('json')`. This change matches the actual behavior with
+  documented (and expected) behavior.

--- a/tests/cases/action/RequestTest.php
+++ b/tests/cases/action/RequestTest.php
@@ -1129,6 +1129,45 @@ class RequestTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $request->accepts(true));
 	}
 
+	public function testAcceptWithTypeParam() {
+		$request = new Request(array('env' => array(
+			'HTTP_ACCEPT' => 'application/json'
+		)));
+		$this->assertFalse($request->accepts('text'));
+		$this->assertTrue($request->accepts('json'));
+		$this->assertFalse($request->accepts('html'));
+	}
+
+	public function testAcceptWithTypeParamFallbackHtml() {
+		$request = new Request(array('env' => array(
+			'HTTP_ACCEPT' => 'nothing/matches'
+		)));
+		$this->assertFalse($request->accepts('json'));
+		$this->assertTrue($request->accepts('html'));
+
+		$request = new Request(array('env' => array(
+			'HTTP_ACCEPT' => 'application/json'
+		)));
+		$this->assertFalse($request->accepts('text'));
+		$this->assertTrue($request->accepts('json'));
+		$this->assertFalse($request->accepts('html'));
+	}
+
+	public function testAcceptForBothXmlWithAliasedHtml() {
+		$request = new Request(array('env' => array(
+			'HTTP_ACCEPT' => 'application/xml'
+		)));
+		$this->assertTrue($request->accepts('xml'));
+		$this->assertFalse($request->accepts('html'));
+	}
+
+	public function testAcceptDoesNotAccepFullNamespacedType() {
+		$request = new Request(array('env' => array(
+			'HTTP_ACCEPT' => 'application/json'
+		)));
+		$this->assertFalse($request->accepts('application/json'));
+	}
+
 	public function testParsingAcceptHeader() {
 		$chrome = array(
 			'application/xml',

--- a/tests/cases/net/http/MediaTest.php
+++ b/tests/cases/net/http/MediaTest.php
@@ -657,6 +657,18 @@ class MediaTest extends \lithium\test\Unit {
 		$this->assertEqual('/foo/bar/image.jpg', $result);
 	}
 
+	public function testContentNegotiationSimple() {
+		$request = new Request(array('env' => array(
+			'HTTP_ACCEPT' => 'text/html,text/plain;q=0.5'
+		)));
+		$this->assertEqual('html', Media::negotiate($request));
+
+		$request = new Request(array('env' => array(
+			'HTTP_ACCEPT' => 'application/json'
+		)));
+		$this->assertEqual('json', Media::negotiate($request));
+	}
+
 	public function testContentNegotiationByType() {
 		$this->assertEqual('html', Media::type('text/html'));
 


### PR DESCRIPTION
- This makes the implementation match its documentation.
- Expand documentation and update documented return type.
- Add tests.
- Add changelog entry.

Fixes #856.
Refs 97412cfe16eab37c50372d39e2345349803ba5f2.

Target version is 1.0, as this is a BC break, if accepts is used with a type. IMHO the documented behavior was correct and would be what a user expects to happen (return boolean if asked if a type is accepted), so we should correct this before 1.0.
