### PR TITLE
Added HTTP Status Code 426 per RFC7231

### DIFF
--- a/net/http/Response.php
+++ b/net/http/Response.php
@@ -87,6 +87,7 @@ class Response extends \lithium\net\http\Message {
 		422 => 'Unprocessable Entity',
 		423 => 'Locked',
 		424 => 'Method Failure',
+		426 => 'Upgrade Required',
 		428 => 'Precondition Required',
 		429 => 'Too Many Requests',
 		431 => 'Request Header Fields Too Large',


### PR DESCRIPTION
Added HTTP Status Code 426 per [RFC7231](https://tools.ietf.org/html/rfc7231#section-6.5.15).

The 426 (Upgrade Required) status code indicates that the server refuses to perform the request using the current protocol but might be willing to do so after the client upgrades to a different protocol.