### PR TITLE
Add ability to cache BLOBs using file cache adapter

### DIFF
--- a/storage/cache/adapter/File.php
+++ b/storage/cache/adapter/File.php
@@ -23,7 +23,7 @@ use lithium\storage\Cache;
  * for single-keys only. Clearing the cache is supported. Real persistence of cached items
  * is provided. Increment/decrement functionality is provided but only in a non-atomic way.
  *
- * This can't handle serialization natively. Scope support is available but not natively.
+ * This adapter can't handle serialization natively. Scope support is available but not natively.
  *
  * A simple configuration can be accomplished as follows:
  *

--- a/storage/cache/adapter/File.php
+++ b/storage/cache/adapter/File.php
@@ -250,7 +250,7 @@ class File extends \lithium\storage\cache\Adapter {
 	 *
 	 * @see lithium\storage\cache\adapter\File::write()
 	 * @param string $key Key to uniquely identify the cached item.
-	 * @param mixed $value Value to store under given key.
+	 * @param mixed $value Value or resource with value to store under given key.
 	 * @param integer $expires UNIX timestamp after which the item is invalid.
 	 * @return boolean `true` on success, `false` otherwise.
 	 */
@@ -261,8 +261,12 @@ class File extends \lithium\storage\cache\Adapter {
 			return false;
 		}
 		fwrite($stream, "{:expiry:{$expires}}\n");
-		fwrite($stream, $value);
 
+		if (is_resource($value)) {
+			stream_copy_to_stream($value, $stream);
+		} else {
+			fwrite($stream, $value);
+		}
 		return fclose($stream);
 	}
 

--- a/tests/cases/storage/cache/adapter/FileTest.php
+++ b/tests/cases/storage/cache/adapter/FileTest.php
@@ -216,6 +216,25 @@ class FileTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 	}
 
+	public function testWriteUsingStream() {
+		$now = time();
+
+		$adapter = new File();
+		$file = Libraries::get(true, 'resources') . '/tmp/cache/bar';
+
+		$time = $now + 5;
+		$expiry = 5;
+
+		$stream = fopen('php://temp', 'wb');
+		fwrite($stream, 'foo');
+		rewind($stream);
+		$adapter->write(array('bar' => $stream), $expiry);
+
+		$expected = "{:expiry:{$time}}\nfoo";
+		$result = file_get_contents($file);
+		$this->assertEqual($expected, $result);
+	}
+
 	public function testRead() {
 		$key = 'key';
 		$keys = array($key);

--- a/tests/cases/storage/cache/adapter/FileTest.php
+++ b/tests/cases/storage/cache/adapter/FileTest.php
@@ -324,6 +324,18 @@ class FileTest extends \lithium\test\Unit {
 		$this->assertEqual($expected, $result);
 	}
 
+	public function testReadStreams() {
+		$adapter = new File(array('streams' => true));
+
+		$adapter->write(array('bar' => 'foo'), 50);
+		$result = $adapter->read(array('bar'));
+		$this->assertTrue(is_resource($result['bar']));
+
+		$expected = 'foo';
+		$result = stream_get_contents($result['bar']);
+		$this->assertEqual($expected, $result);
+	}
+
 	public function testWriteAndReadNull() {
 		$expiry = '+1 minute';
 		$keys = array(


### PR DESCRIPTION
This introduces a new configuration option to the file cache adapter, which will cause it to return stream handles instead of the value itself. This allows for reading and writing BLOBs. 

The file format remains the same along the file's meta data header.

This feature is introduced to cover the following use cases:


1. You compile a PDF upon user request, an expensive operation is kicked of to compile the PDF. Upon following requests from other users, the PDF should be returned from cache to reduce compile overhead.

2. Your application downloads an instagram feed and stores the data together with images. Each image is downloaded into a temporary file, then a resize process will generate a "version" off it. As the version processing is isolated and knows nothing about the other resize processes the image would need to be re-downloaded for each version.  

I plan to add a BLOB caching section to the caching manual.