### PR TITLE
New filter implementation (for PHP7 compat)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ your application's lifecycle, if your needs require.
 
 li₃ takes full advantage of the latest PHP features, including
 namespaces, late static binding and closures. li₃'s innovative [method filter
-system](http://li3.me/docs/lithium/util/collection/Filters) makes extensive use
+system](http://li3.me/docs/lithium/aop/Filters) makes extensive use
 of closures and anonymous functions to allow application developers to "wrap"
 framework method calls, intercepting parameters before, and return values after.
 

--- a/analysis/Logger.php
+++ b/analysis/Logger.php
@@ -8,6 +8,7 @@
 
 namespace lithium\analysis;
 
+use lithium\aop\Filters;
 use UnexpectedValueException;
 
 /**
@@ -118,7 +119,18 @@ class Logger extends \lithium\core\Adaptable {
 		foreach ($methods as $name => $method) {
 			$params = compact('priority', 'message', 'options');
 			$config = static::_config($name);
-			$result &= static::_filter(__FUNCTION__, $params, $method, $config['filters']);
+
+			if (!empty($config['filters'])) {
+				$message  = 'Per adapter filters have been deprecated. Please ';
+				$message .= "filter the manager class' static methods instead.";
+				trigger_error($message, E_USER_DEPRECATED);
+
+				$result &= Filters::bcRun(
+					get_called_class(), __FUNCTION__, $params, $method, $config['filters']
+				);
+			} else {
+				$result &= Filters::run(get_called_class(), __FUNCTION__, $params, $method);
+			}
 		}
 		return $methods ? $result : false;
 	}

--- a/analysis/logger/adapter/Cache.php
+++ b/analysis/logger/adapter/Cache.php
@@ -79,7 +79,7 @@ class Cache extends \lithium\core\Object {
 	public function write($priority, $message) {
 		$config = $this->_config + $this->_classes;
 
-		return function($self, $params) use ($config) {
+		return function($params) use ($config) {
 			$params += array('timestamp' => strtotime('now'));
 			$key = $config['key'];
 			$key = is_callable($key) ? $key($params) : Text::insert($key, $params);

--- a/analysis/logger/adapter/File.php
+++ b/analysis/logger/adapter/File.php
@@ -70,12 +70,10 @@ class File extends \lithium\core\Object {
 	 * @return \Closure Function returning boolean `true` on successful write, `false` otherwise.
 	 */
 	public function write($priority, $message) {
-		$config = $this->_config;
-
-		return function($self, $params) use (&$config) {
-			$path = $config['path'] . '/' . $config['file']($params, $config);
-			$params['timestamp'] = date($config['timestamp']);
-			$message = Text::insert($config['format'], $params);
+		return function($params) {
+			$path = $this->_config['path'] . '/' . $this->_config['file']($params, $this->_config);
+			$params['timestamp'] = date($this->_config['timestamp']);
+			$message = Text::insert($this->_config['format'], $params);
 			return file_put_contents($path, $message, FILE_APPEND);
 		};
 	}

--- a/analysis/logger/adapter/FirePhp.php
+++ b/analysis/logger/adapter/FirePhp.php
@@ -8,6 +8,8 @@
 
 namespace lithium\analysis\logger\adapter;
 
+use lithium\aop\Filters;
+
 /**
  * The `FirePhp` log adapter allows you to log messages to FirePHP.
  *
@@ -18,18 +20,18 @@ namespace lithium\analysis\logger\adapter;
  * For example, the following can be placed in a bootstrap file:
  *
  * ```
- * use lithium\action\Dispatcher;
  * use lithium\analysis\Logger;
+ * use lithium\aop\Filters;
  *
  * Logger::config(array(
  * 	'default' => array('adapter' => 'FirePhp')
  * ));
  *
- * Dispatcher::applyFilter('_call', function($self, $params, $chain) {
+ * Filters::apply('lithium\action\Dispatcher', '_call', function($params, $chain) {
  * 	if (isset($params['callable']->response)) {
  * 		Logger::adapter('default')->bind($params['callable']->response);
  * 	}
- * 	return $chain->next($self, $params, $chain);
+ * 	return $next($params);
  * });
  * ```
  *
@@ -144,13 +146,11 @@ class FirePhp extends \lithium\core\Object {
 	 *                 the current request. See the `bind()` method.
 	 */
 	public function write($priority, $message) {
-		$_self =& $this;
-
-		return function($self, $params) use (&$_self) {
+		return function($params) {
 			$priority = $params['priority'];
 			$message = $params['message'];
-			$message = $_self->invokeMethod('_format', array($priority, $message));
-			$_self->invokeMethod('_write', array($message));
+			$message = $this->_format($priority, $message);
+			$this->_write($message);
 			return true;
 		};
 	}

--- a/analysis/logger/adapter/Growl.php
+++ b/analysis/logger/adapter/Growl.php
@@ -127,17 +127,14 @@ class Growl extends \lithium\core\Object {
 	 * @return \Closure Function returning boolean `true` on successful write, `false` otherwise.
 	 */
 	public function write($priority, $message, array $options = array()) {
-		$_self =& $this;
-		$_priorities = $this->_priorities;
-
-		return function($self, $params) use (&$_self, $_priorities) {
+		return function($params) {
 			$priority = 0;
 			$options = $params['options'];
 
-			if (isset($options['priority']) && isset($_priorities[$options['priority']])) {
-				$priority = $_priorities[$options['priority']];
+			if (isset($options['priority']) && isset($this->_priorities[$options['priority']])) {
+				$priority = $this->_priorities[$options['priority']];
 			}
-			return $_self->notify($params['message'], compact('priority') + $options);
+			return $this->notify($params['message'], compact('priority') + $options);
 		};
 	}
 

--- a/analysis/logger/adapter/Syslog.php
+++ b/analysis/logger/adapter/Syslog.php
@@ -69,7 +69,6 @@ class Syslog extends \lithium\core\Object {
 	 */
 	public function write($priority, $message) {
 		$config = $this->_config;
-		$_priorities = $this->_priorities;
 
 		if (!$this->_isConnected) {
 			closelog();
@@ -77,8 +76,8 @@ class Syslog extends \lithium\core\Object {
 			$this->_isConnected = true;
 		}
 
-		return function($self, $params) use ($_priorities) {
-			$priority = $_priorities[$params['priority']];
+		return function($params) {
+			$priority = $this->_priorities[$params['priority']];
 			return syslog($priority, $params['message']);
 		};
 	}

--- a/aop/Chain.php
+++ b/aop/Chain.php
@@ -1,0 +1,249 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2013, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\aop;
+
+/**
+ * The `Chain` class represents a collection of callables, called filters.
+ * Instances contain a list of filters in line to be executed. It is often
+ * used in conjunction with the `Filters` class.
+ *
+ * Filters wrap around each other and then finally around the implementation.
+ * While the first added filter is called with the input first, and last in
+ * receiving the result.
+ *
+ * ```
+ *        │                ▲
+ *        │                │
+ * ┌──────┼────────────────┼──────┐
+ * │      │    Filter 1    │      │
+ * │      │                │      │
+ * │ ┌────┼────────────────┼────┐ │
+ * │ │    │    Filter 2    │    │ │
+ * │ │    │                │    │ │
+ * │ │┌───┼────────────────┼───┐│ │
+ * │ ││   │ Implementation │   ││ │
+ * │ ││   ▼                │   ││ │
+ * │ ││                        ││ │
+ * │ │└────────────────────────┘│ │
+ * │ └──────────────────────────┘ │
+ * └──────────────────────────────┘
+ * ```
+ *
+ * Filters executed inside the chain receive two parameters, the named
+ * parameters and the instance of the chain itself. Filters may _advance the
+ * chain_ by one `$next($params)` anywhere inside their function body. Filters
+ * can interrupt the chain by returning without advancing the chain.
+ *
+ * An example filter modifying the named parameters before advancing the chain.
+ * ```
+ * function($params, $next) {
+ *     $params['foo'] = 'bar';
+ *     return $next($params);
+ * }
+ * ```
+ *
+ * This class separates concerns as follows. It is context-less and knows
+ * nothing about the class/method it filters. This is the task of the `Filters`
+ * manager class. Concepts of _filter_ and _implementation_ are clearly
+ * separated, too. Filters take two arguments, the implementation one. The
+ * implementation does not know about it being part of the `Chain` and has no
+ * access to it.
+ */
+class Chain {
+
+	/**
+	 * An array of callables.
+	 *
+	 * @var array
+	 */
+	protected $_filters = array();
+
+	/**
+	 * The current implementation.
+	 *
+	 * @see lithium\aop\Chain::run()
+	 * @var callable
+	 */
+	protected $_implementation = null;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array $config Class configuration parameters The available options are:
+	 *         - `'filters'` _array_
+	 *         - `'class'` _array_: Deprecated. Here for BC.
+	 *         - `'method'` _array_: Depreacted. Here for BC.
+	 * @return void
+	 */
+	public function __construct(array $config = array()) {
+		$config += array(
+			'filters' => array(),
+			'class' => null,
+			'method' => null
+		);
+		$this->_filters = $config['filters'];
+		$this->_class = $config['class'];
+		$this->_method = $config['method'];
+
+		$this->_bcFilters();
+	}
+
+	/**
+	 * Runs the chain causing any queued callables and finally the
+	 * implementation to be executed.
+	 *
+	 * Before each run the implementation is made available to
+	 * `Chain::__invoke()` and the chain rewinded, after each run the
+	 * implementation is unset.
+	 *
+	 * An example implementation which is bound to an instance receives exactly
+	 * one argument (the named parameters).
+	 * ```
+	 * function($params) {
+	 *     $foo = $this->_bar;
+	 *     return $foo . 'baz';
+	 * }
+	 * ```
+	 *
+	 * @param array $params An array of named parameters.
+	 * @param callable $implementation
+	 * @return mixed The end result of the chain.
+	 */
+	public function run(array $params, $implementation) {
+		$this->_implementation = $implementation;
+
+		$filter = reset($this->_filters);
+		$result = $filter($params, $this);
+
+		$this->_implementation = null;
+		return $result;
+	}
+
+	/**
+	 * Advances the chain by one and executes the next filter in line. This
+	 * method is usually accessed from within a filter function.
+	 *
+	 * This method is implemented as a magic method as it allows use to hide the
+	 * fact that the second parameter passed to filters is a rich object. Making
+	 * the single purpose (next) very clear.
+	 *
+	 * A filter function using `$next` inside its function body to advance the
+	 * chain.
+	 * ```
+	 * function($params, $next) {
+	 *     return $next($params);
+	 * }
+	 * ```
+	 *
+	 * @see lithium\aop\Chain::next()
+	 * @param array $params An array of named parameters.
+	 * @return mixed The return value of the next filter. If there is no
+	 *         next filter, the return value of the implementation.
+	 */
+	public function __invoke(array $params) {
+		if (($filter = next($this->_filters)) !== false) {
+			return $filter($params, $this);
+		}
+
+		$implementation = $this->_implementation;
+		return $implementation($params);
+	}
+
+	/* Deprecated / BC */
+
+	/**
+	 * The fully-namespaced class name of the class or an instance of a
+	 * class containing the method being filtered.
+	 *
+	 * @deprecated
+	 * @see lithium\aop\Chain::method()
+	 * @var string|object
+	 */
+	protected $_class = null;
+
+	/**
+	 * The name of the method being filtered.
+	 *
+	 * @deprecated
+	 * @see lithium\aop\Chain::method()
+	 * @var string
+	 */
+	protected $_method = null;
+
+	/**
+	 * Advances the chain by one and executes the next filter in line.
+	 * This method is usually accessed from within a filter function.
+	 *
+	 * ```
+	 * function($params, $chain) {
+	 *     return $chain->next($params);
+	 * }
+	 * ```
+	 *
+	 * @deprecated
+	 * @param array $params An array of named parameters.
+	 * @return mixed The return value of the next filter. If there is no
+	 *         next filter, the return value of the implementation.
+	 */
+	public function next(/* array */ $params) {
+		$message = '`$chain->next()` has been deprecated in favor of `$chain($params)`.';
+		trigger_error($message, E_USER_DEPRECATED);
+
+		return $this($this->_bcNext(func_get_args()));
+	}
+
+	/**
+	 * Gets the method name associated with this filter chain. This is
+	 * the method being filtered.
+	 *
+	 * @deprecated
+	 * @param boolean $full Whether to include the class name, defaults to `false`.
+	 * @return string When $full is `true` returns a string with pattern
+	 *        `<CLASS>::<METHOD>`, else returns just the method name.
+	 */
+	public function method($full = false) {
+		$message = '`$chain->method()` has been deprecated.';
+		trigger_error($message, E_USER_DEPRECATED);
+
+		$class = is_string($this->_class) ? $this->_class : get_class($this->_class);
+		return $full ? $class . '::' . $this->_method : $this->_method;
+	}
+
+	protected function _bcFilters() {
+		foreach ($this->_filters as &$filter) {
+			$reflect = new \ReflectionFunction($filter);
+
+			if ($reflect->getNumberOfParameters() > 2) {
+				$message  = 'Old style filter function in file ' . $reflect->getFileName() . ' ';
+				$message .= 'on line ' . $reflect->getStartLine() . '. ';
+				$message .= 'The signature for filter functions has changed. It is now ';
+				$message .= '`($params, $next)` instead of the old `($self, $params, $chain)`. ';
+				$message .= 'Instead of `$self` use `$this` or `static`.';
+				trigger_error($message, E_USER_DEPRECATED);
+
+				$filter = function($params, $chain) use ($filter) {
+					return $filter($this->_class, $params, $chain);
+				};
+			}
+		}
+	}
+
+	protected function _bcNext($args) {
+		if (isset($args[1])) {
+			$message  = '`$chain->next($s, $p, $c)` signature changed. ';
+			$message .= 'Please use `$next($params)` instead.';
+			trigger_error($message, E_USER_DEPRECATED);
+
+			return $args[1];
+		}
+		return $args[0];
+	}
+}
+
+?>

--- a/aop/Filters.php
+++ b/aop/Filters.php
@@ -1,0 +1,368 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2013, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\aop;
+
+use lithium\aop\Chain;
+
+/**
+ * The `Filters` class centrally manages all filters and together with `Chain`
+ * forms the basis of the filtering system.
+ *
+ * The filters system is the innovative, no-nonsense and streamlined take on AOP:
+ * an efficient way to enable event-driven communication between classes without
+ * tight coupling.
+ *
+ * ## Making a Method Filterable
+ *
+ * Many methods inside the framework are already filterable and marked with
+ * a `@filter` docblock tag.
+ *
+ * To make a method filterable you first wrap the implementation inside a
+ * closure, create a named array of the parameters, then use `Filters::run()`.
+ *
+ * ```
+ * class Foo {
+ *	public function bar($name) {
+ *		return "Hello {$name}!";
+ *	}
+ * }
+ * ```
+ *
+ * ... turns into  ..
+ *
+ * ```
+ * use lithium\aop\Filters;
+ *
+ * class Foo {
+ *	public function bar($name) {
+ *		return Filters::run($this, __FUNCTION__, compact('name'), function($params) {
+ *			return "Hello {$params['name']}!";
+ *		});
+ *	}
+ * }
+ * ```
+ *
+ * ## Creating a Filter
+ *
+ * A filter can be any callable, but usually is a closure. It always takes two
+ * parameters: `$params` and `$next`, both are explained below.
+ *
+ * ```
+ * function($params, $next) {
+ *	// Do something before ...
+ *	$result = $next($params);
+ *	// Do something after ...
+ *	return $result;
+ * };
+ * ```
+ *
+ * `$params` contains an associative array of the parameters that are passed
+ * into the implementation. You can modify or inspect these parameters before
+ * allowing the filter to continue.
+ *
+ * `$next` allows you to pass control to the next filter
+ * in the chain and finally when to the implementation itself. This allows you
+ * to interact with the return value as well as the parameters.
+ *
+ * ## Applying a Filter
+ *
+ * Filters are applied using `Filters::apply()`. The method needs the class
+ * and method which should be filtered as well as a filter to apply.
+ *
+ * Filters can be applied to both static or instantiated objects.
+ *
+ * Here we apply a filter to the `Dispatcher`, where we want to run custom
+ * logic before `Dispatcher::run()` executes. The logic in the filter will be
+ * executed on every call to `Dispatcher::run()`, and `$response` will always be
+ * modified by any custom logic present before being returned from `run()`.
+ * ```
+ * use lithium\aop\Filters;
+ *
+ * Filters::apply('lithium\action\Dispatcher', 'run', function($params, $next) {
+ * 	// Custom pre-dispatch logic goes here.
+ * 	$response = $next($params);
+ *
+ * 	// $response now contains a Response object with the result of the
+ * 	// dispatched request, and can be modified as appropriate.
+ * 	return $response;
+ * });
+ * ```
+ *
+ * @link https://en.wikipedia.org/wiki/Aspect-oriented_programming
+ * @link http://php.net/functions.anonymous.php
+ * @see lithium\aop\Chain
+ */
+class Filters {
+
+	/**
+	 * An array of filters keyed by their class and method id.
+	 * Will be used to later construct `Chain` objects, per class and method.
+	 *
+	 * @see lithium\aop\Filters::_ids()
+	 * @see lithium\aop\Filters::_chain()
+	 * @var array
+	 */
+	protected static $_filters = array();
+
+	/**
+	 * Holds `Chain` objects keyed by their primary class and method id.
+	 *
+	 * @see lithium\aop\Filters::_ids()
+	 * @see lithium\aop\Filters::_chain()
+	 * @array
+	 */
+	protected static $_chains = array();
+
+	/**
+	 * Lazily applies a filter to a method.
+	 *
+	 * Classes aliased via `class_alias()` are treated as entirely seperate from
+	 * their original class.
+	 *
+	 * When calling apply after previous runs (rarely happens), this method will
+	 * invalidate the chain cache.
+	 *
+	 * Multiple applications of a filter will add the filter multiple times to
+	 * the chain. It is up to the user to keep the list of filters unique.
+	 *
+	 * This method intentionally does not establish class context for closures
+	 * by binding them to the instance or statically to the class. Closures can
+	 * originate from static and instance methods and can PHP does not allow to
+	 * rebind a closure from a static method to an instance.
+	 *
+	 * @param string|object $class The fully namespaced name of a static class or
+	 *        an instance of a concrete class to which the filter will be applied.
+	 *        Passing a class name for a concrete class will apply the filter to all
+	 *        instances of that class.
+	 * @param string $method The method name to which the filter will be applied i.e. `'bar'`.
+	 * @param callable $filter The filter to apply to the class method. Can be anykind of
+	 *        a callable, most often this is a closure.
+	 * @return void
+	 */
+	public static function apply($class, $method, $filter) {
+		list($id,) = static::_ids($class, $method);
+
+		if (!isset(static::$_filters[$id])) {
+			static::$_filters[$id] = array();
+		}
+		static::$_filters[$id][] = $filter;
+
+		if (isset(static::$_chains[$id])) {
+			unset(static::$_chains[$id]);
+		}
+	}
+
+	/**
+	 * Checks to see if the given class/method has any filters applied.
+	 *
+	 * @param string|object $class Fully namespaced class name or an instance of a class.
+	 * @param string $method The method name i.e. `'bar'`.
+	 * @return boolean
+	 */
+	public static function hasApplied($class, $method) {
+		foreach (static::_ids($class, $method) as $id) {
+			if (isset(static::$_filters[$id])) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Runs the chain and returns its result value. This method is used to make
+	 * a method filterable.
+	 *
+	 * All filters in the run will have access to given parameters. The
+	 * implementation will be placed as the last item in the chain, so
+	 * that effectively filters for the implementation wrap arround its
+	 * implementation.
+	 *
+	 * Creates `Chain` objects lazily, caches and reuses them with differing
+	 * parameters for best of both worlds: lazy object construction to save
+	 * upfront memory as well as quick re-execution. This method may be called
+	 * quite often when filtered methods are executed inside a loop. Thus it
+	 * tries to reduce overhead as much as possible. Optimized for the common
+	 * case that no filters for a filtered method are present.
+	 *
+	 * An example implementation function:
+	 * ```
+	 * function($params) {
+	 *     $params['foo'] = 'bar';
+	 *     return $params['foo'];
+	 * }
+	 * ```
+	 *
+	 * Two examples to make a method filterable.
+	 * ```
+	 * // Inside a static method.
+	 * Filters::run(get_called_class(), __FUNCTION__, $params, function($params) {
+	 *     return 'implementation';
+	 * });
+	 *
+	 * // Inside an instance method.
+	 * Filters::run($this, __FUNCTION__, $params, function($params) {
+	 *     return 'implementation';
+	 * });
+	 * ```
+	 *
+	 * @see lithium\aop\Chain
+	 * @see lithium\aop\Chain::run()
+	 * @param string|object $class The fully namespaced name of a static class or
+	 *        an instance of a concrete class. Do not pass a class name for
+	 *        concrete classes. For instances will use a set of merged filters.
+	 *        First class filter, then instance filters.
+	 * @param string $method The method name i.e. `'bar'`.
+	 * @param array $params
+	 * @param callable $implementation
+	 * @return mixed The result of running the chain.
+	 */
+	public static function run($class, $method, array $params, $implementation) {
+		$implementation = static::_bcImplementation($class, $method, $params, $implementation);
+
+		if (!static::hasApplied($class, $method)) {
+			return $implementation($params);
+		}
+		return static::_chain($class, $method)->run($params, $implementation);
+	}
+
+	/**
+	 * Clears filters optionally constrained by class or class and method combination.
+	 *
+	 * To clear filters for all methods of static class:
+	 * ```
+	 * Filters::clear('Foo');
+	 * ```
+	 *
+	 * To clear instance and class filters for all methods of concrete class,
+	 * or to clear just the instance filters for all methods:
+	 * ```
+	 * Filters::clear('Bar');
+	 * Filters::clear($instance);
+	 * ```
+	 *
+	 * This method involves some overhead. This is neglectable as it isn't commonly
+	 * called in hot code paths.
+	 *
+	 * @param string|object $class Fully namespaced class name or an instance of a class.
+	 * @param string $method The method name i.e. `'bar'`.
+	 * @return void
+	 */
+	public static function clear($class = null, $method = null) {
+		if ($class === null && $method === null) {
+			static::$_filters = static::$_chains = array();
+			return;
+		}
+
+		if (is_string($class)) {
+			$regex  = '^<' . str_replace('\\', '\\\\', ltrim($class, '\\')) . '.*>';
+		} else {
+			$regex  = '^<.*#' . spl_object_hash($class) . '>';
+		}
+		if ($method) {
+			$regex .= "::{$method}$";
+		}
+		foreach (array_keys(static::$_filters) as $id) {
+			if (preg_match("/{$regex}/", $id)) {
+				unset(static::$_filters[$id]);
+			}
+		}
+		foreach (array_keys(static::$_chains) as $id) {
+			if (preg_match("/{$regex}/", $id)) {
+				unset(static::$_chains[$id]);
+			}
+		}
+	}
+
+	/**
+	 * Calculates possible ids for a class/method combination. Normalizes
+	 * leading backslash in class name by removing it.
+	 *
+	 * In general instances have two possible ids and static classes have one.
+	 * The id is formattet according to the following pattern which is inspired
+	 * by the format used by `psysh`:
+	 * ```
+	 * <foo\Bar #0000000046feb0630000000176a1b630>::baz
+	 * <lithium\action\Dispatcher>::run
+	 * ```
+	 *
+	 * @link http://psysh.org/
+	 * @param string|object $class Fully namespaced class name or an instance of a class.
+	 * @param string $method The method name i.e. `'bar'`.
+	 * @return array An array of the possible ids.
+	 */
+	protected static function _ids($class, $method) {
+		if (is_string($class)) {
+			return array('<' . ltrim($class, '\\') . ">::{$method}");
+		}
+		return array(
+			'<' . get_class($class) . ' #' . spl_object_hash($class) . ">::{$method}",
+			'<' . get_class($class) . ">::{$method}"
+		);
+	}
+
+	/**
+	 * Creates a chain for given class/method combination or retrieves it from
+	 * cache. Will implictly do a reverse merge to put static filters first before
+	 * instance filters.
+	 *
+	 * @see lithium\aop\Chain
+	 * @param string|object $class Fully namespaced class name or an instance of a class.
+	 * @param string $method The method name i.e. `'bar'`.
+	 * @return \lithium\aop\Chain
+	 */
+	protected static function _chain($class, $method) {
+		$ids = static::_ids($class, $method);
+
+		if (isset(static::$_chains[$ids[0]])) {
+			return static::$_chains[$ids[0]];
+		}
+		$filters = array();
+
+		foreach ($ids as $id) {
+			if (isset(static::$_filters[$id])) {
+				$filters = array_merge(static::$_filters[$id], $filters);
+			}
+		}
+		return static::$_chains[$ids[0]] = new Chain(compact('class', 'method', 'filters'));
+	}
+
+	/* Deprecated / BC */
+
+	public static function bcRun($class, $method, array $params, $implementation, array $filters) {
+		$implementation = static::_bcImplementation($class, $method, $params, $implementation);
+		$ids = static::_ids($class, $method);
+
+		foreach ($ids as $id) {
+			if (isset(static::$_filters[$id])) {
+				$filters = array_merge(static::$_filters[$id], $filters);
+			}
+		}
+		return new Chain(compact('class', 'method', 'filters'));
+	}
+
+	protected static function _bcImplementation($class, $method, $params, $implementation) {
+		$reflect = new \ReflectionFunction($implementation);
+
+		if ($reflect->getNumberOfParameters() > 1) {
+			$message  = 'Old style implementation function in file ' . $reflect->getFileName() . ' ';
+			$message .= 'on line ' . $reflect->getStartLine() . '. ';
+			$message .= 'The signature for implementation functions has changed. It is now ';
+			$message .= '`($params)` instead of the old `($self, $params)`. ';
+			$message .= 'Instead of `$self` use `$this` or `static`.';
+			trigger_error($message, E_USER_DEPRECATED);
+
+			$implementation = function($params) use ($class, $implementation) {
+				return $implementation($class, $params, null);
+			};
+		}
+		return $implementation;
+	}
+}
+
+?>

--- a/core/Object.php
+++ b/core/Object.php
@@ -9,7 +9,7 @@
 namespace lithium\core;
 
 use lithium\core\Libraries;
-use lithium\util\collection\Filters;
+use lithium\aop\Filters;
 use lithium\analysis\Inspector;
 
 /**
@@ -25,9 +25,6 @@ use lithium\analysis\Inspector;
  *   automatically by `Object::__construct()`, but may be disabled by passing `'init' => false` to
  *   the constructor. The initializer is also used for automatically assigning object properties.
  *   See the documentation on the `_init()` method for more details.
- * - **Filters**: The `Object` class implements two methods which allow an object to easily
- *   implement filterable methods. The `_filter()` method allows methods to be implemented as
- *   filterable, and the `applyFilter()` method allows filters to be wrapped around them.
  * - **Testing / misc.**: The `__set_state()` method provides a default implementation of the PHP
  *   magic method (works with `var_export()`) which can instantiate an object with a static method
  *   call. Finally, the `_stop()` method may be used instead of `exit()`, as it can be overridden
@@ -56,16 +53,6 @@ class Object {
 	 * @var array
 	 */
 	protected $_autoConfig = array();
-
-	/**
-	 * Contains a 2-dimensional array of filters applied to this object's methods, indexed by method
-	 * name. See the associated methods for more details.
-	 *
-	 * @see lithium\core\Object::_filter()
-	 * @see lithium\core\Object::applyFilter()
-	 * @var array
-	 */
-	protected $_methodFilters = array();
 
 	/**
 	 * Parents of the current class.
@@ -131,33 +118,6 @@ class Object {
 				$this->{"_{$key}"} = $this->_config[$key] + $this->{"_{$key}"};
 			} else {
 				$this->{"_$flag"} = $this->_config[$flag];
-			}
-		}
-	}
-
-	/**
-	 * Apply a closure to a method of the current object instance.
-	 *
-	 * @see lithium\core\Object::_filter()
-	 * @see lithium\util\collection\Filters
-	 * @param mixed $method The name of the method to apply the closure to. Can either be a single
-	 *        method name as a string, or an array of method names. Can also be false to remove
-	 *        all filters on the current object.
-	 * @param \Closure $filter The closure that is used to filter the method(s), can also be false
-	 *        to remove all the current filters for the given method.
-	 * @return void
-	 */
-	public function applyFilter($method, $filter = null) {
-		if ($method === false) {
-			$this->_methodFilters = array();
-			return;
-		}
-		foreach ((array) $method as $m) {
-			if (!isset($this->_methodFilters[$m]) || $filter === false) {
-				$this->_methodFilters[$m] = array();
-			}
-			if ($filter !== false) {
-				$this->_methodFilters[$m][] = $filter;
 			}
 		}
 	}
@@ -239,36 +199,6 @@ class Object {
 	}
 
 	/**
-	 * Executes a set of filters against a method by taking a method's main implementation as a
-	 * callback, and iteratively wrapping the filters around it. This, along with the `Filters`
-	 * class, is the core of Lithium's filters system. This system allows you to "reach into" an
-	 * object's methods which are marked as _filterable_, and intercept calls to those methods,
-	 * optionally modifying parameters or return values.
-	 *
-	 * @see lithium\core\Object::applyFilter()
-	 * @see lithium\util\collection\Filters
-	 * @param string $method The name of the method being executed, usually the value of
-	 *               `__METHOD__`.
-	 * @param array $params An associative array containing all the parameters passed into
-	 *              the method.
-	 * @param \Closure $callback The method's implementation, wrapped in a closure.
-	 * @param array $filters Additional filters to apply to the method for this call only.
-	 * @return mixed Returns the return value of `$callback`, modified by any filters passed in
-	 *         `$filters` or applied with `applyFilter()`.
-	 */
-	protected function _filter($method, $params, $callback, $filters = array()) {
-		list($class, $method) = explode('::', $method);
-
-		if (empty($this->_methodFilters[$method]) && empty($filters)) {
-			return $callback($this, $params, null);
-		}
-
-		$f = isset($this->_methodFilters[$method]) ? $this->_methodFilters[$method] : array();
-		$data = array_merge($f, $filters, array($callback));
-		return Filters::run($this, $params, compact('data', 'class', 'method'));
-	}
-
-	/**
 	 * Gets and caches an array of the parent methods of a class.
 	 *
 	 * @return array Returns an array of parent classes for the current class.
@@ -292,6 +222,81 @@ class Object {
 		exit($status);
 	}
 
+	/* Deprecated / BC */
+
+	/**
+	 * Contains a 2-dimensional array of filters applied to this object's methods, indexed by method
+	 * name. See the associated methods for more details.
+	 *
+	 * @deprecated Not used anymore.
+	 * @see lithium\core\Object::_filter()
+	 * @see lithium\core\Object::applyFilter()
+	 * @var array
+	 */
+	protected $_methodFilters = array();
+
+	/**
+	 * Apply a closure to a method of the current object instance.
+	 *
+	 * @deprecated Replaced by `\lithium\aop\Filters::apply()` and `::clear()`.
+	 * @see lithium\core\Object::_filter()
+	 * @see lithium\util\collection\Filters
+	 * @param mixed $method The name of the method to apply the closure to. Can either be a single
+	 *        method name as a string, or an array of method names. Can also be false to remove
+	 *        all filters on the current object.
+	 * @param \Closure $filter The closure that is used to filter the method(s), can also be false
+	 *        to remove all the current filters for the given method.
+	 * @return void
+	 */
+	public function applyFilter($method, $filter = null) {
+		$message  = '`' . __METHOD__ . '()` has been deprecated in favor of ';
+		$message .= '`\lithium\aop\Filters::apply()` and `::clear()`.';
+		trigger_error($message, E_USER_DEPRECATED);
+
+		if ($method === false) {
+			Filters::clear($this);
+			return;
+		}
+		foreach ((array) $method as $m) {
+			if ($filter === false) {
+				Filters::clear($this, $m);
+			} else {
+				Filters::apply($this, $m, $filter);
+			}
+		}
+	}
+
+	/**
+	 * Executes a set of filters against a method by taking a method's main implementation as a
+	 * callback, and iteratively wrapping the filters around it. This, along with the `Filters`
+	 * class, is the core of Lithium's filters system. This system allows you to "reach into" an
+	 * object's methods which are marked as _filterable_, and intercept calls to those methods,
+	 * optionally modifying parameters or return values.
+	 *
+	 * @deprecated Replaced by `\lithium\aop\Filters::run()`.
+	 * @see lithium\core\Object::applyFilter()
+	 * @see lithium\util\collection\Filters
+	 * @param string $method The name of the method being executed, usually the value of
+	 *               `__METHOD__`.
+	 * @param array $params An associative array containing all the parameters passed into
+	 *              the method.
+	 * @param \Closure $callback The method's implementation, wrapped in a closure.
+	 * @param array $filters Additional filters to apply to the method for this call only.
+	 * @return mixed Returns the return value of `$callback`, modified by any filters passed in
+	 *         `$filters` or applied with `applyFilter()`.
+	 */
+	protected function _filter($method, $params, $callback, $filters = array()) {
+		$message  = '`' . __METHOD__ . '()` has been deprecated in favor of ';
+		$message .= '`\lithium\aop\Filters::run()` and `::apply()`.';
+		trigger_error($message, E_USER_DEPRECATED);
+
+		list(, $method) = explode('::', $method);
+
+		foreach ($filters as $filter) {
+			Filters::apply($this, $method, $filter);
+		}
+		return Filters::run($this, $method, $params, $callback);
+	}
 }
 
 ?>

--- a/data/Collection.php
+++ b/data/Collection.php
@@ -637,7 +637,7 @@ abstract class Collection extends \lithium\util\Collection implements \Serializa
 	 * the `_result` property which may hold unserializable `PDOStatement`s.
 	 *
 	 * Properties that hold anonymous functions are also skipped. Some of these
-	 * can almost be reconstructed (`_handlers`) others cannot (`_methodFilters`).
+	 * can almost be reconstructed (`_handlers`).
 	 *
 	 * @return string Serialized properties of the object.
 	 */
@@ -648,7 +648,6 @@ abstract class Collection extends \lithium\util\Collection implements \Serializa
 		$vars = get_object_vars($this);
 		unset($vars['_result']);
 		unset($vars['_handlers']);
-		unset($vars['_methodFilters']);
 
 		return serialize($vars);
 	}

--- a/data/Entity.php
+++ b/data/Entity.php
@@ -545,8 +545,7 @@ class Entity extends \lithium\core\Object implements \Serializable {
 	 * and schema are ignored with serialized objects.
 	 *
 	 * Properties that hold anonymous functions are also skipped. Some of these
-	 * can almost be reconstructed (`_handlers`) others cannot (`_methodFilters`
-	 * and `schema`).
+	 * can almost be reconstructed (`_handlers`) others cannot (`schema`).
 	 *
 	 * @return string Serialized properties of the object.
 	 */
@@ -555,7 +554,6 @@ class Entity extends \lithium\core\Object implements \Serializable {
 		unset($vars['_schema']);
 		unset($vars['_config']['schema']);
 		unset($vars['_handlers']);
-		unset($vars['_methodFilters']);
 
 		return serialize($vars);
 	}

--- a/data/source/Http.php
+++ b/data/source/Http.php
@@ -9,6 +9,7 @@
 namespace lithium\data\source;
 
 use lithium\util\Text;
+use lithium\aop\Filters;
 use lithium\data\model\Query;
 
 /**
@@ -133,9 +134,9 @@ class Http extends \lithium\data\Source {
 		}
 		$params[0] = new Query($params[0]->export($this) + $this->_methods[$method]);
 
-		return $this->_filter(__CLASS__ . "::" . $method, $params, function($self, $params) {
+		return Filters::run($this, $method, $params, function($params) {
 			list($query, $options) = $params;
-			return $self->send($query, $options);
+			return $this->send($query, $options);
 		});
 	}
 
@@ -234,9 +235,12 @@ class Http extends \lithium\data\Source {
 		$query = !is_object($query) ? new Query() : $query;
 		$query->method() ?: $query->method("post");
 		$query->path() ?: $query->path("/{:source}");
-		return $this->_filter(__METHOD__, array($query, $options), function($self, $params) {
+
+		$params = array($query, $options);
+
+		return Filters::run($this, __FUNCTION__, $params, function($params) {
 			list($query, $options) = $params;
-			return $self->send($query, $options);
+			return $this->send($query, $options);
 		});
 	}
 
@@ -252,9 +256,12 @@ class Http extends \lithium\data\Source {
 		$query = !is_object($query) ? new Query() : $query;
 		$query->method() ?: $query->method("get");
 		$query->path() ?: $query->path("/{:source}");
-		return $this->_filter(__METHOD__, array($query, $options), function($self, $params) {
+
+		$params = array($query, $options);
+
+		return Filters::run($this, __FUNCTION__, $params, function($params) {
 			list($query, $options) = $params;
-			return $self->send($query, $options);
+			return $this->send($query, $options);
 		});
 	}
 
@@ -270,9 +277,12 @@ class Http extends \lithium\data\Source {
 		$query = !is_object($query) ? new Query() : $query;
 		$query->method() ?: $query->method("put");
 		$query->path() ?: $query->path("/{:source}/{:id}");
-		return $this->_filter(__METHOD__, array($query, $options), function($self, $params) {
+
+		$params = array($query, $options);
+
+		return Filters::run($this, __FUNCTION__, $params, function($params) {
 			list($query, $options) = $params;
-			return $self->send($query, $options);
+			return $this->send($query, $options);
 		});
 	}
 
@@ -288,9 +298,12 @@ class Http extends \lithium\data\Source {
 		$query = !is_object($query) ? new Query() : $query;
 		$query->method() ?: $query->method("delete");
 		$query->path() ?: $query->path("/{:source}/{:id}");
-		return $this->_filter(__METHOD__, array($query, $options), function($self, $params) {
+
+		$params = array($query, $options);
+
+		return Filters::run($this, __FUNCTION__, $params, function($params) {
 			list($query, $options) = $params;
-			return $self->send($query, $options);
+			return $this->send($query, $options);
 		});
 	}
 

--- a/g11n/Message.php
+++ b/g11n/Message.php
@@ -8,6 +8,7 @@
 
 namespace lithium\g11n;
 
+use lithium\aop\Filters;
 use lithium\core\Environment;
 use lithium\util\Text;
 use lithium\g11n\Catalog;
@@ -191,8 +192,7 @@ class Message extends \lithium\core\StaticObject {
 	protected static function _translated($id, $count, $locale, array $options = array()) {
 		$params = compact('id', 'count', 'locale', 'options');
 
-		$cache =& static::$_cachedPages;
-		return static::_filter(__FUNCTION__, $params, function($self, $params) use (&$cache) {
+		return Filters::run(get_called_class(), __FUNCTION__, $params, function($params) {
 			extract($params);
 
 			if (isset($options['context']) && $options['context'] !== null) {
@@ -200,12 +200,12 @@ class Message extends \lithium\core\StaticObject {
 				$id = "{$id}|{$context}";
 			}
 
-			if (!isset($cache[$options['scope']][$locale])) {
-				$cache[$options['scope']][$locale] = Catalog::read(
+			if (!isset(static::$_cachedPages[$options['scope']][$locale])) {
+				static::$_cachedPages[$options['scope']][$locale] = Catalog::read(
 					true, 'message', $locale, $options
 				);
 			}
-			$page = $cache[$options['scope']][$locale];
+			$page = static::$_cachedPages[$options['scope']][$locale];
 
 			if (!isset($page[$id])) {
 				return null;

--- a/storage/Cache.php
+++ b/storage/Cache.php
@@ -8,6 +8,7 @@
 
 namespace lithium\storage;
 
+use lithium\aop\Filters;
 use lithium\core\ConfigException;
 
 /**
@@ -178,7 +179,7 @@ class Cache extends \lithium\core\Adaptable {
 		}
 		$params = compact('keys', 'expiry');
 
-		return static::_filter(__FUNCTION__, $params, function($self, $params) use ($adapter) {
+		return Filters::run(get_called_class(), __FUNCTION__, $params, function($params) use ($adapter) {
 			return $adapter->write($params['keys'], $params['expiry']);
 		});
 	}
@@ -240,7 +241,7 @@ class Cache extends \lithium\core\Adaptable {
 		}
 		$params = compact('keys');
 
-		$results = static::_filter(__FUNCTION__, $params, function($self, $params) use ($adapter) {
+		$results = Filters::run(get_called_class(), __FUNCTION__, $params, function($params) use ($adapter) {
 			return $adapter->read($params['keys']);
 		});
 
@@ -307,7 +308,7 @@ class Cache extends \lithium\core\Adaptable {
 		}
 		$params = compact('keys');
 
-		return static::_filter(__FUNCTION__, $params, function($self, $params) use ($adapter) {
+		return Filters::run(get_called_class(), __FUNCTION__, $params, function($params) use ($adapter) {
 			return $adapter->delete($params['keys']);
 		});
 	}
@@ -339,7 +340,7 @@ class Cache extends \lithium\core\Adaptable {
 		$key = static::key($key);
 		$params = compact('key', 'offset');
 
-		return static::_filter(__FUNCTION__, $params, function($self, $params) use ($adapter) {
+		return Filters::run(get_called_class(), __FUNCTION__, $params, function($params) use ($adapter) {
 			return $adapter->increment($params['key'], $params['offset']);
 		});
 	}
@@ -371,7 +372,7 @@ class Cache extends \lithium\core\Adaptable {
 		$key = static::key($key);
 		$params = compact('key', 'offset');
 
-		return static::_filter(__FUNCTION__, $params, function($self, $params) use ($adapter) {
+		return Filters::run(get_called_class(), __FUNCTION__, $params, function($params) use ($adapter) {
 			return $adapter->decrement($params['key'], $params['offset']);
 		});
 	}

--- a/storage/Session.php
+++ b/storage/Session.php
@@ -8,6 +8,8 @@
 
 namespace lithium\storage;
 
+use lithium\aop\Filters;
+
 /**
  * The `Session` static class provides a consistent interface to configure and utilize the
  * different persistent storage adapters included with Lithium, as well as your own adapters.
@@ -104,8 +106,19 @@ class Session extends \lithium\core\Adaptable {
 				return null;
 			}
 		}
-		$filters = $settings['filters'] ?: array();
-		$result = static::_filter(__FUNCTION__, compact('key', 'options'), $method, $filters);
+		$params = compact('key', 'options');
+
+		if (!empty($settings['filters'])) {
+			$message  = 'Per adapter filters have been deprecated. Please ';
+			$message .= "filter the manager class' static methods instead.";
+			trigger_error($message, E_USER_DEPRECATED);
+
+			$result = Filters::bcRun(
+				get_called_class(), __FUNCTION__, $params, $method, $settings['filters']
+			);
+		} else {
+			$result = Filters::run(get_called_class(), __FUNCTION__, $params, $method);
+		}
 
 		if ($options['strategies']) {
 			$options += array('key' => $key, 'mode' => 'LIFO', 'class' => __CLASS__);
@@ -151,13 +164,24 @@ class Session extends \lithium\core\Adaptable {
 
 		foreach ($methods as $name => $method) {
 			$settings = static::_config($name);
-			$filters = $settings['filters'];
+
 			if ($options['strategies']) {
 				$options += array('key' => $key, 'class' => __CLASS__);
 				$value = static::applyStrategies(__FUNCTION__, $name, $original, $options);
 			}
 			$params = compact('key', 'value', 'options');
-			$result = static::_filter(__FUNCTION__, $params, $method, $filters) || $result;
+
+			if (!empty($settings['filters'])) {
+				$message  = 'Per adapter filters have been deprecated. Please ';
+				$message .= "filter the manager class' static methods instead.";
+				trigger_error($message, E_USER_DEPRECATED);
+
+				$result = Filters::bcRun(
+					get_called_class(), __FUNCTION__, $params, $method, $settings['filters']
+				) || $result;
+			} else {
+				$result = Filters::run(get_called_class(), __FUNCTION__, $params, $method) || $result;
+			}
 		}
 		return $result;
 	}
@@ -196,13 +220,24 @@ class Session extends \lithium\core\Adaptable {
 
 		foreach ($methods as $name => $method) {
 			$settings = static::_config($name);
+
 			if ($options['strategies']) {
 				$options += array('key' => $key, 'class' => __CLASS__);
 				$key = static::applyStrategies(__FUNCTION__, $name, $original, $options);
 			}
 			$params = compact('key', 'options');
-			$filters = $settings['filters'];
-			$result = static::_filter(__FUNCTION__, $params, $method, $filters) || $result;
+
+			if (!empty($settings['filters'])) {
+				$message  = 'Per adapter filters have been deprecated. Please ';
+				$message .= "filter the manager class' static methods instead.";
+				trigger_error($message, E_USER_DEPRECATED);
+
+				$result = Filters::bcRun(
+					get_called_class(), __FUNCTION__, $params, $method, $settings['filters']
+				) || $result;
+			} else {
+				$result = Filters::run(get_called_class(), __FUNCTION__, $params, $method) || $result;
+			}
 		}
 		return $result;
 	}
@@ -237,8 +272,18 @@ class Session extends \lithium\core\Adaptable {
 
 		foreach ($methods as $name => $method) {
 			$settings = static::_config($name);
-			$filters = $settings['filters'];
-			$result = static::_filter(__FUNCTION__, $params, $method, $filters) || $result;
+
+			if (!empty($settings['filters'])) {
+				$message  = 'Per adapter filters have been deprecated. Please ';
+				$message .= "filter the manager class' static methods instead.";
+				trigger_error($message, E_USER_DEPRECATED);
+
+				$result = Filters::bcRun(
+					get_called_class(), __FUNCTION__, $params, $method, $settings['filters']
+				) || $result;
+			} else {
+				$result = Filters::run(get_called_class(), __FUNCTION__, $params, $method) || $result;
+			}
 		}
 		if ($options['strategies']) {
 			$options += array('mode' => 'LIFO', 'class' => __CLASS__);
@@ -275,8 +320,18 @@ class Session extends \lithium\core\Adaptable {
 
 		foreach ($methods as $name => $method) {
 			$settings = static::_config($name);
-			$filters = $settings['filters'];
-			$result = static::_filter(__FUNCTION__, $params, $method, $filters) || $result;
+
+			if (!empty($settings['filters'])) {
+				$message  = 'Per adapter filters have been deprecated. Please ';
+				$message .= "filter the manager class' static methods instead.";
+				trigger_error($message, E_USER_DEPRECATED);
+
+				$result = Filters::bcRun(
+					get_called_class(), __FUNCTION__, $params, $method, $settings['filters']
+				) || $result;
+			} else {
+				$result = Filters::run(get_called_class(), __FUNCTION__, $params, $method) || $result;
+			}
 		}
 		if ($options['strategies']) {
 			$options += array('key' => $key, 'mode' => 'LIFO', 'class' => __CLASS__);

--- a/storage/session/adapter/Memory.php
+++ b/storage/session/adapter/Memory.php
@@ -50,9 +50,8 @@ class Memory extends \lithium\core\Object {
 	 * @return \Closure Function returning boolean `true` if the key exists, `false` otherwise.
 	 */
 	public function check($key, array $options = array()) {
-		$session =& $this->_session;
-		return function($self, $params) use (&$session) {
-			return isset($session[$params['key']]);
+		return function($params) {
+			return isset($this->_session[$params['key']]);
 		};
 	}
 
@@ -65,13 +64,11 @@ class Memory extends \lithium\core\Object {
 	 * @return \Closure Function returning data in the session if successful, `false` otherwise.
 	 */
 	public function read($key = null, array $options = array()) {
-		$session = $this->_session;
-
-		return function($self, $params) use ($session) {
+		return function($params) {
 			if (!$params['key']) {
-				return $session;
+				return $this->_session;
 			}
-			return isset($session[$params['key']]) ? $session[$params['key']] : null;
+			return isset($this->_session[$params['key']]) ? $this->_session[$params['key']] : null;
 		};
 	}
 
@@ -84,10 +81,8 @@ class Memory extends \lithium\core\Object {
 	 * @return \Closure Function returning boolean `true` on successful write, `false` otherwise.
 	 */
 	public function write($key, $value, array $options = array()) {
-		$session =& $this->_session;
-
-		return function($self, $params) use (&$session) {
-			return (boolean) ($session[$params['key']] = $params['value']);
+		return function($params) {
+			return (boolean) ($this->_session[$params['key']] = $params['value']);
 		};
 	}
 
@@ -99,11 +94,9 @@ class Memory extends \lithium\core\Object {
 	 * @return \Closure Function returning boolean `true` on successful delete, `false` otherwise
 	 */
 	public function delete($key, array $options = array()) {
-		$session =& $this->_session;
-
-		return function($self, $params) use (&$session) {
-			unset($session[$params['key']]);
-			return !isset($session[$params['key']]);
+		return function($params) {
+			unset($this->_session[$params['key']]);
+			return !isset($this->_session[$params['key']]);
 		};
 	}
 
@@ -114,10 +107,8 @@ class Memory extends \lithium\core\Object {
 	 * @return \Closure Function that clears the session
 	 */
 	public function clear(array $options = array()) {
-		$session =& $this->_session;
-
-		return function($self, $params) use (&$session) {
-			$session = array();
+		return function($params) {
+			$this->_session = array();
 		};
 	}
 

--- a/storage/session/adapter/Php.php
+++ b/storage/session/adapter/Php.php
@@ -133,7 +133,7 @@ class Php extends \lithium\core\Object {
 		if (!$this->isStarted() && !$this->_start()) {
 			throw new RuntimeException('Could not start session.');
 		}
-		return function($class, $params) {
+		return function($params) {
 			return Set::check($_SESSION, $params['key']);
 		};
 	}
@@ -150,7 +150,7 @@ class Php extends \lithium\core\Object {
 		if (!$this->isStarted() && !$this->_start()) {
 			throw new RuntimeException('Could not start session.');
 		}
-		return function($self, $params) {
+		return function($params) {
 			$key = $params['key'];
 
 			if (!$key) {
@@ -181,9 +181,8 @@ class Php extends \lithium\core\Object {
 		if (!$this->isStarted() && !$this->_start()) {
 			throw new RuntimeException('Could not start session.');
 		}
-		$self = $this;
-		return function($class, $params) use ($self) {
-			return $self->overwrite(
+		return function($params) {
+			return $this->overwrite(
 				$_SESSION, Set::insert($_SESSION, $params['key'], $params['value'])
 			);
 		};
@@ -201,10 +200,9 @@ class Php extends \lithium\core\Object {
 		if (!$this->isStarted() && !$this->_start()) {
 			throw new RuntimeException('Could not start session.');
 		}
-		$self = $this;
-		return function($class, $params) use ($self) {
+		return function($params) {
 			$key = $params['key'];
-			$self->overwrite($_SESSION, Set::remove($_SESSION, $key));
+			$this->overwrite($_SESSION, Set::remove($_SESSION, $key));
 			return !Set::check($_SESSION, $key);
 		};
 	}
@@ -219,7 +217,7 @@ class Php extends \lithium\core\Object {
 		if (!$this->isStarted() && !$this->_start()) {
 			throw new RuntimeException('Could not start session.');
 		}
-		return function($class, $params) {
+		return function($params) {
 			return session_destroy();
 		};
 	}

--- a/template/View.php
+++ b/template/View.php
@@ -8,6 +8,7 @@
 
 namespace lithium\template;
 
+use lithium\aop\Filters;
 use lithium\core\Libraries;
 use lithium\template\TemplateException;
 
@@ -389,11 +390,10 @@ class View extends \lithium\core\Object {
 			'renderer' => $_renderer
 		);
 
-		$filter = function($self, $params) {
+		$result = Filters::run($this, __FUNCTION__, $params, function($params) {
 			$template = $params['loader']->template($params['step']['path'], $params['params']);
 			return $params['renderer']->render($template, $params['data'], $params['options']);
-		};
-		$result = $this->_filter(__METHOD__, $params, $filter);
+		});
 
 		if (is_array($step['capture'])) {
 			switch (key($step['capture'])) {

--- a/template/helper/Html.php
+++ b/template/helper/Html.php
@@ -8,6 +8,8 @@
 
 namespace lithium\template\helper;
 
+use lithium\aop\Filters;
+
 /**
  * A template helper that assists in generating HTML content. Accessible in templates via
  * `$this->html`, which will auto-load this helper into the rendering context. For examples of how
@@ -185,8 +187,8 @@ class Html extends \lithium\template\Helper {
 		$m = __METHOD__;
 		$params = compact('path', 'options');
 
-		$script = $this->_filter(__METHOD__, $params, function($self, $params, $chain) use ($m) {
-			return $self->invokeMethod('_render', array($m, 'script', $params));
+		$script = Filters::run($this, __FUNCTION__, $params, function($params) use ($m) {
+			return $this->_render($m, 'script', $params);
 		});
 		if ($scope['inline']) {
 			return $script;
@@ -226,14 +228,14 @@ class Html extends \lithium\template\Helper {
 			}
 			return ($scope['inline']) ? join("\n\t", $path) . "\n" : null;
 		}
-		$method = __METHOD__;
+		$m = __METHOD__;
 		$type = $scope['type'];
 		$params = compact('type', 'path', 'options');
-		$filter = function($self, $params, $chain) use ($defaults, $method) {
+
+		$style = Filters::run($this, __FUNCTION__, $params, function($params) use ($m) {
 			$template = ($params['type'] === 'import') ? 'style-import' : 'style-link';
-			return $self->invokeMethod('_render', array($method, $template, $params));
-		};
-		$style = $this->_filter($method, $params, $filter);
+			return $this->_render($m, $template, $params);
+		});
 
 		if ($scope['inline']) {
 			return $style;
@@ -260,11 +262,11 @@ class Html extends \lithium\template\Helper {
 		if (!isset($this->_strings[$tag])) {
 			return null;
 		}
-		$method = __METHOD__;
-		$filter = function($self, $options, $chain) use ($method, $tag) {
-			return $self->invokeMethod('_render', array($method, $tag, $options));
-		};
-		$head = $this->_filter($method, $options, $filter);
+		$m = __METHOD__;
+
+		$head = Filters::run($this, __FUNCTION__, $options, function($params) use ($m, $tag) {
+			return $this->_render($m, $tag, $params);
+		});
 		if ($this->_context) {
 			$this->_context->head($head);
 		}
@@ -287,11 +289,12 @@ class Html extends \lithium\template\Helper {
 		$defaults = array('alt' => '');
 		$options += $defaults;
 		$path = is_array($path) ? $this->_context->url($path) : $path;
-		$params = compact('path', 'options');
-		$method = __METHOD__;
 
-		return $this->_filter($method, $params, function($self, $params, $chain) use ($method) {
-			return $self->invokeMethod('_render', array($method, 'image', $params));
+		$params = compact('path', 'options');
+		$m = __METHOD__;
+
+		return Filters::run($this, __FUNCTION__, $params, function($params) use ($m) {
+			return $this->_render($m, 'image', $params);
 		});
 	}
 

--- a/template/view/Renderer.php
+++ b/template/view/Renderer.php
@@ -9,6 +9,7 @@
 namespace lithium\template\view;
 
 use RuntimeException;
+use lithium\aop\Filters;
 use lithium\core\Libraries;
 use lithium\core\ClassNotFoundException;
 
@@ -262,20 +263,16 @@ abstract class Renderer extends \lithium\core\Object {
 	 * @filter
 	 */
 	public function __get($property) {
-		$context = $this->_context;
-		$helpers = $this->_helpers;
-
-		$filter = function($self, $params, $chain) use ($context, $helpers) {
+		return Filters::run($this, __FUNCTION__, compact('property'), function($params) {
 			$property = $params['property'];
 
 			foreach (array('context', 'helpers') as $key) {
-				if (isset(${$key}[$property])) {
-					return ${$key}[$property];
+				if (isset($this->{"_{$key}"}[$property])) {
+					return $this->{"_{$key}"}[$property];
 				}
 			}
-			return $self->helper($property);
-		};
-		return $this->_filter(__METHOD__, compact('property'), $filter);
+			return $this->helper($property);
+		});
 	}
 
 	/**

--- a/test/Controller.php
+++ b/test/Controller.php
@@ -8,6 +8,7 @@
 
 namespace lithium\test;
 
+use lithium\aop\Filters;
 use lithium\test\Dispatcher;
 use lithium\core\Libraries;
 use lithium\test\Group;
@@ -44,7 +45,7 @@ class Controller extends \lithium\core\Object {
 		$options += (array) $request->query + $defaults;
 		$params = compact('request', 'dispatchParams', 'options');
 
-		return $this->_filter(__METHOD__, $params, function($self, $params) {
+		return Filters::run($this, __FUNCTION__, $params, function($params) {
 			$request = $params['request'];
 			$options = $params['options'];
 			$params = $params['dispatchParams'];
@@ -56,9 +57,9 @@ class Controller extends \lithium\core\Object {
 				$options['title'] = 'All Tests';
 			}
 
-			$self->invokeMethod('_saveCtrlContext');
+			$this->_saveCtrlContext();
 			$report = Dispatcher::run($group, $options);
-			$self->invokeMethod('_restoreCtrlContext');
+			$this->_restoreCtrlContext();
 
 			$filters = Libraries::locate('test.filter');
 			$menu = Libraries::locate('tests', null, array(

--- a/test/Dispatcher.php
+++ b/test/Dispatcher.php
@@ -8,6 +8,7 @@
 
 namespace lithium\test;
 
+use lithium\aop\Filters;
 use lithium\util\Set;
 use lithium\core\Libraries;
 use lithium\core\Environment;
@@ -62,7 +63,7 @@ class Dispatcher extends \lithium\core\StaticObject {
 		$group = static::_group($items);
 		$report = static::_report($group, $options);
 
-		return static::_filter(__FUNCTION__, compact('report'), function($self, $params, $chain) {
+		return Filters::run(get_called_class(), __FUNCTION__, compact('report'), function($params) {
 			$environment = Environment::get();
 			Environment::set('test');
 

--- a/test/Integration.php
+++ b/test/Integration.php
@@ -8,6 +8,8 @@
 
 namespace lithium\test;
 
+use lithium\aop\Filters;
+
 /**
  * This is the base class for integration tests.
  *
@@ -28,12 +30,12 @@ class Integration extends \lithium\test\Unit {
 	protected function _init() {
 		parent::_init();
 
-		$this->applyFilter('run', function($self, $params, $chain) {
-			$before = $self->results();
+		Filters::apply($this, 'run', function($params, $next) {
+			$before = $this->results();
 
-			$chain->next($self, $params, $chain);
+			$next($params);
 
-			$after = $self->results();
+			$after = $this->results();
 
 			while (count($after) > count($before)) {
 				$result = array_pop($after);

--- a/test/Report.php
+++ b/test/Report.php
@@ -8,6 +8,7 @@
 
 namespace lithium\test;
 
+use lithium\aop\Filters;
 use lithium\core\Libraries;
 use lithium\util\Inflector;
 use lithium\core\ClassNotFoundException;
@@ -237,7 +238,7 @@ class Report extends \lithium\core\Object {
 		}
 		$params = compact('template', 'data', 'config');
 
-		return $this->_filter(__METHOD__, $params, function($self, $params, $chain) {
+		return Filters::run(__CLASS__, __FUNCTION__, $params, function($params) {
 			extract($params['data']);
 			ob_start();
 			include $params['template'];

--- a/test/Unit.php
+++ b/test/Unit.php
@@ -12,6 +12,7 @@ use Exception;
 use ErrorException;
 use ReflectionClass;
 use InvalidArgumentException;
+use lithium\aop\Filters;
 use lithium\util\Text;
 use lithium\core\Libraries;
 use lithium\util\Validator;
@@ -1604,13 +1605,13 @@ class Unit extends \lithium\core\Object {
 		}
 		$params = compact('options', 'method');
 
-		$passed = $this->_filter(__CLASS__ . '::run', $params, function($self, $params, $chain) {
+		$passed = Filters::run($this, 'run', $params, function($params) {
 			try {
 				$method = $params['method'];
 				$lineFlag = __LINE__ + 1;
-				$self->{$method}();
+				$this->{$method}();
 			} catch (Exception $e) {
-				$self->invokeMethod('_handleException', array($e));
+				$this->_handleException($e);
 			}
 		});
 

--- a/test/templates/stats.html.php
+++ b/test/templates/stats.html.php
@@ -15,7 +15,7 @@ $exceptions = (integer) $count['exceptions'] ?: 0;
 
 <?php foreach ((array) $stats['errors'] as $error): ?>
 	<?php if ($error['result'] == 'fail' || $error['result'] == 'exception'): ?>
-		<?php echo $self->render("{$error['result']}", compact('error')); ?>
+		<?php echo $this->render("{$error['result']}", compact('error')); ?>
 	<?php endif ?>
 <?php endforeach ?>
 

--- a/tests/cases/analysis/LoggerTest.php
+++ b/tests/cases/analysis/LoggerTest.php
@@ -200,7 +200,7 @@ class LoggerTest extends \lithium\test\Unit {
 	}
 
 	public function testRespondsToParentCall() {
-		$this->assertTrue(Logger::respondsTo('applyFilter'));
+		$this->assertTrue(Logger::respondsTo('invokeMethod'));
 		$this->assertFalse(Logger::respondsTo('fooBarBaz'));
 	}
 

--- a/tests/cases/analysis/logger/adapter/FileTest.php
+++ b/tests/cases/analysis/logger/adapter/FileTest.php
@@ -9,7 +9,6 @@
 namespace lithium\tests\cases\analysis\logger\adapter;
 
 use lithium\core\Libraries;
-use lithium\util\collection\Filters;
 use lithium\analysis\logger\adapter\File;
 
 class FileTest extends \lithium\test\Unit {
@@ -38,7 +37,7 @@ class FileTest extends \lithium\test\Unit {
 		$message = 'This is a debug message';
 		$function = $this->subject->write($priority, $message);
 		$now = date('Y-m-d H:i:s');
-		$function('lithium\analysis\Logger', compact('priority', 'message'), new Filters());
+		$function(compact('priority', 'message'));
 
 		$log = file_get_contents("{$this->path}/debug.log");
 		$this->assertEqual("{$now} This is a debug message\n", $log);
@@ -52,7 +51,7 @@ class FileTest extends \lithium\test\Unit {
 		$message = 'This is a debug message';
 		$function = $this->subject->write($priority, $message);
 		$now = date('Y-m-d H:i:s');
-		$function('lithium\analysis\Logger', compact('priority', 'message'), new Filters());
+		$function(compact('priority', 'message'));
 
 		$log = file_get_contents("{$this->path}/debug.log");
 		$this->assertEqual("This is a debug message\n", $log);

--- a/tests/cases/analysis/logger/adapter/GrowlTest.php
+++ b/tests/cases/analysis/logger/adapter/GrowlTest.php
@@ -32,7 +32,7 @@ class GrowlTest extends \lithium\test\Unit {
 		));
 		$writer = $growl->write('info', 'info: Test message.', array());
 		$params = array('message' => 'info: Test message.', 'options' => array());
-		$result = $writer('lithium\analysis\Logger', $params, null);
+		$result = $writer($params, null);
 
 		$bytes = array(
 			1, 0, 0, 7, 2, 2, 76, 105, 116, 104, 105, 117, 109, 0, 6, 69, 114, 114, 111, 114, 115,
@@ -60,7 +60,7 @@ class GrowlTest extends \lithium\test\Unit {
 			$params = compact('message') + array('priority' => 'info', 'options' => array());
 
 			$writer = $growl->write('info', $message, array());
-			$writer('lithium\analysis\Logger', $params, null);
+			$writer($params, null);
 		});
 	}
 
@@ -76,7 +76,7 @@ class GrowlTest extends \lithium\test\Unit {
 			$params = compact('message') + array('priority' => 'info', 'options' => array());
 
 			$writer = $growl->write('info', $message, array());
-			$writer('lithium\analysis\Logger', $params, null);
+			$writer($params, null);
 		});
 	}
 
@@ -89,7 +89,7 @@ class GrowlTest extends \lithium\test\Unit {
 		));
 		$writer = $growl->write('info', 'info: Test message.', array());
 		$params = array('message' => 'info: Test message.', 'options' => array('sticky' => true));
-		$result = $writer('lithium\analysis\Logger', $params, null);
+		$result = $writer($params, null);
 
 		$bytes = array(
 			1, 0, 0, 7, 2, 2, 76, 105, 116, 104, 105, 117, 109, 0, 6, 69, 114, 114, 111, 114, 115,
@@ -117,7 +117,7 @@ class GrowlTest extends \lithium\test\Unit {
 		$params = array('message' => 'info: Test message.', 'options' => array(
 			'priority' => 'emergency'
 		));
-		$result = $writer('lithium\analysis\Logger', $params, null);
+		$result = $writer($params, null);
 
 		$bytes = array(
 			1, 0, 0, 7, 2, 2, 76, 105, 116, 104, 105, 117, 109, 0, 6, 69, 114, 114, 111, 114, 115,

--- a/tests/cases/aop/ChainTest.php
+++ b/tests/cases/aop/ChainTest.php
@@ -1,0 +1,288 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2015, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\tests\cases\aop;
+
+use stdClass;
+use lithium\aop\Chain;
+
+class ChainTest extends \lithium\test\Unit {
+
+	public function testAllFiltersAreTriggeredInOrder() {
+		$message = null;
+
+		$subject = new Chain(array(
+			'class' => 'Foo',
+			'method' => 'bar',
+			'filters' => array(
+				function($params, $next) use (&$message) {
+					$message .= '1';
+					return $next($params);
+				},
+				function($params, $next) use (&$message) {
+					$message .= '2';
+					return $next($params);
+				}
+			)
+		));
+		$subject->run(array(), function($params) use (&$message) {
+			$message .= '3';
+		});
+		$this->assertEqual('123', $message);
+	}
+
+	public function testNoNextStopsFurtherFilters() {
+		$message = null;
+
+		$subject = new Chain(array(
+			'class' => 'Foo',
+			'method' => 'bar',
+			'filters' => array(
+				function($params, $next) use (&$message) {
+					$message .= '1';
+					return $next($params);
+				},
+				function($params, $next) use (&$message) {
+					$message .= '2';
+				}
+			)
+		));
+		$subject->run(array(), function($params) use (&$message) {
+			$message .= '3';
+		});
+		$this->assertEqual('12', $message);
+	}
+
+	public function testFilterWrappingInOut() {
+		$message = null;
+
+		$subject = new Chain(array(
+			'class' => 'Foo',
+			'method' => 'bar',
+			'filters' => array(
+				function($params, $next) use (&$message) {
+					$message .= ' 1BEFORE';
+					$result = $next($params);
+					$message .= ' 1AFTER';
+				},
+				function($params, $next) use (&$message) {
+					$message .= ' 2BEFORE';
+					$result = $next($params);
+					$message .= ' 2AFTER';
+				}
+			)
+		));
+		$subject->run(array(), function($params) use (&$message) {
+			$message .= ' 3BEFORE';
+			$message .= ' 3AFTER';
+		});
+		$this->assertEqual(' 1BEFORE 2BEFORE 3BEFORE 3AFTER 2AFTER 1AFTER', $message);
+	}
+
+	public function testRunReturnsReturnValueFromImplementation() {
+		$subject = new Chain(array(
+			'class' => 'Foo',
+			'method' => 'bar',
+			'filters' => array(
+				function($params, $next) {
+					return $next($params);
+				}
+			)
+		));
+		$result = $subject->run(array(), function($params) {
+			return 'foo';
+		});
+		$this->assertEqual('foo', $result);
+	}
+
+	public function testConsecutiveParamsManipulation() {
+		$subject = new Chain(array(
+			'class' => 'Foo',
+			'method' => 'bar',
+			'filters' => array(
+				function($params, $next) {
+					$params['message'] .= '1';
+					return $next($params);
+				},
+				function($params, $next) {
+					$params['message'] .= '2';
+					return $next($params);
+				}
+			)
+		));
+		$result = $subject->run(array('message' => null), function($params) {
+			$params['message'] .= '3';
+			return $params['message'];
+		});
+		$this->assertEqual('123', $result);
+
+		$subject = new Chain(array(
+			'class' => 'Foo',
+			'method' => 'bar',
+			'filters' => array(
+				function($params, $next) {
+					$params['message'] .= '1';
+					return $next($params);
+				},
+				function($params, $next) {
+					$params['message'] = null;
+					return $next($params);
+				}
+			)
+		));
+		$result = $subject->run(array('message' => null), function($params) {
+			$params['message'] .= '3';
+			return $params['message'];
+		});
+		$this->assertEqual('3', $result);
+	}
+
+	public function testObjectInParamsKeepsRef() {
+		$subject = new Chain(array(
+			'class' => 'Foo',
+			'method' => 'bar',
+			'filters' => array(
+				function($params, $next) {
+					$params['object']->foo = 'bar';
+					return $next($params);
+				}
+			)
+		));
+
+		$object = new stdClass();
+		$originalHash = spl_object_hash($object);
+
+		$result = $subject->run(array('object' => $object), function($params) {
+			return $params['object'];
+		});
+		$resultHash = spl_object_hash($result);
+
+		$this->assertEqual($originalHash, $resultHash);
+	}
+
+	/* Deprecated / BC */
+
+	public function testLegacyFiltersBasicSignature() {
+		error_reporting(($original = error_reporting()) & ~E_USER_DEPRECATED);
+
+		$subject = new Chain(array(
+			'class' => 'Foo',
+			'method' => 'bar',
+			'filters' => array(
+				function($self, $params, $chain) {
+					$params['body'] = compact('self', 'params', 'chain');
+					return $chain->next($self, $params, $chain);
+				}
+			)
+		));
+		$result = $subject->run(array('foo' => 'bar'), function($params) {
+			return $params['body'];
+		});
+
+		$this->assertEqual('Foo', $result['self']);
+		$this->assertEqual(array('foo' => 'bar'), $result['params']);
+		$this->assertInstanceOf('\lithium\aop\Chain', $result['chain']);
+
+		error_reporting($original);
+	}
+
+	public function testLegacyFiltersParamsModificationWithLegacyNext() {
+		error_reporting(($original = error_reporting()) & ~E_USER_DEPRECATED);
+
+		$subject = new Chain(array(
+			'class' => 'Foo',
+			'method' => 'bar',
+			'filters' => array(
+				function($self, $params, $chain) {
+					$params['foo'] .= 'baz';
+					return $chain->next($self, $params, $chain);
+				}
+			)
+		));
+		$result = $subject->run(array('foo' => 'bar'), function($params) {
+			return $params;
+		});
+		$this->assertEqual('barbaz', $result['foo']);
+
+		error_reporting($original);
+	}
+
+	public function testAccessingMethodMethodInsideFilterWithStaticObject() {
+		error_reporting(($original = error_reporting()) & ~E_USER_DEPRECATED);
+
+		$subject = new Chain(array(
+			'class' => 'Foo',
+			'method' => 'bar',
+			'filters' => array(
+				function($params, $chain) {
+					$params['result'] = $chain->method();
+					return $chain->next($params);
+				}
+			)
+		));
+		$result = $subject->run(array('result' => null), function($params) {
+			return $params['result'];
+		});
+		$this->assertEqual('bar', $result);
+
+		$subject = new Chain(array(
+			'class' => 'Foo',
+			'method' => 'bar',
+			'filters' => array(
+				function($params, $chain) {
+					$params['result'] = $chain->method(true);
+					return $chain->next($params);
+				}
+			)
+		));
+		$result = $subject->run(array('result' => null), function($params) {
+			return $params['result'];
+		});
+		$this->assertEqual('Foo::bar', $result);
+
+		error_reporting($original);
+	}
+
+	public function testAccessingMethodMethodInsideFilterWithInstance() {
+		error_reporting(($original = error_reporting()) & ~E_USER_DEPRECATED);
+
+		$subject = new Chain(array(
+			'class' => new stdClass(),
+			'method' => 'bar',
+			'filters' => array(
+				function($params, $chain) {
+					$params['result'] = $chain->method();
+					return $chain->next($params);
+				}
+			)
+		));
+		$result = $subject->run(array('result' => null), function($params) {
+			return $params['result'];
+		});
+		$this->assertEqual('bar', $result);
+
+		$subject = new Chain(array(
+			'class' => new stdClass(),
+			'method' => 'bar',
+			'filters' => array(
+				function($params, $chain) {
+					$params['result'] = $chain->method(true);
+					return $chain->next($params);
+				}
+			)
+		));
+		$result = $subject->run(array('result' => null), function($params) {
+			return $params['result'];
+		});
+		$this->assertEqual('stdClass::bar', $result);
+
+		error_reporting($original);
+	}
+}
+
+?>

--- a/tests/cases/aop/FiltersTest.php
+++ b/tests/cases/aop/FiltersTest.php
@@ -1,0 +1,459 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2015, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\tests\cases\aop;
+
+use lithium\aop\Filters;
+use lithium\tests\mocks\aop\MockInstanceFiltered;
+use lithium\tests\mocks\aop\MockStaticFiltered;
+use lithium\tests\mocks\aop\MockStaticFilteredSubclass;
+
+class FiltersTest extends \lithium\test\Unit {
+
+	public function tearDown() {
+		Filters::clear('foo\Bar');
+		Filters::clear('lithium\tests\mocks\aop\MockStaticFiltered');
+		Filters::clear('lithium\tests\mocks\aop\MockInstanceFiltered');
+	}
+
+	public function testApplyAndRun() {
+		$params = array('message' => 'This ');
+
+		Filters::apply('foo\Bar', __FUNCTION__, function($params, $next) {
+			$params['message'] .= 'is a filter chain ';
+			return $next($params);
+		});
+		Filters::apply('foo\Bar', __FUNCTION__, function($params, $next) {
+			$params['message'] .= 'in a method ';
+			return $next($params);
+		});
+		$result = Filters::run('foo\Bar', __FUNCTION__, $params, function($params) {
+			return $params['message'] . 'of the ' . get_class($this) . ' class.';
+		});
+
+		$expected = 'This is a filter chain in a method of the';
+		$expected .= ' lithium\tests\cases\aop\FiltersTest class.';
+		$this->assertEqual($expected, $result);
+	}
+
+	public function testApplyWithLeadingNamespaceBackslash() {
+		Filters::apply('\\' . 'foo\Bar', __FUNCTION__, function($params, $next) {
+			return $next($params) . 'bar';
+		});
+		$result = Filters::run('foo\Bar', __FUNCTION__, array(), function($params) {
+			return 'foo';
+		});
+		$this->assertEqual('foobar', $result);
+	}
+
+	public function testRunWithLeadingNamespaceBackslash() {
+		Filters::apply('foo\Bar', __FUNCTION__, function($params, $next) {
+			return $next($params) . 'bar';
+		});
+		$result = Filters::run('\\' . 'foo\Bar', __FUNCTION__, array(), function($params) {
+			return 'foo';
+		});
+		$this->assertEqual('foobar', $result);
+	}
+
+	public function testChainCachingRunAgain() {
+		$count = 0;
+
+		Filters::apply('foo\Bar', __FUNCTION__, function($params, $next) use (&$count) {
+			$count++;
+			return $next($params);
+		});
+		Filters::run('foo\Bar', __FUNCTION__, array(), function() {});
+		Filters::run('foo\Bar', __FUNCTION__, array(), function() {});
+		Filters::run('foo\Bar', __FUNCTION__, array(), function() {});
+
+		$this->assertEqual(3, $count);
+	}
+
+	public function testChainCachingRunAgainParamsDiffer() {
+		Filters::apply('foo\Bar', __FUNCTION__, function($params, $next) {
+			return $next($params);
+		});
+		$result = Filters::run('foo\Bar', __FUNCTION__, array('foo' => 'bar'), function($params) {
+			return $params;
+		});
+		$this->assertEqual(array('foo' => 'bar'), $result);
+
+		$result = Filters::run('foo\Bar', __FUNCTION__, array('foo' => 'baz'), function($params) {
+			return $params;
+		});
+		$this->assertEqual(array('foo' => 'baz'), $result);
+
+		$result = Filters::run('foo\Bar', __FUNCTION__, array('qux' => 'foo'), function($params) {
+			return $params;
+		});
+		$this->assertEqual(array('qux' => 'foo'), $result);
+	}
+
+	public function testDirectImplementationCall() {
+		$result = Filters::run('foo\Bar', __FUNCTION__, array('foo' => 'bar'), function() {
+			return true;
+		});
+		$this->assertTrue($result);
+	}
+
+	/**
+	 * Tests that calling a filter-able method with no filters added does not trigger an error.
+	 */
+	public function testNoFiltersOnFilterable() {
+		$class = 'lithium\tests\mocks\aop\MockStaticFiltered';
+
+		$result = MockStaticFiltered::method();
+		$expected = 'method';
+		$this->assertEqual($expected, $result);
+	}
+
+	public function testRunWithStatic() {
+		$class = 'lithium\tests\mocks\aop\MockStaticFiltered';
+
+		Filters::apply($class, 'method', function($params, $next) {
+			return $next($params) . '-filtered';
+		});
+
+		$expected = 'method-filtered';
+		$result = MockStaticFiltered::method();
+		$this->assertEqual($expected, $result);
+	}
+
+	public function testRunWithStaticAndTracing() {
+		$class = 'lithium\tests\mocks\aop\MockStaticFiltered';
+
+		$result = MockStaticFiltered::methodTracing(array('Starting test'));
+		$expected = array(
+			'Starting test',
+			'Starting outer method call',
+			"Inside method implementation of {$class}",
+			'Ending outer method call'
+		);
+		$this->assertEqual($expected, $result);
+
+		Filters::apply($class, 'methodTracing', function($params, $next) {
+			$params['trace'][] = 'Starting filter';
+			$result = $next($params);
+			$result[] = 'Ending filter';
+			return $result;
+		});
+
+		$result = $class::methodTracing(array('Starting test'));
+		$expected = array(
+			'Starting test',
+			'Starting outer method call',
+			'Starting filter',
+			"Inside method implementation of {$class}",
+			'Ending filter',
+			'Ending outer method call'
+		);
+		$this->assertEqual($expected, $result);
+
+		Filters::apply($class, 'methodTracing', function($params, $next) {
+			$params['trace'][] = 'Starting inner filter';
+			$result = $next($params);
+			$result[] = 'Ending inner filter';
+			return $result;
+		});
+		$result = $class::methodTracing(array('Starting test'));
+		$expected = array(
+			'Starting test',
+			'Starting outer method call',
+			'Starting filter',
+			'Starting inner filter',
+			"Inside method implementation of {$class}",
+			'Ending inner filter',
+			'Ending filter',
+			'Ending outer method call'
+		);
+		$this->assertEqual($expected, $result);
+	}
+
+	public function testRunWithInstance() {
+		$instance = new MockInstanceFiltered();
+
+		Filters::apply($instance, 'method', function($params, $next) {
+			return $next($params) . '-filtered';
+		});
+
+		$expected = 'method-filtered';
+		$result = $instance->method();
+		$this->assertEqual($expected, $result);
+
+		Filters::clear($instance);
+	}
+
+	public function testRunWithInstanceAndTracing() {
+		$instance = new MockInstanceFiltered();
+
+		$result = $instance->methodTracing(array('Starting test'));
+		$expected = array(
+			'Starting test',
+			'Starting outer method call',
+			"Inside method implementation",
+			'Ending outer method call'
+		);
+		$this->assertEqual($expected, $result);
+
+		Filters::apply($instance, 'methodTracing', function($params, $next) {
+			$params['trace'][] = 'Starting filter';
+			$result = $next($params);
+			$result[] = 'Ending filter';
+			return $result;
+		});
+
+		$result = $instance->methodTracing(array('Starting test'));
+		$expected = array(
+			'Starting test',
+			'Starting outer method call',
+			'Starting filter',
+			"Inside method implementation",
+			'Ending filter',
+			'Ending outer method call'
+		);
+		$this->assertEqual($expected, $result);
+
+		Filters::apply($instance, 'methodTracing', function($params, $next) {
+			$params['trace'][] = 'Starting inner filter';
+			$result = $next($params);
+			$result[] = 'Ending inner filter';
+			return $result;
+		});
+		$result = $instance->methodTracing(array('Starting test'));
+		$expected = array(
+			'Starting test',
+			'Starting outer method call',
+			'Starting filter',
+			'Starting inner filter',
+			"Inside method implementation",
+			'Ending inner filter',
+			'Ending filter',
+			'Ending outer method call'
+		);
+		$this->assertEqual($expected, $result);
+	}
+
+	public function testRunWithAllInstancesOf() {
+		$class = 'lithium\tests\mocks\aop\MockInstanceFiltered';
+		$instance = new MockInstanceFiltered();
+
+		Filters::apply($class, 'method', function($params, $next) {
+			return $next($params) . '-filtered';
+		});
+
+		$expected = 'method-filtered';
+		$result = $instance->method();
+		$this->assertEqual($expected, $result);
+
+		Filters::clear($instance);
+	}
+
+	public function testRunWithMixedOnInstanceOrderIsInstanceThenAll() {
+		$class = 'lithium\tests\mocks\aop\MockInstanceFiltered';
+		$instance = new MockInstanceFiltered();
+
+		Filters::apply($class, 'method', function($params, $next) {
+			return $next($params) . '-all';
+		});
+		Filters::apply($instance, 'method', function($params, $next) {
+			return $next($params) . '-instance';
+		});
+
+		$expected = 'method-instance-all';
+		$result = $instance->method();
+		$this->assertEqual($expected, $result);
+
+		Filters::clear($class);
+		Filters::clear($instance);
+
+		Filters::apply($instance, 'method', function($params, $next) {
+			return $next($params) . '-instance';
+		});
+		Filters::apply($class, 'method', function($params, $next) {
+			return $next($params) . '-all';
+		});
+
+		$expected = 'method-instance-all';
+		$result = $instance->method();
+		$this->assertEqual($expected, $result);
+
+		Filters::clear($instance);
+	}
+
+	public function testNotUniqueFiltersPerClassMethod() {
+		$filter = function($params, $next) {
+			return $next($params) . '-filtered';
+		};
+		Filters::apply('lithium\tests\mocks\aop\MockStaticFiltered', 'method', $filter);
+		Filters::apply('lithium\tests\mocks\aop\MockStaticFiltered', 'method', $filter);
+
+		$expected = 'method-filtered-filtered';
+		$result = MockStaticFiltered::method();
+		$this->assertEqual($expected, $result);
+	}
+
+	public function testClearStatic() {
+		$class = 'lithium\tests\mocks\aop\MockStaticFiltered';
+
+		Filters::apply($class, 'method', function($params, $next) {
+			return $next($params) . '-filtered';
+		});
+
+		Filters::clear($class, 'method');
+
+		$expected = 'method';
+		$result = MockStaticFiltered::method();
+		$this->assertEqual($expected, $result);
+
+		Filters::apply($class, 'method', function($params, $next) {
+			return $next($params) . '-filtered';
+		});
+
+		Filters::clear($class);
+
+		$expected = 'method';
+		$result = MockStaticFiltered::method();
+		$this->assertEqual($expected, $result);
+	}
+
+	public function testClearAnyInstance() {
+		$class = 'lithium\tests\mocks\aop\MockInstanceFiltered';
+		$instance = new MockInstanceFiltered();
+
+		Filters::apply($class, 'method', function($params, $next) {
+			return $next($params) . '-filtered';
+		});
+
+		Filters::clear($class, 'method');
+
+		$expected = 'method';
+		$result = $instance->method();
+		$this->assertEqual($expected, $result);
+
+		Filters::apply($class, 'method', function($params, $next) {
+			return $next($params) . '-filtered';
+		});
+
+		Filters::clear($class);
+
+		$expected = 'method';
+		$result = $instance->method();
+		$this->assertEqual($expected, $result);
+	}
+
+	public function testClearInstance() {
+		$instance = new MockInstanceFiltered();
+
+		Filters::apply($instance, 'method', function($params, $next) {
+			return $next($params) . '-filtered';
+		});
+
+		Filters::clear($instance, 'method');
+
+		$expected = 'method';
+		$result = $instance->method();
+		$this->assertEqual($expected, $result);
+
+		Filters::apply($instance, 'method', function($params, $next) {
+			return $next($params) . '-filtered';
+		});
+
+		Filters::clear($instance);
+
+		$expected = 'method';
+		$result = $instance->method();
+		$this->assertEqual($expected, $result);
+	}
+
+	public function testClearAnyInstanceAlsoClearsInstance() {
+		$class = 'lithium\tests\mocks\aop\MockInstanceFiltered';
+		$instance = new MockInstanceFiltered();
+
+		Filters::apply($instance, 'method', function($params, $next) {
+			return $next($params) . '-filtered';
+		});
+
+		Filters::clear($class);
+
+		$expected = 'method';
+		$result = $instance->method();
+		$this->assertEqual($expected, $result);
+	}
+
+	public function testClearInstanceDoesNotClearAnyInstance() {
+		$class = 'lithium\tests\mocks\aop\MockInstanceFiltered';
+		$instance = new MockInstanceFiltered();
+
+		Filters::apply($class, 'method', function($params, $next) {
+			return $next($params) . '-filtered';
+		});
+
+		Filters::clear($instance);
+
+		$expected = 'method-filtered';
+		$result = $instance->method();
+		$this->assertEqual($expected, $result);
+	}
+
+	public function testClearStaticClassAndMethodDoesNotClearAllMethods() {
+		$class = 'lithium\tests\mocks\aop\MockStaticFiltered';
+
+		Filters::apply($class, 'method', function($params, $next) {
+			return $next($params) . '-filtered';
+		});
+		Filters::apply($class, 'method2', function($params, $next) {
+			return $next($params) . '-filtered';
+		});
+
+		Filters::clear($class, 'method');
+
+		$expected = 'method';
+		$result = $class::method();
+		$this->assertEqual($expected, $result);
+
+		$expected = 'method2-filtered';
+		$result = $class::method2();
+		$this->assertEqual($expected, $result);
+	}
+
+	public function testHasApplied() {
+		$class = 'lithium\tests\mocks\aop\MockStaticFiltered';
+
+		$result = Filters::hasApplied($class, 'method');
+		$this->assertFalse($result);
+
+		Filters::apply($class, 'method', function($params, $next) {
+			return $next($params) . '-filtered';
+		});
+
+		$result = Filters::hasApplied($class, 'method');
+		$this->assertTrue($result);
+	}
+
+	/**
+	 * Tests that filtered methods in parent classes can call methods in subclasses.
+	 */
+	public function testCallingSubclassMethodsInFilteredMethods() {
+		$this->assertEqual('Working', MockStaticFilteredSubclass::callSubclassMethod());
+	}
+
+	/**
+	 * Verifies protected properties of an instance can be accesed and modified
+	 * within a filtered method.
+	 */
+	public function testFilteringWithProtectedAccess() {
+		$instance = new MockInstanceFiltered();
+
+		$this->assertEqual($instance->internal(), 'secret');
+		$this->assertTrue($instance->tamper());
+		$this->assertEqual($instance->internal(), 'tampered');
+	}
+}
+
+?>

--- a/tests/cases/core/AdaptableTest.php
+++ b/tests/cases/core/AdaptableTest.php
@@ -22,7 +22,7 @@ class AdaptableTest extends \lithium\test\Unit {
 
 		$items = array(array(
 			'adapter' => 'some\adapter',
-			'filters' => array('filter1', 'filter2')
+			'filters' => array()
 		));
 		$result = MockAdaptable::config($items);
 		$this->assertNull($result);
@@ -33,7 +33,7 @@ class AdaptableTest extends \lithium\test\Unit {
 
 		$items = array(array(
 			'adapter' => 'some\adapter',
-			'filters' => array('filter1', 'filter2')
+			'filters' => array()
 		));
 		MockAdaptable::config($items);
 		$result = MockAdaptable::config();
@@ -44,7 +44,7 @@ class AdaptableTest extends \lithium\test\Unit {
 	public function testReset() {
 		$items = array(array(
 			'adapter' => '\some\adapter',
-			'filters' => array('filter1', 'filter2')
+			'filters' => array()
 		));
 		MockAdaptable::config($items);
 		$result = MockAdaptable::config();
@@ -328,6 +328,49 @@ class AdaptableTest extends \lithium\test\Unit {
 		));
 		MockAdaptable::enabled('default');
 		$this->assertFalse(MockAdaptable::testInitialized('default'));
+	}
+
+	/* Deprecated / BC */
+
+	public function testDeprecatedConfig() {
+		error_reporting(($original = error_reporting()) & ~E_USER_DEPRECATED);
+
+		$items = array(array(
+			'adapter' => 'some\adapter',
+			'filters' => array('filter1', 'filter2')
+		));
+		$result = MockAdaptable::config($items);
+		$this->assertNull($result);
+
+		$expected = $items;
+		$result = MockAdaptable::config();
+		$this->assertEqual($expected, $result);
+
+		$items = array(array(
+			'adapter' => 'some\adapter',
+			'filters' => array('filter1', 'filter2')
+		));
+		MockAdaptable::config($items);
+		$result = MockAdaptable::config();
+		$expected = $items;
+		$this->assertEqual($expected, $result);
+
+		error_reporting($original);
+	}
+
+	public function testDeprecatedReset() {
+		error_reporting(($original = error_reporting()) & ~E_USER_DEPRECATED);
+
+		$items = array(array(
+			'adapter' => '\some\adapter',
+			'filters' => array('filter1', 'filter2')
+		));
+		MockAdaptable::config($items);
+		$result = MockAdaptable::config();
+		$expected = $items;
+		$this->assertEqual($expected, $result);
+
+		error_reporting($original);
 	}
 }
 

--- a/tests/cases/core/ErrorHandlerTest.php
+++ b/tests/cases/core/ErrorHandlerTest.php
@@ -12,6 +12,8 @@ use Closure;
 use Exception;
 use UnexpectedValueException;
 use lithium\core\ErrorHandler;
+use lithium\aop\Filters;
+use lithium\tests\mocks\core\MockStaticObject;
 use lithium\tests\mocks\core\MockErrorHandler;
 
 class ErrorHandlerTest extends \lithium\test\Unit {
@@ -103,18 +105,14 @@ class ErrorHandlerTest extends \lithium\test\Unit {
 	}
 
 	public function testApply() {
-		$subject = new ErrorHandlerTest();
-		ErrorHandler::apply(array($subject, 'throwException'), array(), function($details) {
+		$class = 'lithium\tests\mocks\core\MockStaticObject';
+
+		ErrorHandler::apply("{$class}::throwException", array(), function($details) {
 			return $details['exception']->getMessage();
 		});
-		$this->assertEqual('foo', $subject->throwException());
-	}
+		$this->assertEqual('foo', MockStaticObject::throwException());
 
-	public function throwException() {
-		return $this->_filter(__METHOD__, array(), function($self, $params) {
-			throw new Exception('foo');
-			return 'bar';
-		});
+		Filters::clear('lithium\tests\mocks\core\MockStaticObject');
 	}
 
 	public function testTrace() {
@@ -170,11 +168,12 @@ class ErrorHandlerTest extends \lithium\test\Unit {
 	}
 
 	public function testRenderedOutput() {
+		$class = 'lithium\tests\mocks\core\MockStaticObject';
+
 		ob_start();
 		echo 'Some Output';
-		$subject = new ErrorHandlerTest();
-		ErrorHandler::apply(array($subject, 'throwException'), array(), function($details) {});
-		$subject->throwException();
+		ErrorHandler::apply("{$class}::throwException", array(), function($details) {});
+		MockStaticObject::throwException();
 		$this->assertEmpty(ob_get_length());
 	}
 }

--- a/tests/cases/core/ObjectTest.php
+++ b/tests/cases/core/ObjectTest.php
@@ -8,6 +8,7 @@
 
 namespace lithium\tests\cases\core;
 
+use lithium\aop\Filters;
 use lithium\tests\mocks\core\MockRequest;
 use lithium\tests\mocks\core\MockMethodFiltering;
 use lithium\tests\mocks\core\MockExposed;
@@ -17,78 +18,6 @@ use lithium\tests\mocks\core\MockObjectConfiguration;
 use lithium\tests\mocks\core\MockInstantiator;
 
 class ObjectTest extends \lithium\test\Unit {
-
-	public function testMethodFiltering() {
-		$test = new MockMethodFiltering();
-		$result = $test->method(array('Starting test'));
-		$expected = array(
-			'Starting test',
-			'Starting outer method call',
-			'Inside method implementation',
-			'Ending outer method call'
-		);
-		$this->assertEqual($expected, $result);
-
-		$test->applyFilter('method', function($self, $params, $chain) {
-			$params['data'][] = 'Starting filter';
-			$result = $chain->next($self, $params, $chain);
-			$result[] = 'Ending filter';
-			return $result;
-		});
-
-		$result = $test->method(array('Starting test'));
-		$expected = array(
-			'Starting test',
-			'Starting outer method call',
-			'Starting filter',
-			'Inside method implementation',
-			'Ending filter',
-			'Ending outer method call'
-		);
-		$this->assertEqual($expected, $result);
-
-		$test->applyFilter('method', function($self, $params, $chain) {
-			$params['data'][] = 'Starting inner filter';
-			$result = $chain->next($self, $params, $chain);
-			$result[] = 'Ending inner filter';
-			return $result;
-		});
-		$result = $test->method(array('Starting test'));
-		$expected = array(
-			'Starting test',
-			'Starting outer method call',
-			'Starting filter',
-			'Starting inner filter',
-			'Inside method implementation',
-			'Ending inner filter',
-			'Ending filter',
-			'Ending outer method call'
-		);
-		$this->assertEqual($expected, $result);
-	}
-
-	/**
-	 * Verifies workaround for accessing protected properties in filtered methods.
-	 */
-	public function testFilteringWithProtectedAccess() {
-		$object = new MockExposed();
-		$this->assertEqual($object->get(), 'secret');
-		$this->assertTrue($object->tamper());
-		$this->assertEqual($object->get(), 'tampered');
-	}
-
-	/**
-	 * Attaches a single filter to multiple methods.
-	 */
-	public function testMultipleMethodFiltering() {
-		$object = new MockMethodFiltering();
-		$this->assertIdentical($object->method2(), array());
-
-		$object->applyFilter(array('method', 'method2'), function($self, $params, $chain) {
-			return $chain->next($self, $params, $chain);
-		});
-		$this->assertIdentical(array_keys($object->method2()), array('method', 'method2'));
-	}
 
 	/**
 	 * Tests that the correct parameters are always passed in Object::invokeMethod(), regardless of
@@ -215,7 +144,113 @@ class ObjectTest extends \lithium\test\Unit {
 		});
 	}
 
+	public function testRespondsTo() {
+		$obj = new MockRequest();
+		$this->assertTrue($this->respondsTo('get'));
+		$this->assertFalse($this->respondsTo('fooBarBaz'));
+	}
+
+	public function testRespondsToProtectedMethod() {
+		$obj = new MockRequest();
+		$this->assertFalse($obj->respondsTo('_parents'));
+		$this->assertTrue($obj->respondsTo('_parents', 1));
+	}
+
+	/* Deprecated / BC */
+
+	public function testMethodFiltering() {
+		error_reporting(($original = error_reporting()) & ~E_USER_DEPRECATED);
+
+		$test = new MockMethodFiltering();
+		$result = $test->method(array('Starting test'));
+		$expected = array(
+			'Starting test',
+			'Starting outer method call',
+			'Inside method implementation',
+			'Ending outer method call'
+		);
+		$this->assertEqual($expected, $result);
+
+		$test->applyFilter('method', function($self, $params, $chain) {
+			$params['data'][] = 'Starting filter';
+			$result = $chain->next($self, $params, $chain);
+			$result[] = 'Ending filter';
+			return $result;
+		});
+
+		$result = $test->method(array('Starting test'));
+		$expected = array(
+			'Starting test',
+			'Starting outer method call',
+			'Starting filter',
+			'Inside method implementation',
+			'Ending filter',
+			'Ending outer method call'
+		);
+		$this->assertEqual($expected, $result);
+
+		$test->applyFilter('method', function($self, $params, $chain) {
+			$params['data'][] = 'Starting inner filter';
+			$result = $chain->next($self, $params, $chain);
+			$result[] = 'Ending inner filter';
+			return $result;
+		});
+		$result = $test->method(array('Starting test'));
+		$expected = array(
+			'Starting test',
+			'Starting outer method call',
+			'Starting filter',
+			'Starting inner filter',
+			'Inside method implementation',
+			'Ending inner filter',
+			'Ending filter',
+			'Ending outer method call'
+		);
+		$this->assertEqual($expected, $result);
+
+		Filters::clear('lithium\tests\mocks\core\MockMethodFiltering');
+		error_reporting($original);
+	}
+
+	/**
+	 * Verifies workaround for accessing protected properties in filtered methods.
+	 */
+	public function testFilteringWithProtectedAccess() {
+		error_reporting(($original = error_reporting()) & ~E_USER_DEPRECATED);
+
+		$object = new MockExposed();
+		$this->assertEqual($object->get(), 'secret');
+		$this->assertTrue($object->tamper());
+		$this->assertEqual($object->get(), 'tampered');
+
+		error_reporting($original);
+	}
+
+	/**
+	 * Attaches a single filter to multiple methods.
+	 */
+	public function testMultipleMethodFiltering() {
+		error_reporting(($original = error_reporting()) & ~E_USER_DEPRECATED);
+
+		$object = new MockMethodFiltering();
+
+		$count = 0;
+		$object->applyFilter(array('method', 'method2'), function($s, $p, $c) use (&$count) {
+			$count++;
+			return $c->next($s, $p, $c);
+		});
+		$object->method(array('foo' => 'bar'));
+		$object->method2();
+
+		$this->assertIdentical(2, $count);
+
+		Filters::clear('lithium\tests\mocks\core\MockMethodFiltering');
+		error_reporting($original);
+	}
+
 	public function testResetMethodFilter() {
+		error_reporting(($original = error_reporting()) & ~E_USER_DEPRECATED);
+
 		$obj = new MockMethodFiltering();
 		$obj->applyFilter(false);
 		$obj->applyFilter('method2', function($self, $params, $chain) {
@@ -227,9 +262,14 @@ class ObjectTest extends \lithium\test\Unit {
 		$obj->applyFilter('method2', false);
 
 		$this->assertNotIdentical($obj->method2(), false);
+
+		Filters::clear('lithium\tests\mocks\core\MockMethodFiltering');
+		error_reporting($original);
 	}
 
 	public function testResetMultipleFilters() {
+		error_reporting(($original = error_reporting()) & ~E_USER_DEPRECATED);
+
 		$obj = new MockMethodFiltering();
 		$obj->applyFilter(false);
 		$obj->applyFilter(array('method2', 'manual'), function($self, $params, $chain) {
@@ -243,9 +283,14 @@ class ObjectTest extends \lithium\test\Unit {
 
 		$this->assertNotIdentical($obj->method2(), false);
 		$this->assertFalse($obj->manual(array()));
+
+		Filters::clear('lithium\tests\mocks\core\MockMethodFiltering');
+		error_reporting($original);
 	}
 
 	public function testResetClass() {
+		error_reporting(($original = error_reporting()) & ~E_USER_DEPRECATED);
+
 		$obj = new MockMethodFiltering();
 		$obj->applyFilter(false);
 		$obj->applyFilter(array('method2', 'manual'), function($self, $params, $chain) {
@@ -259,20 +304,10 @@ class ObjectTest extends \lithium\test\Unit {
 
 		$this->assertNotIdentical($obj->method2(), false);
 		$this->assertNotIdentical($obj->manual(array()), false);
-	}
 
-	public function testRespondsTo() {
-		$obj = new MockMethodFiltering();
-		$this->assertTrue($this->respondsTo('applyFilter'));
-		$this->assertFalse($this->respondsTo('fooBarBaz'));
+		Filters::clear('lithium\tests\mocks\core\MockMethodFiltering');
+		error_reporting($original);
 	}
-
-	public function testRespondsToProtectedMethod() {
-		$obj = new MockMethodFiltering();
-		$this->assertFalse($this->respondsTo('_parents'));
-		$this->assertTrue($this->respondsTo('_parents', 1));
-	}
-
 }
 
 ?>

--- a/tests/cases/core/StaticObjectTest.php
+++ b/tests/cases/core/StaticObjectTest.php
@@ -8,12 +8,100 @@
 
 namespace lithium\tests\cases\core;
 
+use lithium\aop\Filters;
 use lithium\tests\mocks\core\MockRequest;
 use lithium\tests\mocks\core\MockStaticInstantiator;
+use lithium\tests\mocks\core\MockStaticObject;
 
 class StaticObjectTest extends \lithium\test\Unit {
 
+	/**
+	 * Tests that the correct parameters are always passed in `StaticObject::invokeMethod()`,
+	 * regardless of the number.
+	 */
+	public function testMethodInvocationWithParameters() {
+		$this->assertEqual(MockStaticObject::invokeMethod('foo'), array());
+		$this->assertEqual(MockStaticObject::invokeMethod('foo', array('bar')), array('bar'));
+
+		$params = array('one', 'two');
+		$this->assertEqual(MockStaticObject::invokeMethod('foo', $params), $params);
+
+		$params = array('short', 'parameter', 'list');
+		$this->assertEqual(MockStaticObject::invokeMethod('foo', $params), $params);
+
+		$params = array('a', 'longer', 'parameter', 'list');
+		$this->assertEqual(MockStaticObject::invokeMethod('foo', $params), $params);
+
+		$params = array('a', 'much', 'longer', 'parameter', 'list');
+		$this->assertEqual(MockStaticObject::invokeMethod('foo', $params), $params);
+
+		$params = array('an', 'extremely', 'long', 'list', 'of', 'parameters');
+		$this->assertEqual(MockStaticObject::invokeMethod('foo', $params), $params);
+
+		$params = array('an', 'extremely', 'long', 'list', 'of', 'parameters');
+		$this->assertEqual(MockStaticObject::invokeMethod('foo', $params), $params);
+
+		$params = array(
+			'if', 'you', 'have', 'a', 'parameter', 'list', 'this',
+			'long', 'then', 'UR', 'DOIN', 'IT', 'RONG'
+		);
+		$this->assertEqual(MockStaticObject::invokeMethod('foo', $params), $params);
+	}
+
+	public function testClassParents() {
+		$class = 'lithium\tests\mocks\core\MockStaticObject';
+		$class::parents(null);
+
+		$result = $class::parents();
+		$expected = array('lithium\core\StaticObject' => 'lithium\core\StaticObject');
+		$this->assertEqual($expected, $result);
+
+		$cache = $class::parents(true);
+		$this->assertEqual(array($class => $expected), $cache);
+	}
+
+	public function testInstanceWithClassesKey() {
+		$expected = 'lithium\tests\mocks\core\MockRequest';
+		$result = get_class(MockStaticInstantiator::instance('request'));
+		$this->assertEqual($expected, $result);
+	}
+
+	public function testInstanceWithNamespacedClass() {
+		$expected = 'lithium\tests\mocks\core\MockRequest';
+		$result = get_class(MockStaticInstantiator::instance(
+			'lithium\tests\mocks\core\MockRequest'
+		));
+		$this->assertEqual($expected, $result);
+	}
+
+	public function testInstanceWithObject() {
+		$request = new MockRequest();
+		$expected = 'lithium\tests\mocks\core\MockRequest';
+		$result = get_class(MockStaticInstantiator::instance($request));
+		$this->assertEqual($expected, $result);
+	}
+
+	public function testInstanceFalse() {
+		$this->assertException('/^Invalid class lookup/', function() {
+			MockStaticInstantiator::instance(false);
+		});
+	}
+
+	public function testRespondsTo() {
+		$this->assertTrue(MockStaticInstantiator::respondsTo('applyFilter'));
+		$this->assertFalse(MockStaticInstantiator::respondsTo('fooBarBaz'));
+	}
+
+	public function testRespondsToProtectedMethod() {
+		$this->assertFalse(MockStaticInstantiator::respondsTo('_foo'));
+		$this->assertTrue(MockStaticInstantiator::respondsTo('_foo', 1));
+	}
+
+	/* Deprecated / BC */
+
 	public function testMethodFiltering() {
+		error_reporting(($original = error_reporting()) & ~E_USER_DEPRECATED);
+
 		$class = 'lithium\tests\mocks\core\MockStaticMethodFiltering';
 
 		$result = $class::method(array('Starting test'));
@@ -61,103 +149,43 @@ class StaticObjectTest extends \lithium\test\Unit {
 			'Ending outer method call'
 		);
 		$this->assertEqual($expected, $result);
-	}
 
-	/**
-	 * Tests that the correct parameters are always passed in `StaticObject::invokeMethod()`,
-	 * regardless of the number.
-	 */
-	public function testMethodInvocationWithParameters() {
-		$class = 'lithium\tests\mocks\core\MockStaticMethodFiltering';
-
-		$this->assertEqual($class::invokeMethod('foo'), array());
-		$this->assertEqual($class::invokeMethod('foo', array('bar')), array('bar'));
-
-		$params = array('one', 'two');
-		$this->assertEqual($class::invokeMethod('foo', $params), $params);
-
-		$params = array('short', 'parameter', 'list');
-		$this->assertEqual($class::invokeMethod('foo', $params), $params);
-
-		$params = array('a', 'longer', 'parameter', 'list');
-		$this->assertEqual($class::invokeMethod('foo', $params), $params);
-
-		$params = array('a', 'much', 'longer', 'parameter', 'list');
-		$this->assertEqual($class::invokeMethod('foo', $params), $params);
-
-		$params = array('an', 'extremely', 'long', 'list', 'of', 'parameters');
-		$this->assertEqual($class::invokeMethod('foo', $params), $params);
-
-		$params = array('an', 'extremely', 'long', 'list', 'of', 'parameters');
-		$this->assertEqual($class::invokeMethod('foo', $params), $params);
-
-		$params = array(
-			'if', 'you', 'have', 'a', 'parameter', 'list', 'this',
-			'long', 'then', 'UR', 'DOIN', 'IT', 'RONG'
-		);
-		$this->assertEqual($class::invokeMethod('foo', $params), $params);
+		Filters::clear('lithium\tests\mocks\core\MockStaticMethodFiltering');
+		error_reporting($original);
 	}
 
 	/**
 	 * Tests that calling a filter-able method with no filters added does not trigger an error.
 	 */
 	public function testCallingUnfilteredMethods() {
+		error_reporting(($original = error_reporting()) & ~E_USER_DEPRECATED);
+
 		$class = 'lithium\tests\mocks\core\MockStaticMethodFiltering';
 		$result = $class::manual(array(function($self, $params, $chain) {
 			return '-' . $chain->next($self, $params, $chain) . '-';
 		}));
 		$expected = '-Working-';
 		$this->assertEqual($expected, $result);
+
+		Filters::clear('lithium\tests\mocks\core\MockStaticMethodFiltering');
+		error_reporting($original);
 	}
 
 	/**
 	 * Tests that filtered methods in parent classes can call methods in subclasses.
 	 */
 	public function testCallingSubclassMethodsInFilteredMethods() {
+		error_reporting(($original = error_reporting()) & ~E_USER_DEPRECATED);
+
 		$class = 'lithium\tests\mocks\core\MockStaticFilteringExtended';
 		$this->assertEqual('Working', $class::callSubclassMethod());
-	}
 
-	public function testClassParents() {
-		$class = 'lithium\tests\mocks\core\MockStaticMethodFiltering';
-		$class::parents(null);
-
-		$result = $class::parents();
-		$expected = array('lithium\core\StaticObject' => 'lithium\core\StaticObject');
-		$this->assertEqual($expected, $result);
-
-		$cache = $class::parents(true);
-		$this->assertEqual(array($class => $expected), $cache);
-	}
-
-	public function testInstanceWithClassesKey() {
-		$expected = 'lithium\tests\mocks\core\MockRequest';
-		$result = get_class(MockStaticInstantiator::instance('request'));
-		$this->assertEqual($expected, $result);
-	}
-
-	public function testInstanceWithNamespacedClass() {
-		$expected = 'lithium\tests\mocks\core\MockRequest';
-		$result = get_class(MockStaticInstantiator::instance(
-			'lithium\tests\mocks\core\MockRequest'
-		));
-		$this->assertEqual($expected, $result);
-	}
-
-	public function testInstanceWithObject() {
-		$request = new MockRequest();
-		$expected = 'lithium\tests\mocks\core\MockRequest';
-		$result = get_class(MockStaticInstantiator::instance($request));
-		$this->assertEqual($expected, $result);
-	}
-
-	public function testInstanceFalse() {
-		$this->assertException('/^Invalid class lookup/', function() {
-			MockStaticInstantiator::instance(false);
-		});
+		error_reporting($original);
 	}
 
 	public function testResetMethodFilter() {
+		error_reporting(($original = error_reporting()) & ~E_USER_DEPRECATED);
+
 		$class = 'lithium\tests\mocks\core\MockStaticMethodFiltering';
 		$class::applyFilter(false);
 		$class::applyFilter('method2', function($self, $params, $chain) {
@@ -169,9 +197,14 @@ class StaticObjectTest extends \lithium\test\Unit {
 		$class::applyFilter('method2', false);
 
 		$this->assertNotIdentical($class::method2(), false);
+
+		Filters::clear('lithium\tests\mocks\core\MockStaticMethodFiltering');
+		error_reporting($original);
 	}
 
 	public function testResetMultipleFilters() {
+		error_reporting(($original = error_reporting()) & ~E_USER_DEPRECATED);
+
 		$class = 'lithium\tests\mocks\core\MockStaticMethodFiltering';
 		$class::applyFilter(false);
 		$class::applyFilter(array('method2', 'manual'), function($self, $params, $chain) {
@@ -185,9 +218,14 @@ class StaticObjectTest extends \lithium\test\Unit {
 
 		$this->assertNotIdentical($class::method2(), false);
 		$this->assertFalse($class::manual(array()));
+
+		Filters::clear('lithium\tests\mocks\core\MockStaticMethodFiltering');
+		error_reporting($original);
 	}
 
-	public function testResetClass() {
+	public function testResetFiltersInClass() {
+		error_reporting(($original = error_reporting()) & ~E_USER_DEPRECATED);
+
 		$class = 'lithium\tests\mocks\core\MockStaticMethodFiltering';
 		$class::applyFilter(false);
 		$class::applyFilter(array('method2', 'manual'), function($self, $params, $chain) {
@@ -201,18 +239,10 @@ class StaticObjectTest extends \lithium\test\Unit {
 
 		$this->assertNotIdentical($class::method2(), false);
 		$this->assertNotIdentical($class::manual(array()), false);
-	}
 
-	public function testRespondsTo() {
-		$this->assertTrue(MockStaticInstantiator::respondsTo('applyFilter'));
-		$this->assertFalse(MockStaticInstantiator::respondsTo('fooBarBaz'));
+		Filters::clear('lithium\tests\mocks\core\MockStaticMethodFiltering');
+		error_reporting($original);
 	}
-
-	public function testRespondsToProtectedMethod() {
-		$this->assertFalse(MockStaticInstantiator::respondsTo('_foo'));
-		$this->assertTrue(MockStaticInstantiator::respondsTo('_foo', 1));
-	}
-
 }
 
 ?>

--- a/tests/cases/data/EntityTest.php
+++ b/tests/cases/data/EntityTest.php
@@ -277,7 +277,7 @@ class EntityTest extends \lithium\test\Unit {
 		$data = array('foo' => true);
 		$entity = new Entity(compact('model', 'data'));
 
-		$this->assertTrue($entity->respondsTo('applyFilter'));
+		$this->assertTrue($entity->respondsTo('invokeMethod'));
 		$this->assertFalse($entity->respondsTo('fooBarBaz'));
 	}
 

--- a/tests/cases/data/ModelTest.php
+++ b/tests/cases/data/ModelTest.php
@@ -8,6 +8,7 @@
 
 namespace lithium\tests\cases\data;
 
+use lithium\aop\Filters;
 use lithium\data\model\Query;
 use stdClass;
 use lithium\util\Inflector;
@@ -57,13 +58,20 @@ class ModelTest extends \lithium\test\Unit {
 	public function tearDown() {
 		Connections::remove('mocksource');
 		Connections::remove('mockconn');
-		MockPost::reset();
-		MockTag::reset();
-		MockComment::reset();
-		MockCreator::reset();
-		MockSubProduct::reset();
-		MockProduct::reset();
-		MockPostForValidates::reset();
+
+		$models = array(
+			'lithium\tests\mocks\data\MockPost',
+			'lithium\tests\mocks\data\MockTag',
+			'lithium\tests\mocks\data\MockComment',
+			'lithium\tests\mocks\data\MockCreator',
+			'lithium\tests\mocks\data\MockSubProduct',
+			'lithium\tests\mocks\data\MockProduct',
+			'lithium\tests\mocks\data\MockPostForValidates'
+		);
+		foreach ($models as $model) {
+			$model::reset();
+			Filters::clear($model);
+		}
 	}
 
 	public function testOverrideMeta() {
@@ -393,10 +401,9 @@ class ModelTest extends \lithium\test\Unit {
 		$this->assertInternalType('array', $result);
 	}
 
-	public function testFilteredFind() {
-		MockComment::applyFilter('find', function($self, $params, $chain) {
-			$result = $chain->next($self, $params, $chain);
-
+	public function testFilteredFindInvokedMagically() {
+		Filters::apply('lithium\tests\mocks\data\MockComment', 'find', function($params, $next) {
+			$result = $next($params);
 			if ($result !== null) {
 				$result->filtered = true;
 			}
@@ -1127,7 +1134,7 @@ class ModelTest extends \lithium\test\Unit {
 	}
 
 	public function testRespondsToParentCall() {
-		$this->assertTrue(MockPost::respondsTo('applyFilter'));
+		$this->assertTrue(MockPost::respondsTo('invokeMethod'));
 		$this->assertFalse(MockPost::respondsTo('fooBarBaz'));
 	}
 

--- a/tests/cases/data/source/HttpTest.php
+++ b/tests/cases/data/source/HttpTest.php
@@ -349,10 +349,9 @@ class HttpTest extends \lithium\test\Unit {
 
 	public function testRespondsToParentCall() {
 		$http = new Http();
-		$this->assertTrue($http->respondsTo('applyFilter'));
+		$this->assertTrue($http->respondsTo('invokeMethod'));
 		$this->assertFalse($http->respondsTo('fooBarBaz'));
 	}
-
 }
 
 ?>

--- a/tests/cases/data/source/MongoDbTest.php
+++ b/tests/cases/data/source/MongoDbTest.php
@@ -1073,7 +1073,7 @@ class MongoDbTest extends \lithium\test\Unit {
 
 	public function testRespondsToParentCall() {
 		$db = new MongoDb($this->_testConfig);
-		$this->assertTrue($db->respondsTo('applyFilter'));
+		$this->assertTrue($db->respondsTo('_parents'));
 		$this->assertFalse($db->respondsTo('fooBarBaz'));
 	}
 

--- a/tests/cases/g11n/LocaleTest.php
+++ b/tests/cases/g11n/LocaleTest.php
@@ -492,7 +492,7 @@ class LocaleTest extends \lithium\test\Unit {
 	}
 
 	public function testRespondsToParentCall() {
-		$this->assertTrue(Locale::respondsTo('applyFilter'));
+		$this->assertTrue(Locale::respondsTo('invokeMethod'));
 		$this->assertFalse(Locale::respondsTo('fooBarBaz'));
 	}
 

--- a/tests/cases/storage/CacheTest.php
+++ b/tests/cases/storage/CacheTest.php
@@ -47,7 +47,7 @@ class CacheTest extends \lithium\test\Unit {
 
 		$config = array('default' => array(
 			'adapter' => '\some\adapter',
-			'filters' => array('Filter1', 'Filter2')
+			'filters' => array()
 		));
 		Cache::config($config);
 		$result = Cache::config();

--- a/tests/cases/storage/SessionTest.php
+++ b/tests/cases/storage/SessionTest.php
@@ -8,6 +8,7 @@
 
 namespace lithium\tests\cases\storage;
 
+use lithium\aop\Filters;
 use lithium\storage\Session;
 use lithium\storage\session\adapter\Memory;
 use lithium\tests\mocks\storage\session\adapter\SessionStorageConditional;
@@ -197,8 +198,8 @@ class SessionTest extends \lithium\test\Unit {
 			'primary' => array('adapter' => new Memory(), 'filters' => array()),
 			'secondary' => array('adapter' => new Memory(), 'filters' => array())
 		));
-		Session::applyFilter('read', function($self, $params, $chain) {
-			$result = $chain->next($self, $params, $chain);
+		Filters::apply('lithium\storage\Session', 'read', function($params, $next) {
+			$result = $next($params);
 
 			if (isset($params['options']['increment'])) {
 				$result += $params['options']['increment'];
@@ -210,6 +211,8 @@ class SessionTest extends \lithium\test\Unit {
 
 		Session::write('bar', 1);
 		$this->assertEqual(2, Session::read('bar', array('increment' => 1)));
+
+		Filters::clear('lithium\storage\Session');
 	}
 
 	public function testStrategies() {

--- a/tests/cases/storage/session/adapter/CookieTest.php
+++ b/tests/cases/storage/session/adapter/CookieTest.php
@@ -74,7 +74,7 @@ class CookieTest extends \lithium\test\Unit {
 		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'value');
-		$result = $closure($this->cookie, $params, null);
+		$result = $closure($params, null);
 
 		$this->assertCookie(compact('key', 'value', 'expires', 'path'));
 	}
@@ -97,7 +97,7 @@ class CookieTest extends \lithium\test\Unit {
 		$closure = $this->cookie->write($key, $value);
 		$this->assertInternalType('callable', $closure);
 		$params = compact('key', 'value');
-		$result = $closure($this->cookie, $params, null);
+		$result = $closure($params, null);
 
 		$expected = compact('expires');
 		$expected += array('key' => 'user.email', 'value' => 'test@localhost');
@@ -117,10 +117,10 @@ class CookieTest extends \lithium\test\Unit {
 		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
-		$result = $closure($this->cookie, $params, null);
+		$result = $closure($params, null);
 		$this->assertEqual($value, $result);
 
-		$result = $closure($this->cookie, array('key' => null), null);
+		$result = $closure(array('key' => null), null);
 		$this->assertEqual($_COOKIE[$this->name], $result);
 
 		$key = 'does.not.exist';
@@ -128,7 +128,7 @@ class CookieTest extends \lithium\test\Unit {
 		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
-		$result = $closure($this->cookie, $params, null);
+		$result = $closure($params, null);
 		$this->assertNull($result);
 
 	}
@@ -144,7 +144,7 @@ class CookieTest extends \lithium\test\Unit {
 		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'value', 'options');
-		$result = $closure($this->cookie, $params, null);
+		$result = $closure($params, null);
 
 		$this->assertCookie(compact('key', 'value', 'expires', 'path'));
 	}
@@ -158,10 +158,10 @@ class CookieTest extends \lithium\test\Unit {
 		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
-		$result = $closure($this->cookie, $params, null);
+		$result = $closure($params, null);
 		$this->assertEqual($value, $result);
 
-		$result = $closure($this->cookie, array('key' => null), null);
+		$result = $closure(array('key' => null), null);
 		$this->assertEqual($_COOKIE[$this->name], $result);
 
 		$key = 'does_not_exist';
@@ -169,7 +169,7 @@ class CookieTest extends \lithium\test\Unit {
 		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
-		$result = $closure($this->cookie, $params, null);
+		$result = $closure($params, null);
 		$this->assertNull($result);
 	}
 
@@ -182,7 +182,7 @@ class CookieTest extends \lithium\test\Unit {
 		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
-		$result = $closure($this->cookie, $params, null);
+		$result = $closure($params, null);
 		$this->assertTrue($result);
 
 		$key = 'does_not_exist';
@@ -190,7 +190,7 @@ class CookieTest extends \lithium\test\Unit {
 		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
-		$result = $closure($this->cookie, $params, null);
+		$result = $closure($params, null);
 		$this->assertFalse($result);
 	}
 
@@ -203,14 +203,14 @@ class CookieTest extends \lithium\test\Unit {
 		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
-		$result = $closure($this->cookie, $params, null);
+		$result = $closure($params, null);
 		$this->assertTrue($result);
 
 		$closure = $this->cookie->clear();
 		$this->assertInternalType('callable', $closure);
 
 		$params = array();
-		$result = $closure($this->cookie, $params, null);
+		$result = $closure($params, null);
 		$this->assertTrue($result);
 		$this->assertNoCookie(compact('key', 'value'));
 
@@ -225,7 +225,7 @@ class CookieTest extends \lithium\test\Unit {
 		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
-		$result = $closure($this->cookie, $params, null);
+		$result = $closure($params, null);
 		$this->assertTrue($result);
 
 		$expected = array('key' => 'user.name', 'value' => 'deleted');
@@ -244,7 +244,7 @@ class CookieTest extends \lithium\test\Unit {
 		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
-		$result = $closure($this->cookie, $params, null);
+		$result = $closure($params, null);
 		$this->assertTrue($result);
 		$this->assertCookie(compact('key', 'value', 'path'));
 	}

--- a/tests/cases/storage/session/adapter/MemoryTest.php
+++ b/tests/cases/storage/session/adapter/MemoryTest.php
@@ -70,7 +70,7 @@ class MemoryTest extends \lithium\test\Unit {
 		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
-		$result = $closure($this->Memory, $params, null);
+		$result = $closure($params, null);
 
 		$this->assertIdentical($value, $result);
 
@@ -79,13 +79,13 @@ class MemoryTest extends \lithium\test\Unit {
 		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
-		$result = $closure($this->Memory, $params, null);
+		$result = $closure($params, null);
 		$this->assertNull($result);
 
 		$closure = $this->Memory->read();
 		$this->assertInternalType('callable', $closure);
 
-		$result = $closure($this->Memory, array('key' => null), null);
+		$result = $closure(array('key' => null), null);
 		$expected = array('read_test' => 'value to be read');
 		$this->assertEqual($expected, $result);
 	}
@@ -101,7 +101,7 @@ class MemoryTest extends \lithium\test\Unit {
 		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'value');
-		$result = $closure($this->Memory, $params, null);
+		$result = $closure($params, null);
 		$this->assertEqual($this->Memory->_session[$key], $value);
 	}
 
@@ -119,7 +119,7 @@ class MemoryTest extends \lithium\test\Unit {
 		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
-		$result = $closure($this->Memory, $params, null);
+		$result = $closure($params, null);
 		$this->assertTrue($result);
 
 		$key = 'does_not_exist';
@@ -127,7 +127,7 @@ class MemoryTest extends \lithium\test\Unit {
 		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
-		$result = $closure($this->Memory, $params, null);
+		$result = $closure($params, null);
 		$this->assertFalse($result);
 	}
 
@@ -146,7 +146,7 @@ class MemoryTest extends \lithium\test\Unit {
 		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
-		$result = $closure($this->Memory, $params, null);
+		$result = $closure($params, null);
 		$this->assertTrue($result);
 
 		$key = 'non-existent';
@@ -154,7 +154,7 @@ class MemoryTest extends \lithium\test\Unit {
 		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
-		$result = $closure($this->Memory, $params, null);
+		$result = $closure($params, null);
 		$this->assertTrue($result);
 	}
 
@@ -165,7 +165,7 @@ class MemoryTest extends \lithium\test\Unit {
 		$this->Memory->_session['foobar'] = 'foo';
 		$closure = $this->Memory->clear();
 		$this->assertInternalType('callable', $closure);
-		$result = $closure($this->Memory, array(), null);
+		$result = $closure(array(), null);
 		$this->assertEmpty($this->Memory->_session);
 	}
 }

--- a/tests/cases/storage/session/adapter/PhpTest.php
+++ b/tests/cases/storage/session/adapter/PhpTest.php
@@ -148,7 +148,7 @@ class PhpTest extends \lithium\test\Unit {
 		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'value');
-		$result = $closure($this->php, $params, null);
+		$result = $closure($params, null);
 
 		$this->assertEqual($_SESSION[$key], $value);
 	}
@@ -165,7 +165,7 @@ class PhpTest extends \lithium\test\Unit {
 		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
-		$result = $closure($this->php, $params, null);
+		$result = $closure($params, null);
 
 		$this->assertIdentical($value, $result);
 
@@ -174,13 +174,13 @@ class PhpTest extends \lithium\test\Unit {
 		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
-		$result = $closure($this->php, $params, null);
+		$result = $closure($params, null);
 		$this->assertNull($result);
 
 		$closure = $this->php->read();
 		$this->assertInternalType('callable', $closure);
 
-		$result = $closure($this->php, array('key' => null), null);
+		$result = $closure(array('key' => null), null);
 		$expected = array('read_test' => 'value to be read');
 		$this->assertEqual($expected, $result);
 	}
@@ -196,7 +196,7 @@ class PhpTest extends \lithium\test\Unit {
 		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
-		$result = $closure($this->php, $params, null);
+		$result = $closure($params, null);
 		$this->assertTrue($result);
 
 		$key = 'does_not_exist';
@@ -204,7 +204,7 @@ class PhpTest extends \lithium\test\Unit {
 		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
-		$result = $closure($this->php, $params, null);
+		$result = $closure($params, null);
 		$this->assertFalse($result);
 	}
 
@@ -220,7 +220,7 @@ class PhpTest extends \lithium\test\Unit {
 		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
-		$result = $closure($this->php, $params, null);
+		$result = $closure($params, null);
 		$this->assertTrue($result);
 
 		$key = 'non-existent';
@@ -228,7 +228,7 @@ class PhpTest extends \lithium\test\Unit {
 		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
-		$result = $closure($this->php, $params, null);
+		$result = $closure($params, null);
 		$this->assertTrue($result);
 	}
 
@@ -240,7 +240,7 @@ class PhpTest extends \lithium\test\Unit {
 		$this->assertNotEmpty($_SESSION);
 		$closure = $this->php->clear();
 		$this->assertInternalType('callable', $closure);
-		$result = $closure($this->php, array(), null);
+		$result = $closure(array(), null);
 		$this->assertEmpty($_SESSION);
 	}
 
@@ -284,12 +284,12 @@ class PhpTest extends \lithium\test\Unit {
 		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key');
-		$result = $closure($this->php, $params, null);
+		$result = $closure($params, null);
 
 		$this->assertIdentical($value, $result);
 
 		$params = array('key' => 'dot.syntax');
-		$result = $closure($this->php, $params, null);
+		$result = $closure($params, null);
 
 		$this->assertIdentical($value['syntax'], $result);
 	}
@@ -302,7 +302,7 @@ class PhpTest extends \lithium\test\Unit {
 		$this->assertInternalType('callable', $closure);
 
 		$params = compact('key', 'value');
-		$result = $closure($this->php, $params, null);
+		$result = $closure($params, null);
 
 		$this->assertEqual($_SESSION['dot']['syntax'], $value);
 	}

--- a/tests/cases/template/helper/SecurityTest.php
+++ b/tests/cases/template/helper/SecurityTest.php
@@ -8,6 +8,7 @@
 
 namespace lithium\tests\cases\template\helper;
 
+use lithium\aop\Filters;
 use lithium\action\Request;
 use lithium\template\helper\Form;
 use lithium\template\helper\Security;
@@ -19,6 +20,10 @@ class SecurityTest extends \lithium\test\Unit {
 	public $subject;
 
 	public $context;
+
+	public function tearDown() {
+		Filters::clear('lithium\template\helper\Form');
+	}
 
 	public static function key($token) {
 		return 'WORKING';

--- a/tests/cases/test/UnitTest.php
+++ b/tests/cases/test/UnitTest.php
@@ -880,8 +880,8 @@ class UnitTest extends \lithium\test\Unit {
 		$this->assertEqual(array(
 			'expected' => 'foobar',
 			'result' => array(
-				new \ReflectionProperty('lithium\core\StaticObject', '_methodFilters'),
-				new \ReflectionProperty('lithium\core\StaticObject', '_parents')
+				new \ReflectionProperty('lithium\core\StaticObject', '_parents'),
+				new \ReflectionProperty('lithium\core\StaticObject', '_methodFilters')
 			)
 		), $result['data']);
 	}
@@ -914,8 +914,8 @@ class UnitTest extends \lithium\test\Unit {
 		$this->assertEqual(array(
 			'expected' => '_methodFilters',
 			'result' => array(
-				new \ReflectionProperty('lithium\core\StaticObject', '_methodFilters'),
-				new \ReflectionProperty('lithium\core\StaticObject', '_parents')
+				new \ReflectionProperty('lithium\core\StaticObject', '_parents'),
+				new \ReflectionProperty('lithium\core\StaticObject', '_methodFilters')
 			)
 		), $result['data']);
 	}

--- a/tests/cases/test/filter/ComplexityTest.php
+++ b/tests/cases/test/filter/ComplexityTest.php
@@ -8,6 +8,7 @@
 
 namespace lithium\tests\cases\test\filter;
 
+use lithium\aop\Filters;
 use lithium\test\filter\Complexity;
 use lithium\test\Group;
 use lithium\test\Report;
@@ -34,13 +35,13 @@ class ComplexityTest extends \lithium\test\Unit {
 	 * Helper array which stores the expected results to clean up the tests.
 	 */
 	protected $_metrics = array(
-		'applyFilter' => 5,
 		'invokeMethod' => 7,
 		'respondsTo' => 1,
 		'_instance' => 2,
-		'_filter' => 3,
 		'_parents' => 2,
-		'_stop' => 1
+		'_stop' => 1,
+		'applyFilter' => 4,
+		'_filter' => 3
 	);
 
 	/**
@@ -64,9 +65,12 @@ class ComplexityTest extends \lithium\test\Unit {
 		$this->report->group = $group;
 
 		Complexity::apply($this->report, $group->tests());
+
 		$results = array_pop($this->report->results['filters'][$this->_paths['complexity']]);
 		$expected = array($this->_paths['testClass'] => $this->_metrics);
 		$this->assertEqual($expected, $results);
+
+		Filters::clear($group);
 	}
 
 	/**
@@ -83,7 +87,7 @@ class ComplexityTest extends \lithium\test\Unit {
 		Complexity::apply($this->report, $group->tests());
 
 		$results = Complexity::analyze($this->report);
-		$expected = array('class' => array($this->_paths['testClass'] => 3.0));
+		$expected = array('class' => array($this->_paths['testClass'] => 2.8999999999999999));
 		foreach ($this->_metrics as $method => $metric) {
 			$expected['max'][$this->_paths['testClass'] . '::' . $method . '()'] = $metric;
 		}

--- a/tests/cases/util/CollectionTest.php
+++ b/tests/cases/util/CollectionTest.php
@@ -447,7 +447,7 @@ class CollectionTest extends \lithium\test\Unit {
 
 	public function testRespondsToParent() {
 		$collection = new Collection();
-		$this->assertTrue($collection->respondsTo('applyFilter'));
+		$this->assertTrue($collection->respondsTo('invokeMethod'));
 		$this->assertFalse($collection->respondsTo('fooBarBaz'));
 	}
 

--- a/tests/cases/util/ValidatorTest.php
+++ b/tests/cases/util/ValidatorTest.php
@@ -1213,7 +1213,7 @@ class ValidatorTest extends \lithium\test\Unit {
 	}
 
 	public function testRespondsToParentCall() {
-		$this->assertTrue(Validator::respondsTo('applyFilter'));
+		$this->assertTrue(Validator::respondsTo('invokeMethod'));
 		$this->assertFalse(Validator::respondsTo('fooBarBaz'));
 	}
 

--- a/tests/cases/util/collection/FiltersTest.php
+++ b/tests/cases/util/collection/FiltersTest.php
@@ -9,10 +9,23 @@
 namespace lithium\tests\cases\util\collection;
 
 use lithium\util\collection\Filters;
+use lithium\aop\Filters as NewFilters;
 
+/**
+ * Filters Test
+ *
+ * @deprecated
+ */
 class FiltersTest extends \lithium\test\Unit {
 
+	public function tearDown() {
+		NewFilters::clear('lithium\tests\mocks\util\MockFilters');
+		NewFilters::clear('foo\Bar');
+	}
+
 	public function testRun() {
+		error_reporting(($original = error_reporting()) & ~E_USER_DEPRECATED);
+
 		$options = array('method' => __FUNCTION__, 'class' => __CLASS__, 'data' => array(
 			function($self, $params, $chain) {
 				$params['message'] .= 'is a filter chain ';
@@ -26,25 +39,35 @@ class FiltersTest extends \lithium\test\Unit {
 				return $params['message'] . 'of the ' . $self . ' class.';
 			}
 		));
-		$result = Filters::run(__CLASS__, array('message' => 'This '), $options);
+		$result = Filters::run('foo\Bar', array('message' => 'This '), $options);
 		$expected = 'This is a filter chain in the testRun method of the';
-		$expected .= ' lithium\tests\cases\util\collection\FiltersTest class.';
+		$expected .= ' foo\Bar class.';
 		$this->assertEqual($expected, $result);
+
+		error_reporting($original);
 	}
 
 	public function testRunWithoutChain() {
+		error_reporting(($original = error_reporting()) & ~E_USER_DEPRECATED);
+
 		$options = array('method' => __FUNCTION__, 'class' => __CLASS__, 'data' => array(
 			function($self, $params, $chain) {
 				return $chain->next($self, $params, null);
 			},
-			'This is a filter chain that calls $chain->next() without the $chain argument.'
+			function() {
+				return 'This is a filter chain that calls $chain->next() without the $chain argument.';
+			}
 		));
-		$result = Filters::run(__CLASS__, array(), $options);
+		$result = Filters::run('foo\Bar', array(), $options);
 		$expected = 'This is a filter chain that calls $chain->next() without the $chain argument.';
 		$this->assertEqual($expected, $result);
+
+		error_reporting($original);
 	}
 
 	public function testLazyApply() {
+		error_reporting(($original = error_reporting()) & ~E_USER_DEPRECATED);
+
 		$class = 'lithium\tests\mocks\util\MockFilters';
 
 		Filters::apply($class, 'filteredMethod', function($self, $params, $chain) {
@@ -62,6 +85,8 @@ class FiltersTest extends \lithium\test\Unit {
 		$expected = md5(sha1('Working?'));
 		$result = $class::filteredMethod();
 		$this->assertEqual($expected, $result);
+
+		error_reporting($original);
 	}
 }
 

--- a/tests/integration/analysis/LoggerTest.php
+++ b/tests/integration/analysis/LoggerTest.php
@@ -10,7 +10,7 @@ namespace lithium\tests\integration\analysis;
 
 use lithium\core\Libraries;
 use lithium\analysis\Logger;
-use lithium\util\collection\Filters;
+use lithium\aop\Filters;
 
 /**
  * Logger adapter integration test cases
@@ -18,13 +18,12 @@ use lithium\util\collection\Filters;
 class LoggerTest extends \lithium\test\Integration {
 
 	public function testWriteFilter() {
-
 		$base = Libraries::get(true, 'resources') . '/tmp/logs';
 		$this->skipIf(!is_writable($base), "Path `{$base}` is not writable.");
 
-		Filters::apply('lithium\analysis\Logger', 'write', function($self, $params, $chain) {
+		Filters::apply('lithium\analysis\Logger', 'write', function($params, $next) {
 			$params['message'] = 'Filtered Message';
-			return $chain->next($self, $params, $chain);
+			return $next($params);
 		});
 
 		$config = array('default' => array(

--- a/tests/mocks/aop/MockInstanceFiltered.php
+++ b/tests/mocks/aop/MockInstanceFiltered.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2015, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\tests\mocks\aop;
+
+use lithium\aop\Filters;
+
+class MockInstanceFiltered {
+
+	protected $_internal = 'secret';
+
+	public function method() {
+		return Filters::run($this, __FUNCTION__, array(), function($params) {
+			return 'method';
+		});
+	}
+
+	public function methodTracing(array $trace = array()) {
+		$trace[] = 'Starting outer method call';
+
+		$result = Filters::run($this, __FUNCTION__, compact('trace'), function($params) {
+			$params['trace'][] = 'Inside method implementation';
+			return $params['trace'];
+		});
+		$result[] = 'Ending outer method call';
+		return $result;
+	}
+
+	public function tamper() {
+		return Filters::run($this, __FUNCTION__, array(), function() {
+			$this->_internal = 'tampered';
+			return true;
+		});
+	}
+
+	public function internal() {
+		return $this->_internal;
+	}
+}
+
+?>

--- a/tests/mocks/aop/MockStaticFiltered.php
+++ b/tests/mocks/aop/MockStaticFiltered.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2015, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\tests\mocks\aop;
+
+use lithium\aop\Filters;
+
+class MockStaticFiltered {
+
+	public static function method() {
+		return Filters::run(get_called_class(), __FUNCTION__, array(), function($params) {
+			return 'method';
+		});
+	}
+
+	public static function method2() {
+		return Filters::run(get_called_class(), __FUNCTION__, array(), function($params) {
+			return 'method2';
+		});
+	}
+
+	public static function methodTracing(array $trace = array()) {
+		$trace[] = 'Starting outer method call';
+
+		$result = Filters::run(get_called_class(), __FUNCTION__, compact('trace'), function($params) {
+			$params['trace'][] = 'Inside method implementation of ' . get_called_class();
+			return $params['trace'];
+		});
+		$result[] = 'Ending outer method call';
+		return $result;
+	}
+
+	public static function callSubclassMethod() {
+		return Filters::run(get_called_class(), __FUNCTION__, array(), function($params) {
+			return static::childMethod();
+		});
+	}
+}
+
+?>

--- a/tests/mocks/aop/MockStaticFilteredSubclass.php
+++ b/tests/mocks/aop/MockStaticFilteredSubclass.php
@@ -6,14 +6,12 @@
  * @license       http://opensource.org/licenses/bsd-license.php The BSD License
  */
 
-namespace lithium\tests\mocks\analysis;
+namespace lithium\tests\mocks\aop;
 
-class MockLoggerAdapter extends \lithium\core\Object {
+class MockStaticFilteredSubclass extends \lithium\tests\mocks\aop\MockStaticFiltered {
 
-	public function write($name, $value) {
-		return function($params) {
-			return true;
-		};
+	public static function childMethod() {
+		return 'Working';
 	}
 }
 

--- a/tests/mocks/core/MockExposed.php
+++ b/tests/mocks/core/MockExposed.php
@@ -8,6 +8,9 @@
 
 namespace lithium\tests\mocks\core;
 
+/**
+ * @deprecated
+ */
 class MockExposed extends \lithium\core\Object {
 
 	protected $_internal = 'secret';

--- a/tests/mocks/core/MockMethodFiltering.php
+++ b/tests/mocks/core/MockMethodFiltering.php
@@ -8,6 +8,9 @@
 
 namespace lithium\tests\mocks\core;
 
+/**
+ * @deprecated
+ */
 class MockMethodFiltering extends \lithium\core\Object {
 
 	public function method($data) {

--- a/tests/mocks/core/MockStaticFilteringExtended.php
+++ b/tests/mocks/core/MockStaticFilteringExtended.php
@@ -8,6 +8,9 @@
 
 namespace lithium\tests\mocks\core;
 
+/**
+ * @deprecated
+ */
 class MockStaticFilteringExtended extends \lithium\tests\mocks\core\MockStaticMethodFiltering {
 
 	public static function childMethod() {

--- a/tests/mocks/core/MockStaticMethodFiltering.php
+++ b/tests/mocks/core/MockStaticMethodFiltering.php
@@ -8,6 +8,9 @@
 
 namespace lithium\tests\mocks\core;
 
+/**
+ * @deprecated
+ */
 class MockStaticMethodFiltering extends \lithium\core\StaticObject {
 
 	public static function method($data) {
@@ -39,21 +42,6 @@ class MockStaticMethodFiltering extends \lithium\core\StaticObject {
 		return static::_filter(__FUNCTION__, array(), function($self, $params, $chain) {
 			return $self::childMethod();
 		});
-	}
-
-	public static function foo() {
-		$args = func_get_args();
-		return $args;
-	}
-
-	public static function parents($get = false) {
-		if ($get === null) {
-			static::$_parents = array();
-		}
-		if ($get) {
-			return static::$_parents;
-		}
-		return static::_parents();
 	}
 }
 

--- a/tests/mocks/core/MockStaticObject.php
+++ b/tests/mocks/core/MockStaticObject.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2015, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\tests\mocks\core;
+
+use Exception;
+use lithium\aop\Filters;
+
+class MockStaticObject extends \lithium\core\StaticObject {
+
+	public static function throwException() {
+		return Filters::run(get_called_class(), __FUNCTION__, array(), function($params) {
+			throw new Exception('foo');
+			return 'bar';
+		});
+	}
+
+	public static function foo() {
+		$args = func_get_args();
+		return $args;
+	}
+
+	public static function parents($get = false) {
+		if ($get === null) {
+			static::$_parents = array();
+		}
+		if ($get) {
+			return static::$_parents;
+		}
+		return static::_parents();
+	}
+}
+
+?>

--- a/tests/mocks/util/MockFilters.php
+++ b/tests/mocks/util/MockFilters.php
@@ -8,10 +8,15 @@
 
 namespace lithium\tests\mocks\util;
 
+/**
+ * Mock Filters Class
+ *
+ * @deprecated In use by deprecated test.
+ */
 class MockFilters extends \lithium\core\StaticObject {
 
 	public static function filteredMethod() {
-		return static::_filter(__FUNCTION__, array(), function($self, $params) {
+		return static::_filter(__FUNCTION__, array(), function($params) {
 			return 'Working?';
 		});
 	}


### PR DESCRIPTION
tl;dr;

To achieve PHP7 compatibility we cannot rely on `Object` anymore. As
`Object` contained the filtering logic it needed to be extracted. The
chance has been taken to cleanly re-implement filters **in a
fully BC-compatible way**.

Features
--------
- >50 added tests, more updated and migrated tests
- full BC
- simplified modern syntax and signature
- separation of concerns filters vs chain
- dedicated namespace
- less code (excl. BC and tests)
- everything is lazy by default / chain caching
- better (future) interoperability with other middleware
  handlers i.e. relayphp possible as signatures match
  closely

Performance
-----------
Using the TechEmpower 20 database queries benchmark in 2000
transactions. The new implementation including full BC shows a minimal
overhead, removing the BC it's minimally faster. The new implementation
always uses less memory but more function calls (~20-60 per benchmark
request of ~5000 total).

```
                   trans/sec    memory
1.1                  14.90      ~2.48M
1.1+new-filters+BC   14.84      ~2.45M
1.1+new-filters      15.04      ~2.42M
```

Original Goals
--------------
- PHP7 compatibility
- Plans to flatten hierarchy by removing Object/StaticObject
- Separating into package for easier breakout later

Why a centralized approach?
---------------------------
Previous implementation was already semi-centralized, to make lazy filters work.
This is just the consequent further development of it.

The centralized approach allows further consolidation, there is now just
one place to document and to maintain code at. Duplications of filtering
logic in `Libraries`, `Model`, `Mocker`, `Object`, `StaticObject` have
all been removed.

As closure filters are not stored on an instance anymore certain objects
become easier serializable i.e. `Entity` and `data\Collection`.

Why change signatures?
----------------------
The old filter and chain advancing signatures were more verbose then
needed as they had to be compatible with PHP 5.3.

The new signatures leverage new context binding features (i.e.
availability of `$this`) and drop unneeded parameters. This makes them
more similar to other middleware handlers (like relayphp).

Why is $chain passed as $next?
-------------------------------
This is to hide the implementation details and makes the concept easier
to understand.

Why isn't params part of chain?
-------------------------------
It would need us to expose the full chain object.

Why drop `method()` from chain?
--------------------------------
This would make Chain not context-free and break isolation.

Why not keep the implementation (callback) as part of the chain?
------------------------------------------
It's conceptually wrong to make it part of that.

Open for Discussion
-------------------
The final package name (`aop`) isn't cast in stone, yet. If somebody has a better
name for it, the name can be changed.

Known Limitations
-----------------
Mocker still uses applyFilter on mocked classes, as mocked class names
are hard to guess and to be passed to Filters::apply(CLASS).