### PR TITLE
Rename String class to Text for PHP7 compatibility.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,13 +43,27 @@
 - Database encoding, timezone, and searchPath methods may now throw exceptions. Please
   wrap code calling these methods directly in try/catch blocks - if needed. #1172
   (David Persson)
-- The String/Text class has been thinned. RNG functionality has been extracted 
-  into `security\Random` and hashing functionality extracted into `security\Hash`.
-  Please update your code accordingly. #1184 (David Persson)
+- The String class has been renamed to `Text` while RNG and hashing functionality 
+  have been extracted into `lithium\security\Random` and `lithium\security\Hash`. #1184 (David Persson)
+
+  This is mainly to achieve PHP 7.0 compatibilty as `String` 
+  [will become a reserved name](https://wiki.php.net/rfc/reserve_even_more_types_in_php_7).  
   
-  - `lithium\util\String::hash()` -> `lithium\security\Hash::calculate()`
-  - `lithium\util\String::compare()` -> `lithium\security\Hash::compare()`
-  - `lithium\util\String::random()` -> `lithium\security\Random::generate()`
+  Old methods are deprecated but continue to work and redirect to new methods. It wont be 
+  possible to use the old String class with PHP >= 7.0. You must use the new names before 
+  switching to PHP 7.0. 
+  
+  | old | new |
+  | --- | --- |
+  | `lithium\util\String::hash()` | `lithium\security\Hash::calculate()` |
+  | `lithium\util\String::compare()` | `lithium\security\Hash::compare()` |
+  | `lithium\util\String::random()` | `lithium\security\Random::generate()` |
+  | `lithium\util\String::ENCODE_BASE_64` | `lithium\security\Random::ENCODE_BASE_64` |
+  | `lithium\util\String::uuid()` | `lithium\util\Text::uuid()` |
+  | `lithium\util\String::insert()` | `lithium\util\Text::insert()` |
+  | `lithium\util\String::clean()` | `lithium\util\Text::clean()` |
+  | `lithium\util\String::extract()` | `lithium\util\Text::extract()` |
+  | `lithium\util\String::tokenize()` | `lithium\util\Text::tokenize()` |
 
 ## v1.0.0
 

--- a/action/Dispatcher.php
+++ b/action/Dispatcher.php
@@ -8,7 +8,7 @@
 
 namespace lithium\action;
 
-use lithium\util\String;
+use lithium\util\Text;
 use lithium\util\Inflector;
 use lithium\core\Libraries;
 use lithium\action\DispatchException;
@@ -51,8 +51,8 @@ class Dispatcher extends \lithium\core\StaticObject {
 	 * (and not empty) in a route, (i.e. the result of `Router::parse()`) then the rule's
 	 * value will be applied to the route before it is dispatched. When applying a rule, any
 	 * array elements of the flag which are present in the route will be modified using a
-	 * `String::insert()`-formatted string. Alternatively, a callback can be used to do custom
-	 * transformations other than the default `String::insert()`.
+	 * `Text::insert()`-formatted string. Alternatively, a callback can be used to do custom
+	 * transformations other than the default `Text::insert()`.
 	 *
 	 * For example, to implement action prefixes (i.e. `admin_index`), set a rule named
 	 * `'admin'`, with a value array containing a modifier key for the `action` element of
@@ -98,7 +98,7 @@ class Dispatcher extends \lithium\core\StaticObject {
 	 * ```
 	 *
 	 * @see lithium\action\Dispatcher::config()
-	 * @see lithium\util\String::insert()
+	 * @see lithium\util\Text::insert()
 	 * @see lithium\util\Inflector
 	 * @var array
 	 */
@@ -220,7 +220,7 @@ class Dispatcher extends \lithium\core\StaticObject {
 				if (preg_match('/' . $match . '/i', $values[$k])) {
 					continue;
 				}
-				$values[$k] = String::insert($v, $values);
+				$values[$k] = Text::insert($v, $values);
 			}
 		}
 		return $values;

--- a/analysis/Debugger.php
+++ b/analysis/Debugger.php
@@ -9,7 +9,7 @@
 namespace lithium\analysis;
 
 use ReflectionClass;
-use lithium\util\String;
+use lithium\util\Text;
 use lithium\analysis\Inspector;
 
 /**
@@ -90,7 +90,7 @@ class Debugger {
 			if ($options['format'] === 'points' && $trace['file'] !== '[internal]') {
 				$back[] = array('file' => $trace['file'], 'line' => $trace['line']);
 			} elseif (is_string($options['format']) && $options['format'] !== 'array') {
-				$back[] = String::insert($options['format'], array_map(
+				$back[] = Text::insert($options['format'], array_map(
 					function($data) { return is_object($data) ? get_class($data) : $data; },
 					$trace
 				));

--- a/analysis/logger/adapter/Cache.php
+++ b/analysis/logger/adapter/Cache.php
@@ -8,7 +8,7 @@
 
 namespace lithium\analysis\logger\adapter;
 
-use lithium\util\String;
+use lithium\util\Text;
 use Closure;
 
 /**
@@ -48,7 +48,7 @@ class Cache extends \lithium\core\Object {
 	/**
 	 * Constructor.
 	 *
-	 * @see lithium\util\String
+	 * @see lithium\util\Text
 	 * @param array $config Possible configuration options are:
 	 *        - `'config'`: The name of the cache configuration to use; defaults to none.
 	 *        - `'expiry'`: Defines when the logged item should expire, by default will
@@ -83,7 +83,7 @@ class Cache extends \lithium\core\Object {
 		return function($self, $params) use ($config) {
 			$params += array('timestamp' => strtotime('now'));
 			$key = $config['key'];
-			$key = is_callable($key) ? $key($params) : String::insert($key, $params);
+			$key = is_callable($key) ? $key($params) : Text::insert($key, $params);
 
 			$cache = $config['cache'];
 			return $cache::write($config['config'], $key, $params['message'], $config['expiry']);

--- a/analysis/logger/adapter/File.php
+++ b/analysis/logger/adapter/File.php
@@ -8,7 +8,7 @@
 
 namespace lithium\analysis\logger\adapter;
 
-use lithium\util\String;
+use lithium\util\Text;
 use lithium\core\Libraries;
 use Closure;
 
@@ -36,7 +36,7 @@ class File extends \lithium\core\Object {
 	/**
 	 * Constructor.
 	 *
-	 * @see lithium\util\String::insert()
+	 * @see lithium\util\Text::insert()
 	 * @param array $config Settings used to configure the adapter. Available options:
 	 *        - `'path'` _string_: The directory to write log files to. Defaults to
 	 *          `<app>/resources/tmp/logs`.
@@ -47,7 +47,7 @@ class File extends \lithium\core\Object {
 	 *          adapter's current configuration. It must then return a file name to write the
 	 *          log message to. The default will produce a log file name corresponding to the
 	 *          priority of the log message, i.e. `"debug.log"` or `"alert.log"`.
-	 *        - `'format'` _string_: A `String::insert()`-compatible string that specifies how
+	 *        - `'format'` _string_: A `Text::insert()`-compatible string that specifies how
 	 *          the log message should be formatted. The default format is
 	 *          `"{:timestamp} {:message}\n"`.
 	 * @return void
@@ -76,7 +76,7 @@ class File extends \lithium\core\Object {
 		return function($self, $params) use (&$config) {
 			$path = $config['path'] . '/' . $config['file']($params, $config);
 			$params['timestamp'] = date($config['timestamp']);
-			$message = String::insert($config['format'], $params);
+			$message = Text::insert($config['format'], $params);
 			return file_put_contents($path, $message, FILE_APPEND);
 		};
 	}

--- a/console/Dispatcher.php
+++ b/console/Dispatcher.php
@@ -45,10 +45,10 @@ class Dispatcher extends \lithium\core\StaticObject {
 	 * not empty) in a route, (i.e. the result of `lithium\console\Router::parse()`) then the rule's
 	 * value will be applied to the route before it is dispatched.  When applying a rule, any array
 	 * elements array elements of the flag which are present in the route will be modified using a
-	 * `lithium\util\String::insert()`-formatted string.
+	 * `lithium\util\Text::insert()`-formatted string.
 	 *
 	 * @see lithium\console\Dispatcher::config()
-	 * @see lithium\util\String::insert()
+	 * @see lithium\util\Text::insert()
 	 * @var array
 	 */
 	protected static $_rules = array(

--- a/console/Response.php
+++ b/console/Response.php
@@ -8,7 +8,7 @@
 
 namespace lithium\console;
 
-use lithium\util\String;
+use lithium\util\Text;
 
 /**
  * The `Response` class is used by other console classes to generate output. It contains stream
@@ -75,7 +75,7 @@ class Response extends \lithium\core\Object {
 	 * @return mixed
 	 */
 	public function output($output) {
-		return fwrite($this->output, String::insert($output, $this->styles()));
+		return fwrite($this->output, Text::insert($output, $this->styles()));
 	}
 
 	/**
@@ -85,7 +85,7 @@ class Response extends \lithium\core\Object {
 	 * @return mixed
 	 */
 	public function error($error) {
-		return fwrite($this->error, String::insert($error, $this->styles()));
+		return fwrite($this->error, Text::insert($error, $this->styles()));
 	}
 
 	/**

--- a/console/command/Create.php
+++ b/console/command/Create.php
@@ -8,7 +8,7 @@
 
 namespace lithium\console\command;
 
-use lithium\util\String;
+use lithium\util\Text;
 use lithium\core\Libraries;
 use lithium\util\Inflector;
 use lithium\core\ClassNotFoundException;
@@ -229,7 +229,7 @@ class Create extends \lithium\console\Command {
 			return false;
 		}
 		$contents = $this->_template();
-		$result = String::insert($contents, $params);
+		$result = Text::insert($contents, $params);
 		$namespace = str_replace($this->_library['prefix'], '\\', $params['namespace']);
 		$path = str_replace('\\', '/', "{$namespace}\\{$params['class']}");
 		$path = $this->_library['path'] . stristr($path, '/');

--- a/console/command/create/View.php
+++ b/console/command/create/View.php
@@ -9,7 +9,7 @@
 namespace lithium\console\command\create;
 
 use lithium\util\Inflector;
-use lithium\util\String;
+use lithium\util\Text;
 
 /**
  * Generate a View file in the `--library` namespace
@@ -61,7 +61,7 @@ class View extends \lithium\console\command\Create {
 		$params['file'] = $this->request->args(0);
 
 		$contents = $this->_template();
-		$result = String::insert($contents, $params);
+		$result = Text::insert($contents, $params);
 
 		if (!empty($this->_library['path'])) {
 			$path = $this->_library['path'] . "/views/{$params['path']}/{$params['file']}";

--- a/core/Libraries.php
+++ b/core/Libraries.php
@@ -9,7 +9,7 @@
 namespace lithium\core;
 
 use RuntimeException;
-use lithium\util\String;
+use lithium\util\Text;
 use lithium\util\collection\Filters;
 use lithium\core\ConfigException;
 use lithium\core\ClassNotFoundException;
@@ -876,7 +876,7 @@ class Libraries {
 
 			foreach (static::_searchPaths($paths, $library) as $tpl) {
 				$params['library'] = rtrim($config['prefix'], '\\');
-				$class = str_replace('\\*', '', String::insert($tpl, $params));
+				$class = str_replace('\\*', '', Text::insert($tpl, $params));
 
 				if (file_exists($file = Libraries::path($class, $options))) {
 					return ($options['type'] === 'file') ? $file : $class;
@@ -931,7 +931,7 @@ class Libraries {
 			$params['library'] = $config['path'];
 
 			foreach (static::_searchPaths($paths, $library) as $tpl) {
-				$options['path'] = str_replace('\\', '/', String::insert($tpl, $params, $flags));
+				$options['path'] = str_replace('\\', '/', Text::insert($tpl, $params, $flags));
 				$options['path'] = str_replace('*/', '', $options['path']);
 				$classes = array_merge($classes, static::_search($config, $options));
 			}
@@ -954,7 +954,7 @@ class Libraries {
 		$params += array('app' => LITHIUM_APP_PATH, 'root' => LITHIUM_LIBRARY_PATH);
 
 		foreach (static::$_paths[$type] as $path) {
-			if (is_dir($path = str_replace('\\', '/', String::insert($path, $params)))) {
+			if (is_dir($path = str_replace('\\', '/', Text::insert($path, $params)))) {
 				return $path;
 			}
 		}

--- a/data/source/Database.php
+++ b/data/source/Database.php
@@ -11,7 +11,7 @@ namespace lithium\data\source;
 use PDO;
 use PDOException;
 use lithium\util\Set;
-use lithium\util\String;
+use lithium\util\Text;
 use lithium\util\Inflector;
 use lithium\core\ConfigException;
 use lithium\core\NetworkException;
@@ -503,10 +503,10 @@ abstract class Database extends \lithium\data\Source {
 	 * Inserts a new record into the database based on a the `Query`. The record is updated
 	 * with the id of the insert.
 	 *
-	 * @see lithium\util\String::insert()
+	 * @see lithium\util\Text::insert()
 	 * @param object $query An SQL query string, or `lithium\data\model\Query` object instance.
 	 * @param array $options If $query is a string, $options contains an array of bind values to be
-	 *              escaped, quoted, and inserted into `$query` using `String::insert()`.
+	 *              escaped, quoted, and inserted into `$query` using `Text::insert()`.
 	 * @return boolean Returns `true` if the query succeeded, otherwise `false`.
 	 * @filter
 	 */
@@ -522,7 +522,7 @@ abstract class Database extends \lithium\data\Source {
 				$entity =& $query->entity();
 				$query = $self->renderCommand('create', $params, $query);
 			} else {
-				$query = String::insert($query, $self->value($params['options']));
+				$query = Text::insert($query, $self->value($params['options']));
 			}
 
 			if (!$self->invokeMethod('_execute', array($query))) {
@@ -567,7 +567,7 @@ abstract class Database extends \lithium\data\Source {
 			$model = is_object($query) ? $query->model() : null;
 
 			if (is_string($query)) {
-				$sql = String::insert($query, $self->value($args));
+				$sql = Text::insert($query, $self->value($args));
 			} else {
 				if (!$data = $self->invokeMethod('_queryExport', array($query))) {
 					return false;
@@ -706,7 +706,7 @@ abstract class Database extends \lithium\data\Source {
 			if ($isObject) {
 				$sql = $self->renderCommand('delete', $query->export($self), $query);
 			} else {
-				$sql = String::insert($query, $self->value($params['options']));
+				$sql = Text::insert($query, $self->value($params['options']));
 			}
 			$result = (boolean) $self->invokeMethod('_execute', array($sql));
 
@@ -804,8 +804,8 @@ abstract class Database extends \lithium\data\Source {
 		foreach ($data as $key => $value) {
 			$placeholders[$key] = "{{$key}}";
 		}
-		$template = String::insert($template, $placeholders, array('clean' => true));
-		return trim(String::insert($template, $data, array('before' => '{')));
+		$template = Text::insert($template, $placeholders, array('clean' => true));
+		return trim(Text::insert($template, $data, array('before' => '{')));
 	}
 
 	/**
@@ -1446,7 +1446,7 @@ abstract class Database extends \lithium\data\Source {
 
 		switch (true) {
 			case (isset($config['format'])):
-				return $key . ' ' . String::insert($config['format'], $values);
+				return $key . ' ' . Text::insert($config['format'], $values);
 			case (is_object($value) && isset($config['multiple'])):
 				$op = $config['multiple'];
 				$value = trim(rtrim($this->renderCommand($value), ';'));
@@ -1742,7 +1742,7 @@ abstract class Database extends \lithium\data\Source {
 			}
 		}
 
-		return trim(String::insert($template, $data, array('clean' => array('method' => 'text'))));
+		return trim(Text::insert($template, $data, array('clean' => array('method' => 'text'))));
 	}
 
 	/**

--- a/data/source/Http.php
+++ b/data/source/Http.php
@@ -8,7 +8,7 @@
 
 namespace lithium\data\source;
 
-use lithium\util\String;
+use lithium\util\Text;
 use lithium\data\model\Query;
 
 /**
@@ -170,7 +170,7 @@ class Http extends \lithium\data\Source {
 			$data = array_diff_key($data,  array_flip($matches[1]));
 		}
 		return $this->connection->{$method}(
-			String::insert($path, $insert, array('clean' => true)),
+			Text::insert($path, $insert, array('clean' => true)),
 			$data + (array) $query->conditions() + array('limit' => $query->limit()),
 			(array) $options
 		);

--- a/g11n/Message.php
+++ b/g11n/Message.php
@@ -9,7 +9,7 @@
 namespace lithium\g11n;
 
 use lithium\core\Environment;
-use lithium\util\String;
+use lithium\util\Text;
 use lithium\g11n\Catalog;
 
 /**
@@ -65,7 +65,7 @@ class Message extends \lithium\core\StaticObject {
 	 * Message::translate('house', array('count' => 23));
 	 * ```
 	 *
-	 * `String::insert()`-style placeholders may be used within the message
+	 * `Text::insert()`-style placeholders may be used within the message
 	 * and replacements provided directly within the `options`  argument.
 	 *
 	 * Example:
@@ -76,7 +76,7 @@ class Message extends \lithium\core\StaticObject {
 	 * ));
 	 * ```
 	 *
-	 * @see lithium\util\String::insert()
+	 * @see lithium\util\Text::insert()
 	 * @param string $id The id to use when looking up the translation.
 	 * @param array $options Valid options are:
 	 *              - `'count'`: Used to determine the correct plural form. You can either pass
@@ -116,7 +116,7 @@ class Message extends \lithium\core\StaticObject {
 		}
 
 		if ($result = $result ?: $options['default']) {
-			return strpos($result, '{:') !== false ? String::insert($result, $options) : $result;
+			return strpos($result, '{:') !== false ? Text::insert($result, $options) : $result;
 		}
 	}
 

--- a/net/http/Media.php
+++ b/net/http/Media.php
@@ -9,7 +9,7 @@
 namespace lithium\net\http;
 
 use lithium\util\Set;
-use lithium\util\String;
+use lithium\util\Text;
 use lithium\core\Libraries;
 use lithium\core\Environment;
 use lithium\net\http\MediaException;
@@ -202,7 +202,7 @@ class Media extends \lithium\core\StaticObject {
 	 * @see lithium\action\Request::get()
 	 * @see lithium\action\Request::is()
 	 * @see lithium\action\Request::detect()
-	 * @see lithium\util\String::insert()
+	 * @see lithium\util\Text::insert()
 	 * @param string $type A file-extension-style type name, i.e. `'txt'`, `'js'`, or `'atom'`.
 	 *               Alternatively, a mapped content type, i.e. `'text/html'`,
 	 *               `'application/atom+xml'`, etc.; in which case, the matching type name (i.e.
@@ -224,8 +224,8 @@ class Media extends \lithium\core\StaticObject {
 	 *          specified encode function is first cast to array structures.
 	 *        - `'paths'` _array_: Optional key/value pairs mapping paths for
 	 *          `'template'`, `'layout'`, and `'element'` template files.  Any keys ommitted
-	 *          will use the default path.  The values should be `String::insert()`-style
-	 *          paths or an array of `String::insert()`-style paths.  If it is an array,
+	 *          will use the default path.  The values should be `Text::insert()`-style
+	 *          paths or an array of `Text::insert()`-style paths.  If it is an array,
 	 *          each path will be tried in the order specified until a template is found.
 	 *          This is useful for allowing custom templates while falling back on
 	 *          default templates if no custom template was found.  If you want to
@@ -366,7 +366,7 @@ class Media extends \lithium\core\StaticObject {
 	/**
 	 * Gets or sets options for various asset types.
 	 *
-	 * @see lithium\util\String::insert()
+	 * @see lithium\util\Text::insert()
 	 * @param string $type The name of the asset type, i.e. `'js'` or `'css'`.
 	 * @param array $options If registering a new asset type or modifying an existing asset type,
 	 *        contains settings for the asset type, where the available keys are as follows:
@@ -374,7 +374,7 @@ class Media extends \lithium\core\StaticObject {
 	 *          applicable.
 	 *        - `'filter'`: An array of key/value pairs representing simple string replacements to
 	 *          be done on a path once it is generated.
-	 *        - `'paths'`: An array of key/value pairs where the keys are `String::insert()`
+	 *        - `'paths'`: An array of key/value pairs where the keys are `Text::insert()`
 	 *          compatible paths, and the values are array lists of keys to be inserted into the
 	 *          path string.
 	 * @return array If `$type` is empty, an associative array of all registered types and all
@@ -421,7 +421,7 @@ class Media extends \lithium\core\StaticObject {
 	 *        - `'filter'`: An array of key/value pairs representing simple string replacements to
 	 *          be done on a path once it is generated.
 	 *        - `'paths'`: An array of paths to search for the asset in. The paths should use
-	 *          `String::insert()` formatting. See `Media::$_assets` for more.
+	 *          `Text::insert()` formatting. See `Media::$_assets` for more.
 	 *        - `suffix`: The suffix to attach to the path, generally a file extension.
 	 *        - `'timestamp'`: Appends the last modified time of the file to the path if `true`.
 	 *          Defaults to `false`.
@@ -548,7 +548,7 @@ class Media extends \lithium\core\StaticObject {
 		if ($isAbsolute && $options['base'] && strpos($asset, $options['base']) !== 0) {
 			$asset = "{$options['base']}{$asset}";
 		} elseif (!$isAbsolute) {
-			$asset = String::insert(key($path), array('path' => $asset) + $options);
+			$asset = Text::insert(key($path), array('path' => $asset) + $options);
 		}
 
 		if (is_array($options['filter']) && !empty($options['filter'])) {
@@ -642,7 +642,7 @@ class Media extends \lithium\core\StaticObject {
 		} else {
 			$template = str_replace('{:library}/', '', key($paths));
 			$insert = array('base' => $root) + compact('path');
-			$file = String::insert($template, $insert);
+			$file = Text::insert($template, $insert);
 		}
 		return realpath($file);
 	}

--- a/net/http/Request.php
+++ b/net/http/Request.php
@@ -8,7 +8,7 @@
 
 namespace lithium\net\http;
 
-use lithium\util\String;
+use lithium\util\Text;
 use UnexpectedValueException;
 
 /**
@@ -112,7 +112,7 @@ class Request extends \lithium\net\http\Message {
 				$options['port'] = $options['port'] ? ":{$options['port']}" : '';
 				$options['path'] = str_replace('//', '/', $options['path']);
 
-				return String::insert("{:scheme}://{:host}{:port}{:path}{:query}", $options);
+				return Text::insert("{:scheme}://{:host}{:port}{:path}{:query}", $options);
 			},
 			'context' => function($req, $options, $defaults) {
 				$req->headers($options['headers']);
@@ -243,14 +243,14 @@ class Request extends \lithium\net\http\Message {
 			$q = null;
 			foreach ($query as $key => $value) {
 				if (!is_array($value)) {
-					$q .= String::insert($format, array(
+					$q .= Text::insert($format, array(
 						'key' => urlencode($key),
 						'value' => urlencode($value)
 					));
 					continue;
 				}
 				foreach ($value as $val) {
-					$q .= String::insert($format, array(
+					$q .= Text::insert($format, array(
 						'key' => urlencode("{$key}[]"),
 						'value' => urlencode($val)
 					));

--- a/storage/session/adapter/Memory.php
+++ b/storage/session/adapter/Memory.php
@@ -8,7 +8,7 @@
 
 namespace lithium\storage\session\adapter;
 
-use lithium\util\String;
+use lithium\util\Text;
 use Closure;
 
 /**
@@ -31,7 +31,7 @@ class Memory extends \lithium\core\Object {
 	 * @return string UUID.
 	 */
 	public static function key() {
-		return String::uuid();
+		return Text::uuid();
 	}
 
 	/**

--- a/template/Helper.php
+++ b/template/Helper.php
@@ -8,7 +8,7 @@
 
 namespace lithium\template;
 
-use lithium\util\String;
+use lithium\util\Text;
 
 /**
  * Abstract class for template helpers to extend.
@@ -166,7 +166,7 @@ abstract class Helper extends \lithium\core\Object {
 			}
 			$strings = $this->_context->strings();
 		}
-		return String::insert(isset($strings[$string]) ? $strings[$string] : $string, $params);
+		return Text::insert(isset($strings[$string]) ? $strings[$string] : $string, $params);
 	}
 
 	/**

--- a/template/view/adapter/File.php
+++ b/template/view/adapter/File.php
@@ -8,7 +8,7 @@
 
 namespace lithium\template\view\adapter;
 
-use lithium\util\String;
+use lithium\util\Text;
 use lithium\core\Libraries;
 use lithium\template\TemplateException;
 
@@ -226,7 +226,7 @@ class File extends \lithium\template\view\Renderer implements \ArrayAccess {
 		}
 
 		foreach ((array) $this->_paths[$type] as $path) {
-			if (!file_exists($path = String::insert($path, $params))) {
+			if (!file_exists($path = Text::insert($path, $params))) {
 				continue;
 			}
 			return $path;

--- a/template/view/adapter/Simple.php
+++ b/template/view/adapter/Simple.php
@@ -11,7 +11,7 @@ namespace lithium\template\view\adapter;
 use Closure;
 use Exception;
 use lithium\util\Set;
-use lithium\util\String;
+use lithium\util\Text;
 
 /**
  * This view adapter renders content using simple string substitution, and is only useful for very
@@ -39,7 +39,7 @@ class Simple extends \lithium\template\view\Renderer {
 			$context[$key] = $this->__get($key);
 		}
 		$data = array_merge($this->_toString($context), $this->_toString($data));
-		return String::insert($template, $data, $options);
+		return Text::insert($template, $data, $options);
 	}
 
 	/**

--- a/test/Mocker.php
+++ b/test/Mocker.php
@@ -8,7 +8,7 @@
 
 namespace lithium\test;
 
-use lithium\util\String;
+use lithium\util\Text;
 use lithium\util\collection\Filters;
 use ReflectionClass;
 use ReflectionMethod;
@@ -610,7 +610,7 @@ class Mocker {
 		$tokens += $defaults;
 		$name = '_' . $type . 'Ingredients';
 		$code = implode("\n", self::${$name}[$key]);
-		return String::insert($code, $tokens) . "\n";
+		return Text::insert($code, $tokens) . "\n";
 	}
 
 	/**

--- a/test/Unit.php
+++ b/test/Unit.php
@@ -12,7 +12,7 @@ use Exception;
 use ErrorException;
 use ReflectionClass;
 use InvalidArgumentException;
-use lithium\util\String;
+use lithium\util\Text;
 use lithium\core\Libraries;
 use lithium\util\Validator;
 use lithium\analysis\Debugger;
@@ -216,7 +216,7 @@ class Unit extends \lithium\core\Object {
 	 * @param boolean $expression
 	 * @param string|boolean $message The message to output. If the message is not a string,
 	 *        then it will be converted to '{:message}'. Use '{:message}' in the string and it
-	 *        will use the `$data` to format the message with `String::insert()`.
+	 *        will use the `$data` to format the message with `Text::insert()`.
 	 * @param array $data
 	 * @return boolean `true` if the assertion succeeded, `false` otherwise.
 	 */
@@ -227,7 +227,7 @@ class Unit extends \lithium\core\Object {
 		if (strpos($message, "{:message}") !== false) {
 			$params = $data;
 			$params['message'] = $this->_message($params);
-			$message = String::insert($message, $params);
+			$message = Text::insert($message, $params);
 		}
 		$trace = Debugger::trace(array(
 			'start' => 1, 'depth' => 4, 'format' => 'array', 'closures' => !$expression

--- a/tests/cases/template/view/adapter/SimpleTest.php
+++ b/tests/cases/template/view/adapter/SimpleTest.php
@@ -9,7 +9,7 @@
 namespace lithium\tests\cases\template\view\adapter;
 
 use lithium\template\view\adapter\Simple;
-use lithium\tests\mocks\util\MockStringObject;
+use lithium\tests\mocks\util\MockTextObject;
 
 class SimpleTest extends \lithium\test\Unit {
 
@@ -24,7 +24,7 @@ class SimpleTest extends \lithium\test\Unit {
 		$expected = '{:content}';
 		$this->assertEqual($expected, $result);
 
-		$message = new MockStringObject();
+		$message = new MockTextObject();
 		$message->message = 'Lithium is about to rock you.';
 
 		$result = $this->subject->render('Hello {:name}! {:message}', compact('message') + array(

--- a/tests/cases/util/TextTest.php
+++ b/tests/cases/util/TextTest.php
@@ -8,17 +8,17 @@
 
 namespace lithium\tests\cases\util;
 
-use lithium\util\String;
-use lithium\tests\mocks\util\MockStringObject;
+use lithium\util\Text;
+use lithium\tests\mocks\util\MockTextObject;
 
-class StringTest extends \lithium\test\Unit {
+class TextTest extends \lithium\test\Unit {
 
 	public function testUuidGeneration() {
-		$result = String::uuid();
+		$result = Text::uuid();
 		$pattern = "/^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[8-9a-b][a-f0-9]{3}-[a-f0-9]{12}$/";
 		$this->assertPattern($pattern, $result);
 
-		$result = String::uuid();
+		$result = Text::uuid();
 		$this->assertPattern($pattern, $result);
 	}
 
@@ -28,7 +28,7 @@ class StringTest extends \lithium\test\Unit {
 		$pattern = "/^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[8-9a-b][a-f0-9]{3}-[a-f0-9]{12}$/";
 
 		for ($i = 0; $i < $count; $i++) {
-			$result = String::uuid();
+			$result = Text::uuid();
 			$match = preg_match($pattern, $result);
 			$this->assertNotEmpty($match);
 			$this->assertFalse(in_array($result, $check));
@@ -39,43 +39,43 @@ class StringTest extends \lithium\test\Unit {
 	public function testInsert() {
 		$string = '2 + 2 = {:sum}. Lithium is {:adjective}.';
 		$expected = '2 + 2 = 4. Lithium is yummy.';
-		$result = String::insert($string, array('sum' => '4', 'adjective' => 'yummy'));
+		$result = Text::insert($string, array('sum' => '4', 'adjective' => 'yummy'));
 		$this->assertEqual($expected, $result);
 
 		$string = '2 + 2 = %sum. Lithium is %adjective.';
-		$result = String::insert($string, array('sum' => '4', 'adjective' => 'yummy'), array(
+		$result = Text::insert($string, array('sum' => '4', 'adjective' => 'yummy'), array(
 			'before' => '%', 'after' => ''
 		));
 		$this->assertEqual($expected, $result);
 
 		$string = '2 + 2 = 2sum2. Lithium is 9adjective9.';
-		$result = String::insert($string, array('sum' => '4', 'adjective' => 'yummy'), array(
+		$result = Text::insert($string, array('sum' => '4', 'adjective' => 'yummy'), array(
 			'format' => '/([\d])%s\\1/'
 		));
 		$this->assertEqual($expected, $result);
 
 		$string = '2 + 2 = 12sum21. Lithium is 23adjective45.';
 		$expected = '2 + 2 = 4. Lithium is 23adjective45.';
-		$result = String::insert($string, array('sum' => '4', 'adjective' => 'yummy'), array(
+		$result = Text::insert($string, array('sum' => '4', 'adjective' => 'yummy'), array(
 			'format' => '/([\d])([\d])%s\\2\\1/'
 		));
 		$this->assertEqual($expected, $result);
 
 		$string = '{:web} {:web_site}';
 		$expected = 'www http';
-		$result = String::insert($string, array('web' => 'www', 'web_site' => 'http'));
+		$result = Text::insert($string, array('web' => 'www', 'web_site' => 'http'));
 		$this->assertEqual($expected, $result);
 
 		$string = '2 + 2 = <sum. Lithium is <adjective>.';
 		$expected = '2 + 2 = <sum. Lithium is yummy.';
-		$result = String::insert($string, array('sum' => '4', 'adjective' => 'yummy'), array(
+		$result = Text::insert($string, array('sum' => '4', 'adjective' => 'yummy'), array(
 			'before' => '<', 'after' => '>'
 		));
 		$this->assertEqual($expected, $result);
 
 		$string = '2 + 2 = \:sum. Lithium is :adjective.';
 		$expected = '2 + 2 = :sum. Lithium is yummy.';
-		$result = String::insert(
+		$result = Text::insert(
 			$string,
 			array('sum' => '4', 'adjective' => 'yummy'),
 			array('before' => ':', 'after' => null, 'escape' => '\\')
@@ -83,94 +83,94 @@ class StringTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 
 		$string = '2 + 2 = !:sum. Lithium is :adjective.';
-		$result = String::insert($string, array('sum' => '4', 'adjective' => 'yummy'), array(
+		$result = Text::insert($string, array('sum' => '4', 'adjective' => 'yummy'), array(
 			'escape' => '!', 'before' => ':', 'after' => ''
 		));
 		$this->assertEqual($expected, $result);
 
 		$string = '2 + 2 = \%sum. Lithium is %adjective.';
 		$expected = '2 + 2 = %sum. Lithium is yummy.';
-		$result = String::insert($string, array('sum' => '4', 'adjective' => 'yummy'), array(
+		$result = Text::insert($string, array('sum' => '4', 'adjective' => 'yummy'), array(
 			'before' => '%', 'after' => '', 'escape' => '\\'
 		));
 		$this->assertEqual($expected, $result);
 
 		$string = ':a :b \:a :a';
 		$expected = '1 2 :a 1';
-		$result = String::insert($string, array('a' => 1, 'b' => 2), array(
+		$result = Text::insert($string, array('a' => 1, 'b' => 2), array(
 			'before' => ':', 'after' => '', 'escape' => '\\'
 		));
 		$this->assertEqual($expected, $result);
 
 		$string = '{:a} {:b} {:c}';
 		$expected = '2 3';
-		$result = String::insert($string, array('b' => 2, 'c' => 3), array('clean' => true));
+		$result = Text::insert($string, array('b' => 2, 'c' => 3), array('clean' => true));
 		$this->assertEqual($expected, $result);
 
 		$string = '{:a} {:b} {:c}';
 		$expected = '1 3';
-		$result = String::insert($string, array('a' => 1, 'c' => 3), array('clean' => true));
+		$result = Text::insert($string, array('a' => 1, 'c' => 3), array('clean' => true));
 		$this->assertEqual($expected, $result);
 
 		$string = '{:a} {:b} {:c}';
 		$expected = '2 3';
-		$result = String::insert($string, array('b' => 2, 'c' => 3), array('clean' => true));
+		$result = Text::insert($string, array('b' => 2, 'c' => 3), array('clean' => true));
 		$this->assertEqual($expected, $result);
 
 		$string = ':a, :b and :c';
 		$expected = '2 and 3';
-		$result = String::insert($string, array('b' => 2, 'c' => 3), array(
+		$result = Text::insert($string, array('b' => 2, 'c' => 3), array(
 			'clean' => true, 'before' => ':', 'after' => ''
 		));
 		$this->assertEqual($expected, $result);
 
 		$string = '{:a}, {:b} and {:c}';
 		$expected = '2 and 3';
-		$result = String::insert($string, array('b' => 2, 'c' => 3), array('clean' => true));
+		$result = Text::insert($string, array('b' => 2, 'c' => 3), array('clean' => true));
 		$this->assertEqual($expected, $result);
 
 		$string = '"{:a}, {:b} and {:c}"';
 		$expected = '"1, 2"';
-		$result = String::insert($string, array('a' => 1, 'b' => 2), array('clean' => true));
+		$result = Text::insert($string, array('a' => 1, 'b' => 2), array('clean' => true));
 		$this->assertEqual($expected, $result);
 
 		$string = '"${a}, ${b} and ${c}"';
 		$expected = '"1, 2"';
-		$result = String::insert($string, array('a' => 1, 'b' => 2), array(
+		$result = Text::insert($string, array('a' => 1, 'b' => 2), array(
 			'before' => '${', 'after' => '}', 'clean' => true
 		));
 		$this->assertEqual($expected, $result);
 
 		$string = '<img src="{:src}" alt="{:alt}" class="foo {:extra} bar"/>';
 		$expected = '<img src="foo" class="foo bar"/>';
-		$result = String::insert($string, array('src' => 'foo'), array('clean' => 'html'));
+		$result = Text::insert($string, array('src' => 'foo'), array('clean' => 'html'));
 		$this->assertEqual($expected, $result);
 
 		$string = '<img src=":src" class=":no :extra"/>';
 		$expected = '<img src="foo"/>';
-		$result = String::insert($string, array('src' => 'foo'), array(
+		$result = Text::insert($string, array('src' => 'foo'), array(
 			'clean' => 'html', 'before' => ':', 'after' => ''
 		));
 		$this->assertEqual($expected, $result);
 
 		$string = '<img src="{:src}" class="{:no} {:extra}"/>';
 		$expected = '<img src="foo" class="bar"/>';
-		$result = String::insert($string, array('src' => 'foo', 'extra' => 'bar'), array(
+		$result = Text::insert($string, array('src' => 'foo', 'extra' => 'bar'), array(
 			'clean' => 'html'
 		));
 		$this->assertEqual($expected, $result);
 
-		$result = String::insert("this is a ? string", array("test"));
+		$result = Text::insert("this is a ? string", array("test"));
 		$expected = "this is a test string";
 		$this->assertEqual($expected, $result);
 
-		$result = String::insert("this is a ? string with a ? ? ?", array(
+		$result = Text::insert("this is a ? string with a ? ? ?", array(
 			'long', 'few?', 'params', 'you know'
 		));
 		$expected = "this is a long string with a few? params you know";
 		$this->assertEqual($expected, $result);
 
-		$result = String::insert(
+		$result = Text::insert(
 			'update saved_urls set url = :url where id = :id',
 			array('url' => 'http://testurl.com/param1:url/param2:id', 'id' => 1),
 			array('before' => ':', 'after' => '')
@@ -179,7 +179,7 @@ class StringTest extends \lithium\test\Unit {
 		$expected .= "where id = 1";
 		$this->assertEqual($expected, $result);
 
-		$result = String::insert(
+		$result = Text::insert(
 			'update saved_urls set url = :url where id = :id',
 			array('id' => 1, 'url' => 'http://www.testurl.com/param1:url/param2:id'),
 			array('before' => ':', 'after' => '')
@@ -188,13 +188,13 @@ class StringTest extends \lithium\test\Unit {
 		$expected .= "where id = 1";
 		$this->assertEqual($expected, $result);
 
-		$result = String::insert('{:me} lithium. {:subject} {:verb} fantastic.', array(
+		$result = Text::insert('{:me} lithium. {:subject} {:verb} fantastic.', array(
 			'me' => 'I :verb', 'subject' => 'lithium', 'verb' => 'is'
 		));
 		$expected = "I :verb lithium. lithium is fantastic.";
 		$this->assertEqual($expected, $result);
 
-		$result = String::insert(':I.am: :not.yet: passing.', array('I.am' => 'We are'), array(
+		$result = Text::insert(':I.am: :not.yet: passing.', array('I.am' => 'We are'), array(
 			'before' => ':', 'after' => ':', 'clean' => array(
 				'replacement' => ' of course', 'method' => 'text'
 			)
@@ -202,7 +202,7 @@ class StringTest extends \lithium\test\Unit {
 		$expected = "We are of course passing.";
 		$this->assertEqual($expected, $result);
 
-		$result = String::insert(
+		$result = Text::insert(
 			':I.am: :not.yet: passing.',
 			array('I.am' => 'We are'),
 			array('before' => ':', 'after' => ':', 'clean' => true)
@@ -210,17 +210,17 @@ class StringTest extends \lithium\test\Unit {
 		$expected = "We are passing.";
 		$this->assertEqual($expected, $result);
 
-		$result = String::insert('?-pended result', array('Pre'));
+		$result = Text::insert('?-pended result', array('Pre'));
 		$expected = "Pre-pended result";
 		$this->assertEqual($expected, $result);
 	}
 
 	/**
-	 * Tests that text replacements with `String::insert()` using key/value pairs are not
+	 * Tests that text replacements with `Text::insert()` using key/value pairs are not
 	 * mis-handled if numeric keys are present in the array (only if they appear first).
 	 */
 	public function testInsertWithUnusedNumericKey() {
-		$result = String::insert("Hey, what are you tryin' to {:action} on us?", array(
+		$result = Text::insert("Hey, what are you tryin' to {:action} on us?", array(
 			'action' => 'push', '!'
 		));
 		$expected = "Hey, what are you tryin' to push on us?";
@@ -228,11 +228,11 @@ class StringTest extends \lithium\test\Unit {
 	}
 
 	/**
-	 * Tests casting/inserting of custom objects with `String::insert()`.
+	 * Tests casting/inserting of custom objects with `Text::insert()`.
 	 */
 	public function testInsertWithObject() {
-		$foo = new MockStringObject();
-		$result = String::insert('This is a {:foo}', compact('foo'));
+		$foo = new MockTextObject();
+		$result = Text::insert('This is a {:foo}', compact('foo'));
 		$expected = 'This is a custom object';
 		$this->assertEqual($expected, $result);
 	}
@@ -241,7 +241,7 @@ class StringTest extends \lithium\test\Unit {
 	 * Test that an empty array is not added to the string
 	 */
 	public function testInsertWithEmptyArray() {
-		$result = String::insert("Hey, what are you tryin' to {:action} on us?",
+		$result = Text::insert("Hey, what are you tryin' to {:action} on us?",
 			array('action' => array())
 		);
 		$expected = "Hey, what are you tryin' to  on us?";
@@ -249,101 +249,101 @@ class StringTest extends \lithium\test\Unit {
 	}
 
 	public function testCleanInsert() {
-		$result = String::clean(':incomplete', array(
+		$result = Text::clean(':incomplete', array(
 			'clean' => true, 'before' => ':', 'after' => ''
 		));
 		$this->assertEqual('', $result);
 
-		$result = String::clean(':incomplete', array(
+		$result = Text::clean(':incomplete', array(
 			'clean' => array('method' => 'text', 'replacement' => 'complete'),
 			'before' => ':', 'after' => '')
 		);
 		$this->assertEqual('complete', $result);
 
-		$result = String::clean(':in.complete', array(
+		$result = Text::clean(':in.complete', array(
 			'clean' => true, 'before' => ':', 'after' => ''
 		));
 		$this->assertEqual('', $result);
 
-		$result = String::clean(':in.complete and', array(
+		$result = Text::clean(':in.complete and', array(
 			'clean' => true, 'before' => ':', 'after' => ''
 		));
 		$this->assertEqual('', $result);
 
-		$result = String::clean(':in.complete or stuff', array(
+		$result = Text::clean(':in.complete or stuff', array(
 			'clean' => true, 'before' => ':', 'after' => ''
 		));
 		$this->assertEqual('stuff', $result);
 
-		$result = String::clean(
+		$result = Text::clean(
 			'<p class=":missing" id=":missing">Text here</p>',
 			array('clean' => 'html', 'before' => ':', 'after' => '')
 		);
 		$this->assertEqual('<p>Text here</p>', $result);
 
 		$string = ':a 2 3';
-		$result = String::clean($string, array('clean' => true, 'before' => ':', 'after' => ''));
+		$result = Text::clean($string, array('clean' => true, 'before' => ':', 'after' => ''));
 		$this->assertEqual('2 3', $result);
 	}
 
 	public function testTokenize() {
-		$result = String::tokenize('A,(short,boring test)');
+		$result = Text::tokenize('A,(short,boring test)');
 		$expected = array('A', '(short,boring test)');
 		$this->assertEqual($expected, $result);
 
-		$result = String::tokenize('A,(short,more interesting( test)');
+		$result = Text::tokenize('A,(short,more interesting( test)');
 		$expected = array('A', '(short,more interesting( test)');
 		$this->assertEqual($expected, $result);
 
-		$result = String::tokenize('A,(short,very interesting( test))');
+		$result = Text::tokenize('A,(short,very interesting( test))');
 		$expected = array('A', '(short,very interesting( test))');
 		$this->assertEqual($expected, $result);
 
-		$result = String::tokenize('"single tag"', array(
+		$result = Text::tokenize('"single tag"', array(
 			'separator' => ' ', 'leftBound' => '"', 'rightBound' => '"'
 		));
 		$expected = array('"single tag"');
 		$this->assertEqual($expected, $result);
 
-		$result = String::tokenize('tagA "single tag" tagB', array(
+		$result = Text::tokenize('tagA "single tag" tagB', array(
 			'separator' => ' ', 'leftBound' => '"', 'rightBound' => '"'
 		));
 		$expected = array('tagA', '"single tag"', 'tagB');
 		$this->assertEqual($expected, $result);
 
-		$result = String::tokenize(array());
+		$result = Text::tokenize(array());
 		$expected = array();
 		$this->assertEqual($expected, $result);
 
-		$result = String::tokenize(null);
+		$result = Text::tokenize(null);
 		$this->assertNull($result);
 	}
 
 	/**
-	 * Tests the `String::extract()` regex helper method.
+	 * Tests the `Text::extract()` regex helper method.
 	 */
-	public function testStringExtraction() {
-		$result = String::extract('/string/', 'whole string');
+	public function testTextExtraction() {
+		$result = Text::extract('/string/', 'whole string');
 		$this->assertEqual('string', $result);
 
-		$this->assertFalse(String::extract('/not/', 'whole string'));
-		$this->assertEqual('part', String::extract('/\w+\s*(\w+)/', 'second part', 1));
-		$this->assertNull(String::extract('/\w+\s*(\w+)/', 'second part', 2));
+		$this->assertFalse(Text::extract('/not/', 'whole string'));
+		$this->assertEqual('part', Text::extract('/\w+\s*(\w+)/', 'second part', 1));
+		$this->assertNull(Text::extract('/\w+\s*(\w+)/', 'second part', 2));
 	}
 
-	public function testStringInsertWithQuestionMark() {
-		$result = String::insert('some string with a ?', array());
+	public function testTextInsertWithQuestionMark() {
+		$result = Text::insert('some string with a ?', array());
 		$this->assertEqual('some string with a ?', $result);
 
-		$result = String::insert('some {:param}string with a ?', array('param' => null));
+		$result = Text::insert('some {:param}string with a ?', array('param' => null));
 		$this->assertEqual('some string with a ?', $result);
 	}
 
 	/**
-	 * Verifies that `String::insert()` doesn't completely ignore empty values.
+	 * Verifies that `Text::insert()` doesn't completely ignore empty values.
 	 */
 	public function testInsertingEmptyValues() {
-		$this->assertEqual('value="0"', String::insert('value="{:value}"', array('value' => 0)));
+		$this->assertEqual('value="0"', Text::insert('value="{:value}"', array('value' => 0)));
 	}
 }
 

--- a/tests/integration/data/DatabaseTest.php
+++ b/tests/integration/data/DatabaseTest.php
@@ -13,7 +13,7 @@ use lithium\data\Connections;
 use lithium\data\model\Query;
 use lithium\tests\fixture\model\gallery\Images;
 use lithium\tests\fixture\model\gallery\Galleries;
-use lithium\util\String;
+use lithium\util\Text;
 use li3_fixtures\test\Fixtures;
 use lithium\data\Schema;
 
@@ -207,14 +207,14 @@ class DatabaseTest extends \lithium\tests\integration\data\Base {
 
 	public function testUpdate() {
 		$options = array('conditions' => array('id' => 1));
-		$uuid = String::uuid();
+		$uuid = Text::uuid();
 		$image = Images::find('first', $options);
 		$image->title = $uuid;
 		$firstID = $image->id;
 		$image->save();
 		$this->assertEqual($uuid, Images::find('first', $options)->title);
 
-		$uuid = String::uuid();
+		$uuid = Text::uuid();
 		Images::update(array('title' => $uuid), array('id' => $firstID));
 		$this->assertEqual($uuid, Images::find('first', $options)->title);
 		$this->images[0]['title'] = $uuid;

--- a/tests/mocks/console/MockResponse.php
+++ b/tests/mocks/console/MockResponse.php
@@ -8,7 +8,7 @@
 
 namespace lithium\tests\mocks\console;
 
-use lithium\util\String;
+use lithium\util\Text;
 
 class MockResponse extends \lithium\console\Response {
 
@@ -23,11 +23,11 @@ class MockResponse extends \lithium\console\Response {
 	}
 
 	public function output($output) {
-		return $this->output .= String::insert($output, $this->styles(false));
+		return $this->output .= Text::insert($output, $this->styles(false));
 	}
 
 	public function error($error) {
-		return $this->error .= String::insert($error, $this->styles(false));
+		return $this->error .= Text::insert($error, $this->styles(false));
 	}
 
 	public function __destruct() {

--- a/tests/mocks/template/view/adapters/TestRenderer.php
+++ b/tests/mocks/template/view/adapters/TestRenderer.php
@@ -2,7 +2,7 @@
 
 namespace lithium\tests\mocks\template\view\adapters;
 
-use lithium\util\String;
+use lithium\util\Text;
 
 class TestRenderer extends \lithium\template\view\adapter\File implements \ArrayAccess {
 	public static $templateData = array();
@@ -10,7 +10,7 @@ class TestRenderer extends \lithium\template\view\adapter\File implements \Array
 
 	public function template($type, array $params) {
 		foreach ((array) $this->_paths[$type] as $path) {
-			if (!file_exists($path = String::insert($path, $params))) {
+			if (!file_exists($path = Text::insert($path, $params))) {
 				continue;
 			}
 			self::$templateData[] = compact('type', 'params') + array(

--- a/tests/mocks/util/MockTextObject.php
+++ b/tests/mocks/util/MockTextObject.php
@@ -8,7 +8,7 @@
 
 namespace lithium\tests\mocks\util;
 
-class MockStringObject extends \lithium\template\view\Renderer {
+class MockTextObject extends \lithium\template\view\Renderer {
 
 	public $message = 'custom object';
 

--- a/util/String.php
+++ b/util/String.php
@@ -8,13 +8,28 @@
 
 namespace lithium\util;
 
+use lithium\util\Text;
+use lithium\security\Hash;
 use lithium\security\Random;
 
+$message  = "lithium\util\String has been deprecated in favor of ";
+$message .= "lithium\util\Text and lithium\security\{Hash,Random}. ";
+$message .= "The old class and methods continue to work and redirect calls ";
+$message .= "to the new classes. However it is not possible to use the String ";
+$message .= "class with PHP >=7.0.";
+trigger_error($message, E_USER_DEPRECATED);
+
 /**
- * String manipulation utility class. Includes functionality for generating UUIDs,
- * {:tag} and regex replacement, and tokenization.
+ * String manipulation utility class.
+ *
+ * @deprecated
  */
 class String {
+
+	/**
+	 * Option flag used in `String::random()`.
+	 */
+	const ENCODE_BASE_64 = 1;
 
 	/**
 	 * UUID-related constant. Clears all bits of version byte (`00001111`).
@@ -37,119 +52,81 @@ class String {
 	const UUID_VAR_RFC = 128;
 
 	/**
+	 * Generates random bytes for use in UUIDs and password salts, using
+	 * (when available) a cryptographically strong random number generator.
+	 *
+	 * @param integer $bytes The number of random bytes to generate.
+	 * @param array $options
+	 * @return string Returns a string of random bytes.
+	 */
+	public static function random($bytes, array $options = array()) {
+		$message  = "lithium\util\String::random() has been deprecated in favor of ";
+		$message .= "lithium\security\Random::generate().";
+		trigger_error($message, E_USER_DEPRECATED);
+
+		return Random::generate($bytes, $options);
+	}
+
+	/**
+	 * Uses PHP's hashing functions to create a hash of the string provided.
+	 *
+	 * @param string $string The string to hash.
+	 * @param array $options
+	 * @return string Returns a hashed string.
+	 */
+	public static function hash($string, array $options = array()) {
+		$message  = "lithium\util\String::hash() has been deprecated in favor of ";
+		$message .= "lithium\security\Hash::calculate().";
+		trigger_error($message, E_USER_DEPRECATED);
+
+		return Hash::calculate($string, $options);
+	}
+
+	/**
+	 * Compares two strings in constant time to prevent timing attacks.
+	 *
+	 * @param string $known The string of known length to compare against.
+	 * @param string $user The user-supplied string.
+	 * @return boolean Returns a boolean indicating whether the two strings are equal.
+	 */
+	public static function compare($known, $user) {
+		$message  = "lithium\util\String::compare() has been deprecated in favor of ";
+		$message .= "lithium\security\Hash::compare().";
+		trigger_error($message, E_USER_DEPRECATED);
+
+		return Hash::compare($known, $user);
+	}
+
+	/**
 	 * Generates an RFC 4122-compliant version 4 UUID.
 	 *
 	 * @return string The string representation of an RFC 4122-compliant, version 4 UUID.
 	 * @link http://www.ietf.org/rfc/rfc4122.txt RFC 4122: UUID URN Namespace
 	 */
 	public static function uuid() {
-		$uuid = Random::generate(16);
-		$uuid[6] = chr(ord($uuid[6]) & static::UUID_CLEAR_VER | static::UUID_VERSION_4);
-		$uuid[8] = chr(ord($uuid[8]) & static::UUID_CLEAR_VAR | static::UUID_VAR_RFC);
+		$message  = "lithium\util\String::uuid() has been deprecated in favor of ";
+		$message .= "lithium\util\Text::uuid().";
+		trigger_error($message, E_USER_DEPRECATED);
 
-		return join('-', array(
-			bin2hex(substr($uuid, 0, 4)),
-			bin2hex(substr($uuid, 4, 2)),
-			bin2hex(substr($uuid, 6, 2)),
-			bin2hex(substr($uuid, 8, 2)),
-			bin2hex(substr($uuid, 10, 6))
-		));
+		return Text::uuid();
 	}
 
 	/**
 	 * Replaces variable placeholders inside a string with any given data. Each key
 	 * in the `$data` array corresponds to a variable placeholder name in `$str`.
 	 *
-	 * Usage:
-	 * ```
-	 * String::insert(
-	 *     'My name is {:name} and I am {:age} years old.',
-	 *     array('name' => 'Bob', 'age' => '65')
-	 * ); // returns 'My name is Bob and I am 65 years old.'
-	 * ```
-	 *
-	 * Please note that optimization have applied to this method and parts of the code
-	 * may look like it can refactored or removed but in fact this is part of the applied
-	 * optimization. Please check the history for this section of code before refactoring
-	 *
 	 * @param string $str A string containing variable place-holders.
 	 * @param array $data A key, value array where each key stands for a place-holder variable
 	 *                     name to be replaced with value.
-	 * @param array $options Available options are:
-	 *        - `'after'`: The character or string after the name of the variable place-holder
-	 *          (defaults to `}`).
-	 *        - `'before'`: The character or string in front of the name of the variable
-	 *          place-holder (defaults to `'{:'`).
-	 *        - `'clean'`: A boolean or array with instructions for `String::clean()`.
-	 *        - `'escape'`: The character or string used to escape the before character or string
-	 *          (defaults to `'\'`).
-	 *        - `'format'`: A regular expression to use for matching variable place-holders
-	 *          (defaults to `'/(?<!\\)\:%s/'`. Please note that this option takes precedence over
-	 *          all other options except `'clean'`.
+	 * @param array $options
 	 * @return string
 	 */
 	public static function insert($str, array $data, array $options = array()) {
-		$defaults = array(
-			'before' => '{:',
-			'after' => '}',
-			'escape' => null,
-			'format' => null,
-			'clean' => false
-		);
-		$options += $defaults;
-		$format = $options['format'];
+		$message  = "lithium\util\String::insert() has been deprecated in favor of ";
+		$message .= "lithium\util\Text::insert().";
+		trigger_error($message, E_USER_DEPRECATED);
 
-		if ($format === 'regex' || (!$format && $options['escape'])) {
-			$format = sprintf(
-				'/(?<!%s)%s%%s%s/',
-				preg_quote($options['escape'], '/'),
-				str_replace('%', '%%', preg_quote($options['before'], '/')),
-				str_replace('%', '%%', preg_quote($options['after'], '/'))
-			);
-		}
-
-		if (!$format && key($data) !== 0) {
-			$replace = array();
-
-			foreach ($data as $key => $value) {
-				if (!is_scalar($value)) {
-					if (is_object($value) && method_exists($value, '__toString')) {
-						$value = (string) $value;
-					} else {
-						$value = '';
-					}
-				}
-				$replace["{$options['before']}{$key}{$options['after']}"] = $value;
-			}
-			$str = strtr($str, $replace);
-			return $options['clean'] ? static::clean($str, $options) : $str;
-		}
-
-		if (strpos($str, '?') !== false && isset($data[0])) {
-			$offset = 0;
-
-			while (($pos = strpos($str, '?', $offset)) !== false) {
-				$val = array_shift($data);
-				$offset = $pos + strlen($val);
-				$str = substr_replace($str, $val, $pos, 1);
-			}
-			return $options['clean'] ? static::clean($str, $options) : $str;
-		}
-
-		foreach ($data as $key => $value) {
-			if (!$key = sprintf($format, preg_quote($key, '/'))) {
-				continue;
-			}
-			$hash = crc32($key);
-
-			$str = preg_replace($key, $hash, $str);
-			$str = str_replace($hash, $value, $str);
-		}
-
-		if (!isset($options['format']) && isset($options['before'])) {
-			$str = str_replace($options['escape'] . $options['before'], $options['before'], $str);
-		}
-		return $options['clean'] ? static::clean($str, $options) : $str;
+		return Text::insert($str, $data, $options);
 	}
 
 	/**
@@ -158,66 +135,15 @@ class String {
 	 * and unneeded mark-up around place-holders that did not get replaced by `String::insert()`.
 	 *
 	 * @param string $str The string to clean.
-	 * @param array $options Available options are:
-	 *        - `'after'`: characters marking the end of targeted substring.
-	 *        - `'andText'`: (defaults to `true`).
-	 *        - `'before'`: characters marking the start of targeted substring.
-	 *        - `'clean'`: `true` or an array of clean options:
-	 *          - `'gap'`: Regular expression matching gaps.
-	 *          - `'method'`: Either `'text'` or `'html'` (defaults to `'text'`).
-	 *          - `'replacement'`: String to use for cleaned substrings (defaults to `''`).
-	 *          - `'word'`: Regular expression matching words.
+	 * @param array $options
 	 * @return string The cleaned string.
 	 */
 	public static function clean($str, array $options = array()) {
-		if (is_array($options['clean'])) {
-			$clean = $options['clean'];
-		} else {
-			$clean = array(
-				'method' => is_bool($options['clean']) ? 'text' : $options['clean']
-			);
-		}
+		$message  = "lithium\util\String::clean() has been deprecated in favor of ";
+		$message .= "lithium\util\Text::clean().";
+		trigger_error($message, E_USER_DEPRECATED);
 
-		switch ($clean['method']) {
-			case 'text':
-				$clean += array(
-					'word' => '[\w,.]+',
-					'gap' => '[\s]*(?:(?:and|or|,)[\s]*)?',
-					'replacement' => ''
-				);
-				$before = preg_quote($options['before'], '/');
-				$after = preg_quote($options['after'], '/');
-
-				$kleenex = sprintf(
-					'/(%s%s%s%s|%s%s%s%s|%s%s%s%s%s)/',
-					$before, $clean['word'], $after, $clean['gap'],
-					$clean['gap'], $before, $clean['word'], $after,
-					$clean['gap'], $before, $clean['word'], $after, $clean['gap']
-				);
-				$str = preg_replace($kleenex, $clean['replacement'], $str);
-			break;
-			case 'html':
-				$clean += array(
-					'word' => '[\w,.]+',
-					'andText' => true,
-					'replacement' => ''
-				);
-				$kleenex = sprintf(
-					'/[\s]*[a-z]+=(")(%s%s%s[\s]*)+\\1/i',
-					preg_quote($options['before'], '/'),
-					$clean['word'],
-					preg_quote($options['after'], '/')
-				);
-				$str = preg_replace($kleenex, $clean['replacement'], $str);
-
-				if ($clean['andText']) {
-					return static::clean($str, array(
-						'clean' => array('method' => 'text')
-					) + $options);
-				}
-			break;
-		}
-		return $str;
+		return Text::clean($str, $options);
 	}
 
 	/**
@@ -229,10 +155,11 @@ class String {
 	 * @return mixed
 	 */
 	public static function extract($regex, $str, $index = 0) {
-		if (!preg_match($regex, $str, $match)) {
-			return false;
-		}
-		return isset($match[$index]) ? $match[$index] : null;
+		$message  = "lithium\util\String::extract() has been deprecated in favor of ";
+		$message .= "lithium\util\Text::extract().";
+		trigger_error($message, E_USER_DEPRECATED);
+
+		return Text::extract($regex, $str, $index);
 	}
 
 	/**
@@ -241,145 +168,15 @@ class String {
 	 * `$options['rightBound']`.
 	 *
 	 * @param string $data The data to tokenize.
-	 * @param array $options Options to use when tokenizing:
-	 *              -`'separator'` _string_: The token to split the data on.
-	 *              -`'leftBound'` _string_: Left scope-enclosing boundary.
-	 *              -`'rightBound'` _string_: Right scope-enclosing boundary.
+	 * @param array $options
 	 * @return array Returns an array of tokens.
 	 */
 	public static function tokenize($data, array $options = array()) {
-		$options += array('separator' => ',', 'leftBound' => '(', 'rightBound' => ')');
-
-		if (!$data || is_array($data)) {
-			return $data;
-		}
-
-		$depth = 0;
-		$offset = 0;
-		$buffer = '';
-		$results = array();
-		$length = strlen($data);
-		$open = false;
-
-		while ($offset <= $length) {
-			$tmpOffset = -1;
-			$offsets = array(
-				strpos($data, $options['separator'], $offset),
-				strpos($data, $options['leftBound'], $offset),
-				strpos($data, $options['rightBound'], $offset)
-			);
-
-			for ($i = 0; $i < 3; $i++) {
-				if ($offsets[$i] !== false && ($offsets[$i] < $tmpOffset || $tmpOffset === -1)) {
-					$tmpOffset = $offsets[$i];
-				}
-			}
-
-			if ($tmpOffset === -1) {
-				$results[] = $buffer . substr($data, $offset);
-				$offset = $length + 1;
-				continue;
-			}
-			$buffer .= substr($data, $offset, ($tmpOffset - $offset));
-
-			if ($data[$tmpOffset] === $options['separator'] && $depth === 0) {
-				$results[] = $buffer;
-				$buffer = '';
-			} else {
-				$buffer .= $data{$tmpOffset};
-			}
-
-			if ($options['leftBound'] !== $options['rightBound']) {
-				if ($data[$tmpOffset] === $options['leftBound']) {
-					$depth++;
-				}
-				if ($data[$tmpOffset] === $options['rightBound']) {
-					$depth--;
-				}
-				$offset = ++$tmpOffset;
-				continue;
-			}
-
-			if ($data[$tmpOffset] === $options['leftBound']) {
-				($open) ? $depth-- : $depth++;
-				$open = !$open;
-			}
-			$offset = ++$tmpOffset;
-		}
-
-		if (!$results && $buffer) {
-			$results[] = $buffer;
-		}
-		return $results ? array_map('trim', $results) : array();
-	}
-
-	/* Deprecated / BC */
-
-	/**
-	 * Option flag used in `String::random()`.
-	 *
-	 * @deprecated
-	 */
-	const ENCODE_BASE_64 = 1;
-
-	/**
-	 * Generates random bytes for use in UUIDs and password salts, using
-	 * (when available) a cryptographically strong random number generator.
-	 *
-	 * @deprecated
-	 * @param integer $bytes The number of random bytes to generate.
-	 * @param array $options The options used when generating random bytes:
-	 *              - `'encode'` _integer_: If specified, and set to `String::ENCODE_BASE_64`, the
-	 *                resulting value will be base64-encoded, per the notes above.
-	 * @return string Returns a string of random bytes.
-	 */
-	public static function random($bytes, array $options = array()) {
-		$message  = "lithium\util\String::random() has been deprecated in favor of ";
-		$message .= "lithium\security\Random::generate().";
+		$message  = "lithium\util\String::tokenize() has been deprecated in favor of ";
+		$message .= "lithium\util\Text::tokenize().";
 		trigger_error($message, E_USER_DEPRECATED);
 
-		return \lithium\security\Random::generate($bytes, $options);
-	}
-
-	/**
-	 * Uses PHP's hashing functions to create a hash of the string provided, using the options
-	 * specified. The default hash algorithm is SHA-512.
-	 *
-	 * @deprecated
-	 * @param string $string The string to hash.
-	 * @param array $options Supported options:
-	 *        - `'type'` _string_: Any valid hashing algorithm. See the `hash_algos()` function to
-	 *          determine which are available on your system.
-	 *        - `'salt'` _string_: A _salt_ value which, if specified, will be prepended to the
-	 *          string.
-	 *        - `'key'` _string_: If specified `hash_hmac()` will be used to hash the string,
-	 *          instead of `hash()`, with `'key'` being used as the message key.
-	 *        - `'raw'` _boolean_: If `true`, outputs the raw binary result of the hash operation.
-	 *          Defaults to `false`.
-	 * @return string Returns a hashed string.
-	 */
-	public static function hash($string, array $options = array()) {
-		$message  = "lithium\util\String::hash() has been deprecated in favor of ";
-		$message .= "lithium\security\Hash::calculate().";
-		trigger_error($message, E_USER_DEPRECATED);
-
-		return \lithium\security\Hash::calculate($string, $options);
-	}
-
-	/**
-	 * Compares two strings in constant time to prevent timing attacks.
-	 *
-	 * @deprecated
-	 * @param string $known The string of known length to compare against.
-	 * @param string $user The user-supplied string.
-	 * @return boolean Returns a boolean indicating whether the two strings are equal.
-	 */
-	public static function compare($known, $user) {
-		$message  = "lithium\util\String::compare() has been deprecated in favor of ";
-		$message .= "lithium\security\Hash::compare().";
-		trigger_error($message, E_USER_DEPRECATED);
-
-		return \lithium\security\Hash::compare($known, $user);
+		return Text::tokenize($data, $options);
 	}
 }
 

--- a/util/Text.php
+++ b/util/Text.php
@@ -1,0 +1,317 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2015, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/mit-license.php The MIT License
+ */
+
+namespace lithium\util;
+
+use lithium\security\Random;
+
+/**
+ * Text manipulation utility class. Includes functionality for generating UUIDs,
+ * {:tag} and regex replacement, and tokenization.
+ */
+class Text {
+
+	/**
+	 * UUID-related constant. Clears all bits of version byte (`00001111`).
+	 */
+	const UUID_CLEAR_VER = 15;
+
+	/**
+	 * UUID constant that sets the version bit for generated UUIDs (`01000000`).
+	 */
+	const UUID_VERSION_4 = 64;
+
+	/**
+	 * Clears relevant bits of variant byte (`00111111`).
+	 */
+	const UUID_CLEAR_VAR = 63;
+
+	/**
+	 * The RFC 4122 variant (`10000000`).
+	 */
+	const UUID_VAR_RFC = 128;
+
+	/**
+	 * Generates an RFC 4122-compliant version 4 UUID.
+	 *
+	 * @return string The string representation of an RFC 4122-compliant, version 4 UUID.
+	 * @link http://www.ietf.org/rfc/rfc4122.txt RFC 4122: UUID URN Namespace
+	 */
+	public static function uuid() {
+		$uuid = Random::generate(16);
+		$uuid[6] = chr(ord($uuid[6]) & static::UUID_CLEAR_VER | static::UUID_VERSION_4);
+		$uuid[8] = chr(ord($uuid[8]) & static::UUID_CLEAR_VAR | static::UUID_VAR_RFC);
+
+		return join('-', array(
+			bin2hex(substr($uuid, 0, 4)),
+			bin2hex(substr($uuid, 4, 2)),
+			bin2hex(substr($uuid, 6, 2)),
+			bin2hex(substr($uuid, 8, 2)),
+			bin2hex(substr($uuid, 10, 6))
+		));
+	}
+
+	/**
+	 * Replaces variable placeholders inside a string with any given data. Each key
+	 * in the `$data` array corresponds to a variable placeholder name in `$str`.
+	 *
+	 * Usage:
+	 * ```
+	 * Text::insert(
+	 *     'My name is {:name} and I am {:age} years old.',
+	 *     array('name' => 'Bob', 'age' => '65')
+	 * ); // returns 'My name is Bob and I am 65 years old.'
+	 * ```
+	 *
+	 * Please note that optimization have applied to this method and parts of the code
+	 * may look like it can refactored or removed but in fact this is part of the applied
+	 * optimization. Please check the history for this section of code before refactoring
+	 *
+	 * @param string $str A string containing variable place-holders.
+	 * @param array $data A key, value array where each key stands for a place-holder variable
+	 *                     name to be replaced with value.
+	 * @param array $options Available options are:
+	 *        - `'after'`: The character or string after the name of the variable place-holder
+	 *          (defaults to `}`).
+	 *        - `'before'`: The character or string in front of the name of the variable
+	 *          place-holder (defaults to `'{:'`).
+	 *        - `'clean'`: A boolean or array with instructions for `Text::clean()`.
+	 *        - `'escape'`: The character or string used to escape the before character or string
+	 *          (defaults to `'\'`).
+	 *        - `'format'`: A regular expression to use for matching variable place-holders
+	 *          (defaults to `'/(?<!\\)\:%s/'`. Please note that this option takes precedence over
+	 *          all other options except `'clean'`.
+	 * @return string
+	 */
+	public static function insert($str, array $data, array $options = array()) {
+		$defaults = array(
+			'before' => '{:',
+			'after' => '}',
+			'escape' => null,
+			'format' => null,
+			'clean' => false
+		);
+		$options += $defaults;
+		$format = $options['format'];
+
+		if ($format === 'regex' || (!$format && $options['escape'])) {
+			$format = sprintf(
+				'/(?<!%s)%s%%s%s/',
+				preg_quote($options['escape'], '/'),
+				str_replace('%', '%%', preg_quote($options['before'], '/')),
+				str_replace('%', '%%', preg_quote($options['after'], '/'))
+			);
+		}
+
+		if (!$format && key($data) !== 0) {
+			$replace = array();
+
+			foreach ($data as $key => $value) {
+				if (!is_scalar($value)) {
+					if (is_object($value) && method_exists($value, '__toString')) {
+						$value = (string) $value;
+					} else {
+						$value = '';
+					}
+				}
+				$replace["{$options['before']}{$key}{$options['after']}"] = $value;
+			}
+			$str = strtr($str, $replace);
+			return $options['clean'] ? static::clean($str, $options) : $str;
+		}
+
+		if (strpos($str, '?') !== false && isset($data[0])) {
+			$offset = 0;
+
+			while (($pos = strpos($str, '?', $offset)) !== false) {
+				$val = array_shift($data);
+				$offset = $pos + strlen($val);
+				$str = substr_replace($str, $val, $pos, 1);
+			}
+			return $options['clean'] ? static::clean($str, $options) : $str;
+		}
+
+		foreach ($data as $key => $value) {
+			if (!$key = sprintf($format, preg_quote($key, '/'))) {
+				continue;
+			}
+			$hash = crc32($key);
+
+			$str = preg_replace($key, $hash, $str);
+			$str = str_replace($hash, $value, $str);
+		}
+
+		if (!isset($options['format']) && isset($options['before'])) {
+			$str = str_replace($options['escape'] . $options['before'], $options['before'], $str);
+		}
+		return $options['clean'] ? static::clean($str, $options) : $str;
+	}
+
+	/**
+	 * Cleans up a `Text::insert()` formatted string with given `$options` depending
+	 * on the `'clean'` option. The goal of this function is to replace all whitespace
+	 * and unneeded mark-up around place-holders that did not get replaced by `Text::insert()`.
+	 *
+	 * @param string $str The string to clean.
+	 * @param array $options Available options are:
+	 *        - `'after'`: characters marking the end of targeted substring.
+	 *        - `'andText'`: (defaults to `true`).
+	 *        - `'before'`: characters marking the start of targeted substring.
+	 *        - `'clean'`: `true` or an array of clean options:
+	 *          - `'gap'`: Regular expression matching gaps.
+	 *          - `'method'`: Either `'text'` or `'html'` (defaults to `'text'`).
+	 *          - `'replacement'`: Text to use for cleaned substrings (defaults to `''`).
+	 *          - `'word'`: Regular expression matching words.
+	 * @return string The cleaned string.
+	 */
+	public static function clean($str, array $options = array()) {
+		if (is_array($options['clean'])) {
+			$clean = $options['clean'];
+		} else {
+			$clean = array(
+				'method' => is_bool($options['clean']) ? 'text' : $options['clean']
+			);
+		}
+
+		switch ($clean['method']) {
+			case 'text':
+				$clean += array(
+					'word' => '[\w,.]+',
+					'gap' => '[\s]*(?:(?:and|or|,)[\s]*)?',
+					'replacement' => ''
+				);
+				$before = preg_quote($options['before'], '/');
+				$after = preg_quote($options['after'], '/');
+
+				$kleenex = sprintf(
+					'/(%s%s%s%s|%s%s%s%s|%s%s%s%s%s)/',
+					$before, $clean['word'], $after, $clean['gap'],
+					$clean['gap'], $before, $clean['word'], $after,
+					$clean['gap'], $before, $clean['word'], $after, $clean['gap']
+				);
+				$str = preg_replace($kleenex, $clean['replacement'], $str);
+			break;
+			case 'html':
+				$clean += array(
+					'word' => '[\w,.]+',
+					'andText' => true,
+					'replacement' => ''
+				);
+				$kleenex = sprintf(
+					'/[\s]*[a-z]+=(")(%s%s%s[\s]*)+\\1/i',
+					preg_quote($options['before'], '/'),
+					$clean['word'],
+					preg_quote($options['after'], '/')
+				);
+				$str = preg_replace($kleenex, $clean['replacement'], $str);
+
+				if ($clean['andText']) {
+					return static::clean($str, array(
+						'clean' => array('method' => 'text')
+					) + $options);
+				}
+			break;
+		}
+		return $str;
+	}
+
+	/**
+	 * Extract a part of a string based on a regular expression `$regex`.
+	 *
+	 * @param string $regex The regular expression to use.
+	 * @param string $str The string to run the extraction on.
+	 * @param integer $index The number of the part to return based on the regex.
+	 * @return mixed
+	 */
+	public static function extract($regex, $str, $index = 0) {
+		if (!preg_match($regex, $str, $match)) {
+			return false;
+		}
+		return isset($match[$index]) ? $match[$index] : null;
+	}
+
+	/**
+	 * Tokenizes a string using `$options['separator']`, ignoring any instances of
+	 * `$options['separator']` that appear between `$options['leftBound']` and
+	 * `$options['rightBound']`.
+	 *
+	 * @param string $data The data to tokenize.
+	 * @param array $options Options to use when tokenizing:
+	 *              -`'separator'` _string_: The token to split the data on.
+	 *              -`'leftBound'` _string_: Left scope-enclosing boundary.
+	 *              -`'rightBound'` _string_: Right scope-enclosing boundary.
+	 * @return array Returns an array of tokens.
+	 */
+	public static function tokenize($data, array $options = array()) {
+		$options += array('separator' => ',', 'leftBound' => '(', 'rightBound' => ')');
+
+		if (!$data || is_array($data)) {
+			return $data;
+		}
+
+		$depth = 0;
+		$offset = 0;
+		$buffer = '';
+		$results = array();
+		$length = strlen($data);
+		$open = false;
+
+		while ($offset <= $length) {
+			$tmpOffset = -1;
+			$offsets = array(
+				strpos($data, $options['separator'], $offset),
+				strpos($data, $options['leftBound'], $offset),
+				strpos($data, $options['rightBound'], $offset)
+			);
+
+			for ($i = 0; $i < 3; $i++) {
+				if ($offsets[$i] !== false && ($offsets[$i] < $tmpOffset || $tmpOffset === -1)) {
+					$tmpOffset = $offsets[$i];
+				}
+			}
+
+			if ($tmpOffset === -1) {
+				$results[] = $buffer . substr($data, $offset);
+				$offset = $length + 1;
+				continue;
+			}
+			$buffer .= substr($data, $offset, ($tmpOffset - $offset));
+
+			if ($data[$tmpOffset] === $options['separator'] && $depth === 0) {
+				$results[] = $buffer;
+				$buffer = '';
+			} else {
+				$buffer .= $data{$tmpOffset};
+			}
+
+			if ($options['leftBound'] !== $options['rightBound']) {
+				if ($data[$tmpOffset] === $options['leftBound']) {
+					$depth++;
+				}
+				if ($data[$tmpOffset] === $options['rightBound']) {
+					$depth--;
+				}
+				$offset = ++$tmpOffset;
+				continue;
+			}
+
+			if ($data[$tmpOffset] === $options['leftBound']) {
+				($open) ? $depth-- : $depth++;
+				$open = !$open;
+			}
+			$offset = ++$tmpOffset;
+		}
+
+		if (!$results && $buffer) {
+			$results[] = $buffer;
+		}
+		return $results ? array_map('trim', $results) : array();
+	}
+}
+
+?>


### PR DESCRIPTION
String will become a reserved name in PHP 7.0/7.1
https://wiki.php.net/rfc/reserve_even_more_types_in_php_7

This uses a placeholder class instead of class_alias, so we can trigger deprecation notices when the old class is used.