### PR TITLE
Fix forced nesting of adapters et al. under extensions dir, even if a library defines its own adaptable based class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@
 
 ### Fixed
 
+- Restrictions on library search paths for i.e. adapters inside non-core libraries have been
+  relaxed. This fixes an inconvenience where adapters (and other classes) always had to be placed
+  under the `extensions` directory. Even in cases where it didn't feel natural to put them there.
+
+  This is best demonstrated using the `li3_access` plugin as an example. This plugin
+  defines a new adaptable class (`security\Access`).
+
+  Before:
+  ```
+  li3_access
+  ├── security
+  │   ├── Access.php
+  │   └── access
+  │       └── Adapter.php
+  └── extensions
+      └── adapter
+          └── access
+              ├── Resources.php
+              └── Rules.php
+  ```
+
+  After:
+  ```
+  li3_access
+  └── security
+      ├── Access.php
+      └── access
+          ├── Adapter.php
+          └── adapter
+              ├── Resources.php
+              └── Rules.php
+  ```
+
 ### Improved
 
 - Improved database encoding, timezone and searchPath methods. #1172 (David Persson)

--- a/core/Libraries.php
+++ b/core/Libraries.php
@@ -88,28 +88,24 @@ class Libraries {
 	protected static $_paths = array(
 		'adapter' => array(
 			'{:library}\extensions\adapter\{:namespace}\{:class}\{:name}',
-			'{:library}\{:namespace}\{:class}\adapter\{:name}' => array('libraries' => 'lithium')
+			'{:library}\{:namespace}\{:class}\adapter\{:name}'
 		),
 		'command' => array(
 			'{:library}\extensions\command\{:namespace}\{:class}\{:name}',
-			'{:library}\console\command\{:namespace}\{:class}\{:name}' => array(
-				'libraries' => 'lithium'
-			)
+			'{:library}\console\command\{:namespace}\{:class}\{:name}'
 		),
 		'controllers' => array(
 			'{:library}\controllers\{:namespace}\{:class}\{:name}Controller'
 		),
 		'data' => array(
 			'{:library}\extensions\data\{:namespace}\{:class}\{:name}',
-			'{:library}\data\{:namespace}\{:class}\adapter\{:name}' => array(
-				'libraries' => 'lithium'
-			),
-			'{:library}\data\{:namespace}\{:class}\{:name}' => array('libraries' => 'lithium'),
-			'{:library}\data\{:class}\adapter\{:name}' => array('libraries' => 'lithium')
+			'{:library}\data\{:namespace}\{:class}\adapter\{:name}',
+			'{:library}\data\{:namespace}\{:class}\{:name}',
+			'{:library}\data\{:class}\adapter\{:name}'
 		),
 		'helper' => array(
 			'{:library}\extensions\helper\{:name}',
-			'{:library}\template\helper\{:name}' => array('libraries' => 'lithium')
+			'{:library}\template\helper\{:name}'
 		),
 		'libraries' => array(
 			'{:app}/libraries/{:name}',
@@ -121,7 +117,7 @@ class Libraries {
 		'strategy' => array(
 			'{:library}\extensions\strategy\{:namespace}\{:class}\{:name}',
 			'{:library}\extensions\strategy\{:class}\{:name}',
-			'{:library}\{:namespace}\{:class}\strategy\{:name}' => array('libraries' => 'lithium')
+			'{:library}\{:namespace}\{:class}\strategy\{:name}'
 		),
 		'socket' => array(
 			'{:library}\extensions\net\socket\{:name}',
@@ -130,7 +126,7 @@ class Libraries {
 		),
 		'test' => array(
 			'{:library}\extensions\test\{:namespace}\{:class}\{:name}',
-			'{:library}\test\{:namespace}\{:class}\{:name}' => array('libraries' => 'lithium')
+			'{:library}\test\{:namespace}\{:class}\{:name}'
 		),
 		'tests' => array(
 			'{:library}\tests\{:namespace}\{:class}\{:name}Test'


### PR DESCRIPTION
  Restrictions on library search paths for i.e. adapters inside non-core libraries have been
  relaxed. This fixes an inconvenience where adapters (and other classes) always had to be placed
  under the `extensions` directory. Even in cases where it didn't feel natural to put them there.

  This is best demonstrated using the `li3_access` plugin as an example. This plugin
  defines a new adaptable class (`security\Access`).

  Before:
  ```
  li3_access
  ├── security
  │   ├── Access.php
  │   └── access
  │       └── Adapter.php
  └── extensions
      └── adapter
          └── access
              ├── Resources.php
              └── Rules.php
  ```

  After:
  ```
  li3_access
  └── security
      ├── Access.php
      └── access
          ├── Adapter.php
          └── adapter
              ├── Resources.php
              └── Rules.php
  ```
