### PR TITLE
Adding nested strategy support.

### DIFF
--- a/data/Model.php
+++ b/data/Model.php
@@ -1558,6 +1558,34 @@ class Model extends \lithium\core\StaticObject {
 	}
 
 	/**
+	 * Eager loads relations.
+	 *
+	 * @param mixed $collection The collection to extend.
+	 * @param array $relations The relations to eager load.
+	 * @return mixed The collection.
+	 */
+	public static function embed(&$collection, $relations) {
+		$tree = Set::expand(array_fill_keys(array_keys(Set::normalize($relations)), array()));
+
+		foreach ($tree as $name => $subtree) {
+			$rel = static::relations($name);
+			$to = $rel->to();
+			$related = $rel->embed($collection, isset($relations[$name]) ? $relations[$name] : array());
+
+			$subrelations = array();
+			foreach ($relations as $path => $value) {
+				if (preg_match('~^'.$name.'\.(.*)$~', $path, $matches)) {
+					$subrelations[] = $matches[1];
+				}
+			}
+			if ($subrelations) {
+				$to::embed($related, $subrelations);
+			}
+		}
+		return $collection;
+	}
+
+	/**
 	 * Resetting the model.
 	 */
 	public static function reset() {

--- a/data/model/Query.php
+++ b/data/model/Query.php
@@ -211,12 +211,9 @@ class Query extends \lithium\core\Object {
 		if ($this->_entity && !$this->_config['model']) {
 			$this->model($this->_entity->model());
 		}
-		if ($this->_config['with']) {
-			if (!$model = $this->model()) {
-				throw new ConfigException("The `'with'` option needs a valid binded model.");
-			}
-			$this->_config['with'] = Set::normalize($this->_config['with']);
-		}
+
+		$this->with($this->_config['with']);
+
 		if ($model = $this->model()) {
 			$this->alias($this->_config['alias'] ?: $model::meta('name'));
 		}
@@ -540,6 +537,24 @@ class Query extends \lithium\core\Object {
 		if (isset($this->_config['joins'][$name])) {
 			return $this->_config['joins'][$name];
 		}
+	}
+
+
+	/**
+	 * Set and get method for the query's embed specification.
+	 *
+	 * @param array $with The dotted relation paths to embed
+	 * @return mixed
+	 */
+	public function with($with = array()) {
+		if (!func_num_args()) {
+			return $this->_config['with'];
+		}
+		if ((!$model = $this->model()) && $with) {
+			throw new ConfigException("The `'with'` option needs a valid binded model.");
+		}
+		$this->_config['with'] = Set::normalize($with);
+		return $this;
 	}
 
 	/**

--- a/data/model/Relationship.php
+++ b/data/model/Relationship.php
@@ -8,7 +8,9 @@
 
 namespace lithium\data\model;
 
+use Exception;
 use Countable;
+use Traversable;
 use lithium\util\Set;
 use lithium\core\Libraries;
 use lithium\core\ConfigException;
@@ -311,6 +313,163 @@ class Relationship extends \lithium\core\Object {
 				return $model::all(Set::merge($query, $options));
 			}
 		);
+	}
+
+	/**
+	 * Fetch data related to a whole collection and embed the result in it.
+	 *
+	 * @param mixed $collection A collection of data.
+	 * @param array $options The embed query options.
+	 * @return mixed The fetched data.
+	 */
+	public function embed(&$collection, $options = array()) {
+		$keys = $this->key();
+		if (count($keys) !== 1) {
+			throw new Exception("The embedding doesn't support composite primary key.");
+		}
+		list($formKey, $toKey) = each($keys);
+
+		$related = array();
+
+		if ($this->type() === 'belongsTo') {
+
+			$indexes = $this->_index($collection, $formKey);
+			$related = $this->_find(array_keys($indexes), $options);
+
+			$fieldName = $this->fieldName();
+			$indexes = $this->_index($related, $toKey);
+			$this->_cleanup($collection);
+
+			foreach ($collection as $index => $source) {
+				if (is_object($source)) {
+					$value = (string) $source->{$formKey};
+					if (isset($indexes[$value])) {
+						$source->{$fieldName} = $related[$indexes[$value]];
+					}
+				} else {
+					$value = (string) $source[$formKey];
+					if (isset($indexes[$value])) {
+						$collection[$index][$fieldName] = $related[$indexes[$value]];
+					}
+				}
+			}
+
+		} elseif ($this->type() === 'hasMany') {
+
+			$indexes = $this->_index($collection, $formKey);
+			$related = $this->_find(array_keys($indexes), $options);
+
+			$fieldName = $this->fieldName();
+
+			$this->_cleanup($collection);
+
+			foreach ($collection as $index => $entity) {
+				if (is_object($entity)) {
+					$entity->{$fieldName} = array();
+				} else {
+					$collection[$index][$fieldName] = array();
+				}
+			}
+
+			foreach ($related as $index => $entity) {
+				$isObject = is_object($entity);
+				$values = $isObject ? $entity->{$toKey} : $entity[$toKey];
+				$values = is_array($values) || $values instanceof Traversable ? $values : array($values);
+				foreach ($values as $value) {
+					$value = (string) $value;
+					if (isset($indexes[$value])) {
+						if ($isObject) {
+							$source = $collection[$indexes[$value]];
+							$source->{$fieldName}[] = $entity;
+						} else {
+							$collection[$indexes[$value]][$fieldName][] = $entity;
+						}
+					}
+				}
+			}
+
+		} elseif ($this->type() === 'hasOne') {
+
+			$indexes = $this->_index($collection, $formKey);
+			$related = $this->_find(array_keys($indexes), $options);
+			$fieldName = $this->fieldName();
+			$this->_cleanup($collection);
+			foreach ($related as $index => $entity) {
+				if (is_object($entity)) {
+					$value = (string) $entity->{$toKey};
+					if (isset($indexes[$value])) {
+						$source = $collection[$indexes[$value]];
+						$source->{$fieldName} = $entity;
+					}
+				} else {
+					$value = (string) $entity[$toKey];
+					if (isset($indexes[$value])) {
+						$collection[$indexes[$value]][$fieldName] = $entity;
+					}
+				}
+			}
+
+		} else {
+			throw new Exception("Error {$this->type()} is unsupported ");
+		}
+		return $related;
+	}
+
+	/**
+	 * Gets all entities attached to a collection en entities.
+	 *
+	 * @param  mixed  $id An id or an array of ids.
+	 * @return object     A collection of items matching the id/ids.
+	 */
+	protected function _find($id, $options = array()) {
+		if ($this->link() !== static::LINK_KEY) {
+			throw new Exception("This relation is not based on a foreign key.");
+		}
+		if ($id === array()) {
+			return array();
+		}
+		$to = $this->to();
+		$options += array('conditions' => array());
+		$options['conditions'] = array_merge($options['conditions'], array(
+			current($this->key()) => $id
+		));
+		return $to::find('all', $options);
+	}
+
+	/**
+	 * Indexes a collection.
+	 *
+	 * @param  mixed  $collection An collection to extract index from.
+	 * @param  string $name       The field name to build index for.
+	 * @return array              An array of indexes where keys are `$name` values and
+	 *                            values the correcponding index in the collection.
+	 */
+	protected function _index($collection, $name) {
+		$indexes = array();
+		foreach ($collection as $key => $entity) {
+			if (is_object($entity)) {
+				$indexes[(string) $entity->{$name}] = $key;
+			} else {
+				$indexes[(string) $entity[$name]] = $key;
+			}
+		}
+		return $indexes;
+	}
+
+	/**
+	 * Unsets the relationship attached to a collection en entities.
+	 *
+	 * @param  mixed  $collection An collection to "clean up".
+	 */
+	public function _cleanup($collection) {
+		$name = $this->name();
+		foreach ($collection as $index => $entity) {
+			if (is_object($entity)) {
+				unset($entity->{$name});
+			} else {
+				unset($entity[$name]);
+			}
+		}
 	}
 }
 

--- a/data/source/MongoDb.php
+++ b/data/source/MongoDb.php
@@ -550,7 +550,12 @@ class MongoDb extends \lithium\data\Source {
 			$resource = $result->sort($args['order'])->limit($args['limit'])->skip($args['offset']);
 			$result = $self->invokeMethod('_instance', array('result', compact('resource')));
 			$config = compact('result', 'query') + array('class' => 'set', 'defaults' => false);
-			return $model::create(array(), $config);
+			$collection = $model::create(array(), $config);
+
+			if (is_object($query) && $query->with()) {
+				$model::embed($collection, $query->with());
+			}
+			return $collection;
 		});
 	}
 

