### PR TITLE
columnCount() of null fixed

### DIFF
--- a/data/source/Database.php
+++ b/data/source/Database.php
@@ -828,7 +828,7 @@ abstract class Database extends \lithium\data\Source {
 		}
 		$result = array();
 
-		if (!$resource) {
+		if (!$resource || !$resource->resource()) {
 			return $result;
 		}
 		$count = $resource->resource()->columnCount();


### PR DESCRIPTION
This is an extension of a previous bug https://github.com/UnionOfRAD/lithium/issues/1210 which didn't completely fix the issue. 

To test this locally, we had in a controller method against mysql ~5.6

```
mysql  Ver 14.14 Distrib 5.6.27, for debian-linux-gnu (x86_64) using  EditLine wrapper
```

Running this code: 

```php
Model::connection()->read('SET SESSION group_concat_max_len = 1000000;');
```

throws a fatal error

```
Fatal error: Call to a member function columnCount() on null in libraries/lithium/data/source/Database.php on line 835
```

We were unable to create a regression test to prove this, and it appears to be a false-positive pass for the previous regression test added https://github.com/UnionOfRAD/lithium/commit/3fa37ebbe5a5f673c39143e3f3a5a0870771f191 due to it being a mocked connection. 

Running it against the actual model which hits mysql throws this fatal error.

We have not tested against SQLite3 or any other storage type.

@davidpersson 