### PR TITLE
Clarify APC deprecation message

### DIFF
--- a/storage/cache/adapter/Apc.php
+++ b/storage/cache/adapter/Apc.php
@@ -12,8 +12,8 @@ if (!class_exists('\lithium\storage\cache\Adapter')) {
 	$message  = 'The file (`' . __FILE__ . '`) has probably been included directly within ';
 	$message .= 'the bootstrap process. Due to its dependencies it should be (auto-)loaded ';
 	$message .= 'i.e. through the `Libraries` class exclusively. Please update your app\'s ';
-	$message .= 'bootstrap to the most recent version or remove the line where this file was ';
-	$message .= 'originally included.';
+	$message .= 'bootstrap directory to the most recent version or remove the line where ';
+	$message .= 'this file was originally included.';
 	trigger_error($message, E_USER_DEPRECATED);
 
 	require_once LITHIUM_LIBRARY_PATH . '/lithium/storage/cache/Adapter.php';


### PR DESCRIPTION
Best would be to include a link to https://github.com/UnionOfRAD/framework into the error message.
Unsure about the best practice