### PR TITLE
Implementing datalist support for text fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@
   ```php
   $data = Media::decode($request->type, stream_get_contents($stream));
   ```
+- Text form fields now support generating corresponding `<datalist>` elements for autocompletion.
+  ```php
+  $this->form->field('region', array(
+      'type' => 'text',
+      'list' => array('foo', 'bar', 'baz')
+  ));
+  ```
 
 ### Changed
     

--- a/tests/cases/template/helper/FormTest.php
+++ b/tests/cases/template/helper/FormTest.php
@@ -1135,6 +1135,39 @@ class FormTest extends \lithium\test\Unit {
 		));
 	}
 
+	public function testFormFieldTextDatalist() {
+		$result = $this->form->field('states', array(
+			'type' => 'text', 'list' => array('CA', 'RI')
+		));
+		$this->assertTags($result, array(
+			'div' => array(),
+			'label' => array('for' => 'States'), 'States', '/label',
+			'input' => array(
+				'type' => 'text','name' => 'states',
+				'id' => 'States', 'list' => 'StatesList'
+			),
+			'datalist' => array('id' => 'StatesList'),
+				array('option' => array('value' => 'CA')),
+				'/option',
+				array('option' => array('value' => 'RI')),
+				'/option',
+			'/datalist',
+			'/div',
+		));
+
+		$result = $this->form->field('states', array(
+			'type' => 'text', 'list' => 'StatesList'
+		));
+		$this->assertTags($result, array(
+			'div' => array(),
+			'label' => array('for' => 'States'), 'States', '/label',
+			'input' => array(
+				'type' => 'text','name' => 'states',
+				'id' => 'States', 'list' => 'StatesList'
+			),
+		));
+	}
+
 	public function testFormErrorWithout() {
 		$this->form->create(null);
 		$result = $this->form->error('name');


### PR DESCRIPTION
Text form fields now support generating corresponding `<datalist>` elements for autocompletion.

```php
$this->form->field('region', array(
    'type' => 'text',
    'list' => array('foo', 'bar', 'baz')
));
```

Also see https://www.w3.org/wiki/HTML/Elements/datalist