### PR TITLE
Improve (error) exception titles in tests.

### DIFF
--- a/test/templates/errors.txt.php
+++ b/test/templates/errors.txt.php
@@ -15,7 +15,11 @@ foreach ((array) $stats['errors'] as $error) {
 		echo " ________\n";
 		echo "\n";
 	} elseif ($error['result'] == 'exception') {
-		echo "{:purple}Exception{:end} thrown.\n";
+		if ($error['code'] !== 0) {
+			echo "{:purple}{$error['name']} ({$error['code']}){:end} thrown.\n";
+		} else {
+			echo "{:purple}{$error['name']}{:end} thrown.\n";
+		}
 		echo " File    : {$error['file']}\n";
 		echo " Class   : {$error['class']}\n";
 		echo " Method  : {$error['method']}()\n";

--- a/test/templates/exception.html.php
+++ b/test/templates/exception.html.php
@@ -1,5 +1,10 @@
 <div class="test-exception">
-	<strong>Exception</strong> thrown in <strong><?php echo "{$error['class']}::{$error['method']}()"; ?></strong>
+	<strong><?php echo $error['name'] ?></strong>
+	<?php if ($error['code'] !== 0): ?>
+		(<?php echo $error['code'] ?>)
+	<?php endif ?>
+	thrown
+	in <strong><?php echo "{$error['class']}::{$error['method']}()"; ?></strong>
 	on line <?php echo $error['line'] ?>
 	<span class="content"><?php echo $error['message'] ?></span>
 	<?php if (isset($error['trace']) && !empty($error['trace'])): ?>


### PR DESCRIPTION
This PR enables display of exception names (InvalidErrorException instead of just Exception) as well as display of severity (the name of the error level) when the exception is an ErrorException.

![bildschirmfoto 2015-06-14 um 13 47 25](https://cloud.githubusercontent.com/assets/29702/8148397/36b49f6c-129c-11e5-83fe-de6b1f6bec78.png)