--- a/tests/cases/data/model/QueryTest.php
+++ b/tests/cases/data/model/QueryTest.php
@@ -713,11 +713,7 @@ class QueryTest extends \lithium\test\Unit {
 			'mode' => null,
 			'model' => 'lithium\tests\mocks\data\model\MockGallery',
 			'calculate' => 'MyCalculate',
-			'with' => array(
-				'Image.ImageTag.Tag' => null,
-				'Image' => null,
-				'Image.ImageTag' => null
-			),
+			'with' => array(),
 			'source' => '{mock_gallery}',
 			'offset' => null,
 			'page' => null,

--- a/tests/fixture/model/mongodb/Comments.php
+++ b/tests/fixture/model/mongodb/Comments.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2016, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\tests\fixture\model\mongodb;
+
+class Comments extends \lithium\data\Model {
+
+	protected $_meta = array('connection' => 'test');
+
+	protected $_schema = array(
+		'_id' => array('type' => 'id'),
+		'image' => array('type' => 'id'),
+		'body' => array('type' => 'string')
+	);
+}
+
+?>

--- a/tests/fixture/model/mongodb/Galleries.php
+++ b/tests/fixture/model/mongodb/Galleries.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2016, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\tests\fixture\model\mongodb;
+
+class Galleries extends \lithium\data\Model {
+
+	public $hasMany = array('Images');
+
+	protected $_meta = array('connection' => 'test');
+
+	protected $_schema = array(
+		'_id' => array('type' => 'id'),
+		'name' => array('type' => 'string', 'length' => 50),
+		'active' => array('type' => 'boolean', 'default' => true),
+		'created' => array('type' => 'datetime'),
+		'modified' => array('type' => 'datetime')
+	);
+}
+
+?>

--- a/tests/fixture/model/mongodb/GalleriesFixture.php
+++ b/tests/fixture/model/mongodb/GalleriesFixture.php
@@ -6,14 +6,14 @@
  * @license       http://opensource.org/licenses/bsd-license.php The BSD License
  */
 
-namespace lithium\tests\fixture\model\gallery;
+namespace lithium\tests\fixture\model\mongodb;
 
 class GalleriesFixture extends \li3_fixtures\test\Fixture {
 
-	protected $_model = 'lithium\tests\fixture\model\gallery\Galleries';
+	protected $_model = 'lithium\tests\fixture\model\mongodb\Galleries';
 
 	protected $_fields = array(
-		'id' => array('type' => 'id'),
+		'_id' => array('type' => 'id'),
 		'name' => array('type' => 'string', 'length' => 50),
 		'active' => array('type' => 'boolean', 'default' => true),
 		'created' => array('type' => 'datetime'),
@@ -22,18 +22,18 @@ class GalleriesFixture extends \li3_fixtures\test\Fixture {
 
 	protected $_records = array(
 		array(
-			'id' => 1,
+			'_id' => 1,
 			'name' => 'Foo Gallery',
 			'active' => true,
-			'created' => '2007-06-20 21:02:27',
-			'modified' => '2009-12-14 22:36:09'
+			'created' => '2007-06-20T21:02:27Z',
+			'modified' => '2009-12-14T22:36:09Z'
 		),
 		array(
-			'id' => 2,
+			'_id' => 2,
 			'name' => 'Bar Gallery',
 			'active' => true,
-			'created' => '2008-08-22 16:12:42',
-			'modified' => '2008-08-22 16:12:42'
+			'created' => '2008-08-22T16:12:42Z',
+			'modified' => '2008-08-22T16:12:42Z'
 		),
 	);
 }

--- a/tests/fixture/model/mongodb/Images.php
+++ b/tests/fixture/model/mongodb/Images.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2016, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\tests\fixture\model\mongodb;
+
+class Images extends \lithium\data\Model {
+
+	public $belongsTo = array('Galleries');
+
+	public $hasMany = array('ImagesTags', 'Comments');
+
+	protected $_meta = array('connection' => 'test');
+
+	protected $_schema = array(
+		'_id' => array('type' => 'id'),
+		'gallery' => array('type' => 'id'),
+		'image' => array('type' => 'string', 'length' => 255),
+		'title' => array('type' => 'string', 'length' => 50),
+		'created' => array('type' => 'datetime'),
+		'modified' => array('type' => 'datetime')
+	);
+}
+
+?>

--- a/tests/fixture/model/mongodb/ImagesFixture.php
+++ b/tests/fixture/model/mongodb/ImagesFixture.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2016, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\tests\fixture\model\mongodb;
+
+class ImagesFixture extends \li3_fixtures\test\Fixture {
+
+	protected $_model = 'lithium\tests\fixture\model\mongodb\Images';
+
+	protected $_fields = array(
+		'_id' => array('type' => 'id'),
+		'gallery' => array('type' => 'id'),
+		'image' => array('type' => 'string', 'length' => 255),
+		'title' => array('type' => 'string', 'length' => 50),
+		'created' => array('type' => 'datetime'),
+		'modified' => array('type' => 'datetime')
+	);
+
+	protected $_records = array(
+		array(
+			'_id' => 1,
+			'gallery' => 1,
+			'image' => 'someimage.png',
+			'title' => 'Amiga 1200',
+			'created' => '2011-05-22T10:43:13Z',
+			'modified' => '2012-11-30T18:38:10Z'
+		),
+		array(
+			'_id' => 2,
+			'gallery' => 1,
+			'image' => 'image.jpg',
+			'title' => 'Srinivasa Ramanujan',
+			'created' => '2009-01-05T08:39:27Z',
+			'modified' => '2009-03-14T05:42:07Z'
+		),
+		array(
+			'_id' => 3,
+			'gallery' => 1,
+			'image' => 'photo.jpg',
+			'title' => 'Las Vegas',
+			'created' => '2010-08-11T23:12:03Z',
+			'modified' => '2010-09-24T04:45:14Z'
+		),
+		array(
+			'_id' => 4,
+			'gallery' => 2,
+			'image' => 'picture.jpg',
+			'title' => 'Silicon Valley',
+			'created' => '2008-08-22T17:55:10Z',
+			'modified' => '2008-08-22T17:55:10Z'
+		),
+		array(
+			'_id' => 5,
+			'gallery' => 2,
+			'image' => 'unknown.gif',
+			'title' => 'Unknown',
+			'created' => '2011-02-12T08:32:10Z',
+			'modified' => '2012-04-16T14:18:52Z'
+		)
+	);
+}
+
+?>

--- a/tests/fixture/model/mongodb/ImagesTags.php
+++ b/tests/fixture/model/mongodb/ImagesTags.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2016, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\tests\fixture\model\mongodb;
+
+class ImagesTags extends \lithium\data\Model {
+
+	public $belongsTo = array('Images', 'Tags');
+
+	protected $_meta = array('connection' => 'test');
+
+	protected $_schema = array(
+		'_id' => array('type' => 'id'),
+		'image_id' => array('type' => 'id'),
+		'tag_id' => array('type' => 'id')
+	);
+}
+
+?>

--- a/tests/fixture/model/mongodb/ImagesTagsFixture.php
+++ b/tests/fixture/model/mongodb/ImagesTagsFixture.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2016, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\tests\fixture\model\mongodb;
+
+class ImagesTagsFixture extends \li3_fixtures\test\Fixture {
+
+	protected $_model = 'lithium\tests\fixture\model\mongodb\ImagesTags';
+
+	protected $_fields = array(
+		'_id' => array('type' => 'id'),
+		'image_id' => array('type' => 'id'),
+		'tag_id' => array('type' => 'id')
+	);
+
+	protected $_records = array(
+		array('_id' => 1, 'image' => 1, 'tag' => 1),
+		array('_id' => 2, 'image' => 1, 'tag' => 3),
+		array('_id' => 3, 'image' => 2, 'tag' => 5),
+		array('_id' => 4, 'image' => 3, 'tag' => 6),
+		array('_id' => 5, 'image' => 4, 'tag' => 6),
+		array('_id' => 6, 'image' => 4, 'tag' => 3),
+		array('_id' => 7, 'image' => 4, 'tag' => 1)
+	);
+}
+
+?>

--- a/tests/fixture/model/mongodb/Tags.php
+++ b/tests/fixture/model/mongodb/Tags.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2016, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\tests\fixture\model\mongodb;
+
+class Tags extends \lithium\data\Model {
+
+	public $hasMany = array('ImagesTags');
+
+	protected $_schema = array(
+		'_id' => array('type' => 'id'),
+		'name' => array('type' => 'string', 'length' => 50),
+		'author' => array('type' => 'id')
+	);
+}
+
+?>

--- a/tests/fixture/model/mongodb/TagsFixture.php
+++ b/tests/fixture/model/mongodb/TagsFixture.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Lithium: the most rad php framework
+ *
+ * @copyright     Copyright 2016, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+namespace lithium\tests\fixture\model\mongodb;
+
+class TagsFixture extends \li3_fixtures\test\Fixture {
+
+	protected $_model = 'lithium\tests\fixture\model\mongodb\Tags';
+
+	protected $_fields = array(
+		'_id' => array('type' => 'id'),
+		'name' => array('type' => 'string', 'length' => 50),
+		'author' => array('type' => 'id')
+	);
+
+	protected $_records = array(
+		array('_id' => 1, 'name' => 'High Tech', 'author' => 6),
+		array('_id' => 2, 'name' => 'Sport', 'author' => 9),
+		array('_id' => 3, 'name' => 'Computer', 'author' => 6),
+		array('_id' => 4, 'name' => 'Art', 'author' => 2),
+		array('_id' => 5, 'name' => 'Science', 'author' => 1),
+		array('_id' => 6, 'name' => 'City', 'author' => 2)
+	);
+}
+
+?>

--- a/tests/fixture/model/mongodb/export/testManyToOne.php
+++ b/tests/fixture/model/mongodb/export/testManyToOne.php
@@ -1,0 +1,49 @@
+<?php
+
+return array (
+	1 => array (
+		'_id' => 1,
+		'gallery' => array (
+			'_id' => 1,
+			'name' => 'Foo Gallery',
+			'active' => true,
+			'created' => 1182373347,
+			'modified' => 1260830169,
+		),
+		'image' => 'someimage.png',
+		'title' => 'Amiga 1200',
+		'created' => 1306060993,
+		'modified' => 1354300690,
+	),
+	2 => array (
+		'_id' => 2,
+		'gallery' => 
+		array (
+			'_id' => 1,
+			'name' => 'Foo Gallery',
+			'active' => true,
+			'created' => 1182373347,
+			'modified' => 1260830169,
+		),
+		'image' => 'image.jpg',
+		'title' => 'Srinivasa Ramanujan',
+		'created' => 1231144767,
+		'modified' => 1237009327,
+	),
+	3 => array (
+		'_id' => 3,
+		'gallery' => array (
+			'_id' => 1,
+			'name' => 'Foo Gallery',
+			'active' => true,
+			'created' => 1182373347,
+			'modified' => 1260830169,
+		),
+		'image' => 'photo.jpg',
+		'title' => 'Las Vegas',
+		'created' => 1281568323,
+		'modified' => 1285303514,
+	),
+);
+
+?>

--- a/tests/fixture/model/mongodb/export/testOneToMany.php
+++ b/tests/fixture/model/mongodb/export/testOneToMany.php
@@ -1,0 +1,39 @@
+<?php
+
+return array (
+	1 => array (
+		'_id' => 1,
+		'name' => 'Foo Gallery',
+		'active' => true,
+		'created' => 1182373347,
+		'modified' => 1260830169,
+		'images' => array (
+			0 => array (
+				'_id' => 1,
+				'gallery' => 1,
+				'image' => 'someimage.png',
+				'title' => 'Amiga 1200',
+				'created' => 1306060993,
+				'modified' => 1354300690,
+			),
+			1 => array (
+				'_id' => 2,
+				'gallery' => 1,
+				'image' => 'image.jpg',
+				'title' => 'Srinivasa Ramanujan',
+				'created' => 1231144767,
+				'modified' => 1237009327,
+			),
+			2 => array (
+				'_id' => 3,
+				'gallery' => 1,
+				'image' => 'photo.jpg',
+				'title' => 'Las Vegas',
+				'created' => 1281568323,
+				'modified' => 1285303514,
+			),
+		),
+	),
+);
+
+?>

--- a/tests/integration/data/DatabaseTest.php
+++ b/tests/integration/data/DatabaseTest.php
@@ -162,6 +162,23 @@ class DatabaseTest extends \lithium\tests\integration\data\Base {
 		$this->assertEqual($expected, $images);
 	}
 
+	public function testManyToOneUsingNestedStrategy() {
+		$opts = array('conditions' => array('gallery_id' => 1), 'strategy' => 'nested');
+		$query = new Query($opts + array(
+			'type' => 'read',
+			'model' => 'lithium\tests\fixture\model\gallery\Images',
+			'source' => 'images',
+			'alias' => 'Images',
+			'with' => array('Galleries')
+		));
+		$images = $this->_db->read($query)->data();
+		$expected = include $this->_export . '/testManyToOne.php';
+		$this->assertEqual($expected, $images);
+
+		$images = Images::find('all', $opts + array('with' => 'Galleries'))->data();
+		$this->assertEqual($expected, $images);
+	}
+
 	public function testOneToMany() {
 		$opts = array('conditions' => array('Galleries.id' => 1));
 
@@ -174,9 +191,27 @@ class DatabaseTest extends \lithium\tests\integration\data\Base {
 		));
 		$galleries = $this->_db->read($query)->data();
 		$expected = include $this->_export . '/testOneToMany.php';
-		$gallery = Galleries::find('first', $opts + array('with' => 'Images'))->data();
+		$this->assertEqual($expected, $galleries);
 
+		$gallery = Galleries::find('first', $opts + array('with' => 'Images'))->data();
 		$this->assertEqual(3, count($gallery['images']));
+		$this->assertEqual(reset($expected), $gallery);
+	}
+
+	public function testOneToManyUsingNestedStrategy() {
+		$opts = array('conditions' => array('Galleries.id' => 1), 'strategy' => 'nested');
+		$query = new Query($opts + array(
+			'type' => 'read',
+			'model' => 'lithium\tests\fixture\model\gallery\Galleries',
+			'source' => 'galleries',
+			'alias' => 'Galleries',
+			'with' => array('Images')
+		));
+		$galleries = $this->_db->read($query)->data();
+		$expected = include $this->_export . '/testOneToMany.php';
+		$this->assertEqual($expected, $galleries);
+
+		$gallery = Galleries::find('first', $opts + array('with' => 'Images'))->data();
 		$this->assertEqual(reset($expected), $gallery);
 	}
 

--- a/tests/integration/data/MongoDbTest.php
+++ b/tests/integration/data/MongoDbTest.php
@@ -8,22 +8,56 @@
 
 namespace lithium\tests\integration\data;
 
-use lithium\tests\fixture\model\gallery\Galleries;
+use MongoId;
+use lithium\core\Libraries;
+use lithium\data\Connections;
+use lithium\data\model\Query;
+use lithium\tests\fixture\model\mongodb\Images;
+use lithium\tests\fixture\model\mongodb\Galleries;
+use li3_fixtures\test\Fixtures;
 
 class MongoDbTest extends \lithium\tests\integration\data\Base {
 
+	protected $_export = null;
+
+	protected $_fixtures = array(
+		'images' => 'lithium\tests\fixture\model\mongodb\ImagesFixture',
+		'galleries' => 'lithium\tests\fixture\model\mongodb\GalleriesFixture',
+	);
+
 	public function skip() {
 		parent::connect($this->_connection);
+		if (!class_exists('li3_fixtures\test\Fixtures')) {
+			$this->skipIf(true, 'Need `li3_fixtures` to run tests.');
+		}
 		$this->skipIf(!$this->with(array('MongoDb')));
+		$this->_export = Libraries::path('lithium\tests\fixture\model\mongodb\export', array(
+			'dirs' => true
+		));
 	}
 
+	/**
+	 * Creating the test database
+	 */
 	public function setUp() {
-		Galleries::config(array('meta' => array('connection' => 'test')));
-	}
+		$options = array(
+			'db' => array(
+				'adapter' => 'Connection',
+				'connection' => $this->_connection,
+				'fixtures' => $this->_fixtures
+			)
+		);
 
+		Fixtures::config($options);
+		Fixtures::save('db');
+	}
+	/**
+	 * Dropping the test database
+	 */
 	public function tearDown() {
-		Galleries::remove();
+		Fixtures::clear('db');
 		Galleries::reset();
+		Images::reset();
 	}
 
 	public function testCountOnEmptyResultSet() {
@@ -42,6 +76,7 @@ class MongoDbTest extends \lithium\tests\integration\data\Base {
 	}
 
 	public function testDateCastingUsingExists() {
+		Galleries::remove();
 		Galleries::config(array('schema' => array('_id' => 'id', 'created_at' => 'date')));
 		$gallery = Galleries::create(array('created_at' => time()));
 		$gallery->save();
@@ -49,6 +84,44 @@ class MongoDbTest extends \lithium\tests\integration\data\Base {
 		$result = Galleries::first(array('conditions' => array('created_at' => array('$exists' => false))));
 		$this->assertNull($result);
 	}
+
+	public function testManyToOne() {
+		$opts = array('conditions' => array('gallery' => 1));
+
+		$query = new Query($opts + array(
+			'type' => 'read',
+			'model' => 'lithium\tests\fixture\model\mongodb\Images',
+			'source' => 'images',
+			'alias' => 'Images',
+			'with' => array('Galleries')
+		));
+		$images = $this->_db->read($query)->data();
+		$expected = include $this->_export . '/testManyToOne.php';
+		$this->assertEqual($expected, $images);
+
+		$images = Images::find('all', $opts + array('with' => 'Galleries'))->data();
+		$this->assertEqual($expected, $images);
+	}
+
+	public function testOneToMany() {
+		$opts = array('conditions' => array('_id' => 1));
+
+		$query = new Query($opts + array(
+			'type' => 'read',
+			'model' => 'lithium\tests\fixture\model\mongodb\Galleries',
+			'source' => 'galleries',
+			'alias' => 'Galleries',
+			'with' => array('Images')
+		));
+		$galleries = $this->_db->read($query)->data();
+		$expected = include $this->_export . '/testOneToMany.php';
+		$this->assertEqual($expected, $galleries);
+
+		$gallery = Galleries::find('first', $opts + array('with' => 'Images'))->data();
+		$this->assertEqual(3, count($gallery['images']));
+		$this->assertEqual(reset($expected), $gallery);
+	}
+
 }
 
 ?>


### PR DESCRIPTION
When a gallery as many images, the relationship can be defined like so:

```php
class Galleries extends \lithium\data\Model {
	public $hasMany = array('Images');
	protected $_schema = array(...);
}
```
```php
class Images extends \lithium\data\Model {
	public $belongsTo = array('Galleries');
	protected $_schema = array(...);
}
```

With some classic DBMS, you can use the `'with'` option to eager load related datas out of the box:
```php
Galleries::all(['with' => ['Images']]);
```
This works because joins are done under the hood to fetch related data in a single query.

But for NoSQL databases all related data need to be fetched individually which can lead to either some complex code or a non optimised fetching strategy.

This PR introduces the `'with'` option for NoSQL database. So instead of using joins, related datas are fetched using additionnal queries. But instead of fetching related data individually, queries are done so that it'll require `the number of relations to embed + 1` queries.

For example:
```php
Galleries::all(['with' => ['Images']]);
```
will require 2 queries and:
```php
Galleries::all(['with' => ['Images.Tags']]);
```
will require 3 queries and so on.

Warning, conditions in the `'with'` option for NoSQL databases doesn't constraint the whole result. So you won't be able to perform queries like "I wan't only galleries which contain images of trees". The results will be all galleries with trees only as images.

This strategy can also be used for DBMS databases through the following syntax:
```php
Galleries::all([
	'with' => ['Images'],
	'strategy' => 'nested'
]);
```
This can be usefull if galleries and images are stored on differents hosts in different databases for example. Warning, in this cases the conditions in the `'with'` won't constraint the whole result too.