### PR TITLE
Disable Number to String conversion when the MySQL Native Driver is used

### DIFF
--- a/data/source/database/adapter/MySql.php
+++ b/data/source/database/adapter/MySql.php
@@ -320,6 +320,11 @@ class MySql extends \lithium\data\source\Database {
 			$options = $params['options'];
 			$conn->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, $options['buffered']);
 
+			if (strpos($conn->getAttribute(PDO::ATTR_CLIENT_VERSION), 'mysqlnd') !== false) {
+				$conn->setAttribute(\PDO::ATTR_EMULATE_PREPARES, false);
+				$conn->setAttribute(\PDO::ATTR_STRINGIFY_FETCHES, false);
+			}
+
 			try {
 				$resource = $conn->query($sql);
 			} catch (PDOException $e) {


### PR DESCRIPTION
Allows the MySQL Native Driver to cast resulting numeric fields correctly.

I'm unsure if this is the best place or method to accomplish this. 
