### PR TITLE
Fixed incorrect spelling of lithium

### DIFF
--- a/net/http/Router.php
+++ b/net/http/Router.php
@@ -204,7 +204,7 @@ class Router extends \lithium\core\StaticObject {
 	 * to a `PostsController::indexAction()` method.
 	 *
 	 * ```
-	 * use litthium\util\Inflector;
+	 * use lithium\util\Inflector;
 	 *
 	 * Router::modifiers(array(
 	 *     'controller' => function($value) {


### PR DESCRIPTION
Changed "litthium" to "lithium" in the docblock of Router::modifiers