### PR TITLE
Enable hashing of arbitrary data in Hash::calculate().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Improved
 
 - Improved database encoding, timezone and searchPath methods. #1172 (David Persson)
+- `Hash::calculate()` learned to hash over arbitrary data (scalar and non-scalar, closures). 
+  #1196 (David Persson)
 
 ### Added
 

--- a/security/Hash.php
+++ b/security/Hash.php
@@ -8,6 +8,8 @@
 
 namespace lithium\security;
 
+use Closure;
+
 /**
  * Hash utility class. Contains methods to calculate hashes and compare
  * them in a safe way preventing timing attacks.
@@ -19,22 +21,40 @@ namespace lithium\security;
 class Hash {
 
 	/**
-	 * Uses PHP's hashing functions to calculate a hash over the string provided, using the options
+	 * Uses PHP's hashing functions to calculate a hash over the data provided, using the options
 	 * specified. The default hash algorithm is SHA-512.
 	 *
-	 * @param string $string The string to hash.
+	 * Examples:
+	 * ```
+	 * // Calculates a secure hash over string `'foo'`.
+	 * Hash::calculate('foo'));
+	 *
+	 * // It is possible to hash non-scalar data, too.
+	 * Hash::calculate(array('foo' => 'bar'));        // serializes before hashing
+	 * Hash::calculate(new Foo());                    // -- " --
+	 * Hash::calculate(function() { return 'bar'; }); // uses `spl_object_hash()`
+	 *
+	 * // Also allows for quick - non secure - hashing of arbitrary data.
+	 * Hash::calculate(array('foo' => 'bar'), array('type' => 'crc32b'));
+	 * ```
+	 *
+	 * @param mixed $data The arbitrary data to hash. Non-scalar data will be serialized, before
+	 *        being hashed. For anonymous functions the object hash will be used.
 	 * @param array $options Supported options:
 	 *        - `'type'` _string_: Any valid hashing algorithm. See the `hash_algos()` function to
 	 *          determine which are available on your system.
 	 *        - `'salt'` _string_: A _salt_ value which, if specified, will be prepended to the
-	 *          string.
-	 *        - `'key'` _string_: If specified `hash_hmac()` will be used to hash the string,
+	 *          data.
+	 *        - `'key'` _string_: If specified generates a keyed hash using `hash_hmac()`
 	 *          instead of `hash()`, with `'key'` being used as the message key.
 	 *        - `'raw'` _boolean_: If `true`, outputs the raw binary result of the hash operation.
 	 *          Defaults to `false`.
-	 * @return string Returns a hashed string.
+	 * @return string Returns a hash calculated over given data.
 	 */
-	public static function calculate($string, array $options = array()) {
+	public static function calculate($data, array $options = array()) {
+		if (!is_scalar($data)) {
+			$data = ($data instanceof Closure) ? spl_object_hash($data) : serialize($data);
+		}
 		$defaults = array(
 			'type' => 'sha512',
 			'salt' => false,
@@ -44,12 +64,12 @@ class Hash {
 		$options += $defaults;
 
 		if ($options['salt']) {
-			$string = $options['salt'] . $string;
+			$data = "{$options['salt']}{$data}";
 		}
 		if ($options['key']) {
-			return hash_hmac($options['type'], $string, $options['key'], $options['raw']);
+			return hash_hmac($options['type'], $data, $options['key'], $options['raw']);
 		}
-		return hash($options['type'], $string, $options['raw']);
+		return hash($options['type'], $data, $options['raw']);
 	}
 
 	/**

--- a/tests/cases/security/HashTest.php
+++ b/tests/cases/security/HashTest.php
@@ -9,6 +9,7 @@
 namespace lithium\tests\cases\security;
 
 use lithium\security\Hash;
+use stdClass;
 
 class HashTest extends \lithium\test\Unit {
 
@@ -69,6 +70,62 @@ class HashTest extends \lithium\test\Unit {
 		$expected = 'a9050b4f44797bf60262de984ca12967711389cd6c4c4aeee2a739c159f1f667';
 		$result = Hash::calculate($string, compact('type'));
 		$this->assertEqual($expected, $result);
+	}
+
+	public function testCalculateInstance() {
+		$data0 = new stdClass();
+		$data1 = new stdClass();
+
+		$result0 = Hash::calculate($data0);
+		$result1 = Hash::calculate($data1);
+
+		$this->assertEqual($result0, $result1);
+
+		$data0 = new stdClass();
+		$data1 = new stdClass();
+
+		$data1->foo = 'bar';
+
+		$result0 = Hash::calculate($data0);
+		$result1 = Hash::calculate($data1);
+
+		$this->assertNotEqual($result0, $result1);
+	}
+
+	public function testCalculateArray() {
+		$data0 = array('foo' => 'bar');
+		$data1 = array('foo' => 'bar');
+
+		$result0 = Hash::calculate($data0);
+		$result1 = Hash::calculate($data1);
+
+		$this->assertEqual($result0, $result1);
+
+		$data0 = array('foo' => 'bar');
+		$data1 = array('foo' => 'bar', 'baz');
+
+		$result0 = Hash::calculate($data0);
+		$result1 = Hash::calculate($data1);
+
+		$this->assertNotEqual($result0, $result1);
+	}
+
+	public function testCalculateClosure() {
+		$data0 = function() {};
+		$data1 = $data0;
+
+		$result0 = Hash::calculate($data0);
+		$result1 = Hash::calculate($data1);
+
+		$this->assertEqual($result0, $result1);
+
+		$data0 = function() {};
+		$data1 = function() {};
+
+		$result0 = Hash::calculate($data0);
+		$result1 = Hash::calculate($data1);
+
+		$this->assertNotEqual($result0, $result1);
 	}
 
 	public function testCompare() {


### PR DESCRIPTION
Can be used to quickly generate safe cache keys:
```
Hash::calculate($entity, array('type' => 'crc32b'));
```

... or to identify closures and generate unique arrays of closures:
```
$foo = function() {};
$bar = $foo;

Hash::calculate($foo) === Hash::calculate($bar);

$map[Hash::caculate($foo)] = $foo;
$map[Hash::caculate($bar)] = $bar;
```