### PR TITLE
Deprecated and Refactored stop()

### DIFF
--- a/action/Controller.php
+++ b/action/Controller.php
@@ -335,6 +335,16 @@ class Controller extends \lithium\core\Object {
 		}
 		return $this->response;
 	}
+
+	/**
+	 * Exit immediately. Primarily used for overrides during testing.
+	 *
+	 * @param integer|string $status integer range 0 to 254, string printed on exit
+	 * @return void
+	 */
+	protected function _stop($status = 0) {
+		exit($status);
+	}
 }
 
 ?>

--- a/console/Command.php
+++ b/console/Command.php
@@ -422,6 +422,16 @@ class Command extends \lithium\core\Object {
 		}
 		return $this->response->{$type}($string);
 	}
+
+	/**
+	 * Exit immediately. Primarily used for overrides during testing.
+	 *
+	 * @param integer|string $status integer range 0 to 254, string printed on exit
+	 * @return void
+	 */
+	protected function _stop($status = 0) {
+		exit($status);
+	}
 }
 
 ?>

--- a/core/ErrorHandler.php
+++ b/core/ErrorHandler.php
@@ -300,6 +300,16 @@ class ErrorHandler extends \lithium\core\StaticObject {
 		}
 		return $result;
 	}
+
+	/**
+	 * Exit immediately. Primarily used for overrides during testing.
+	 *
+	 * @param integer|string $status integer range 0 to 254, string printed on exit
+	 * @return void
+	 */
+	protected static function _stop($status = 0) {
+		exit($status);
+	}
 }
 
 ErrorHandler::reset();

--- a/core/Object.php
+++ b/core/Object.php
@@ -286,14 +286,13 @@ class Object {
 	 * Exit immediately. Primarily used for overrides during testing.
 	 *
 	 * @deprecated This method will be removed in a future version. Please use
-	 * 		\\lithium\\core\\Command::_stop() instead.
-	 *
+	 * 		\lithium\core\Command::_stop() instead.
 	 * @param integer|string $status integer range 0 to 254, string printed on exit
 	 * @return void
 	 */
 	protected function _stop($status = 0) {
 		$message  = "Calling of Object::stop() has been deprecated ";
-		$message .= "Please Use \\lithium\\core\\Command::_stop() instead.";
+		$message .= "Please Use \lithium\core\Command::_stop() instead.";
 		trigger_error($message, E_USER_DEPRECATED);
 		exit($status);
 	}

--- a/core/Object.php
+++ b/core/Object.php
@@ -285,10 +285,16 @@ class Object {
 	/**
 	 * Exit immediately. Primarily used for overrides during testing.
 	 *
+	 * @deprecated This method will be removed in a future version. Please use
+	 * 		\\lithium\\core\\Command::_stop() instead.
+	 *
 	 * @param integer|string $status integer range 0 to 254, string printed on exit
 	 * @return void
 	 */
 	protected function _stop($status = 0) {
+		$message  = "Calling of Object::stop() has been deprecated ";
+		$message .= "Please Use \\lithium\\core\\Command::_stop() instead.";
+		trigger_error($message, E_USER_DEPRECATED);
 		exit($status);
 	}
 

--- a/core/StaticObject.php
+++ b/core/StaticObject.php
@@ -165,14 +165,13 @@ class StaticObject {
 	 * Exit immediately. Primarily used for overrides during testing.
 	 *
 	 * @deprecated This method will be removed in a future version. Please use
-	 * 		\\lithium\\core\\ErrorHandler::_stop() instead.
-	 *
+	 * 		\lithium\core\ErrorHandler::_stop() instead.
 	 * @param integer|string $status integer range 0 to 254, string printed on exit
 	 * @return void
 	 */
 	protected static function _stop($status = 0) {
 		$message  = "Calling of StaticObject::_stop() has been deprecated ";
-		$message .= "Please Use \\lithium\\core\\ErrorHandler::_stop() instead.";
+		$message .= "Please Use \lithium\core\ErrorHandler::_stop() instead.";
 		trigger_error($message, E_USER_DEPRECATED);
 		exit($status);
 	}

--- a/core/StaticObject.php
+++ b/core/StaticObject.php
@@ -164,13 +164,18 @@ class StaticObject {
 	/**
 	 * Exit immediately. Primarily used for overrides during testing.
 	 *
+	 * @deprecated This method will be removed in a future version. Please use
+	 * 		\\lithium\\core\\ErrorHandler::_stop() instead.
+	 *
 	 * @param integer|string $status integer range 0 to 254, string printed on exit
 	 * @return void
 	 */
 	protected static function _stop($status = 0) {
+		$message  = "Calling of StaticObject::_stop() has been deprecated ";
+		$message .= "Please Use \\lithium\\core\\ErrorHandler::_stop() instead.";
+		trigger_error($message, E_USER_DEPRECATED);
 		exit($status);
 	}
-
 }
 
 ?>


### PR DESCRIPTION
- Deprecated from:
   - Object
   - StaticObject

- Refactored into:
   - Command
   - ErrorHandler