### PR TITLE
Unset order parameter on the ID query

### DIFF
--- a/data/source/Database.php
+++ b/data/source/Database.php
@@ -654,7 +654,8 @@ abstract class Database extends \lithium\data\Source {
 			$pk = $this->name($model::meta('name') . '.' . $model::key());
 
 			$result = $this->_execute($this->renderCommand('read', [
-				'fields' => "DISTINCT({$pk}) AS _ID_"] + $data
+				'fields' => "DISTINCT({$pk}) AS _ID_",
+				'order' => null] + $data
 			));
 			$ids = [];
 


### PR DESCRIPTION
Because this query is only meant to get the ids of the records up front, there is no need to enforce the same ordering which might be used in the "real" query issued afterward.

Not unsetting the `order` parameter causes problems when a user specifies a field which is aliased to a name not present in any of the queried tables. For example, if a user wants to use a custom `COUNT` operation on a particular field and aliases it to a name.

```php
$results = SomeModel::find('all', [
        'with' => [
                'RelatedOne',   // has many relationship
                'RelatedTwo'    // has many relationship
        ],
        'fields' => [
                'SomeModel.some_model_id',
                'SomeModel.title',
                'COUNT(DISTINCT RelatedOne.related_one_id, SomeModel.some_model_id) as related_one_count'
        ],
        'order' => 'related_one_count DESC',
        'group' => 'SomeModel.some_model_id'
]);
```

This would result in a query like the following:

```sql
SELECT DISTINCT(`SomeModel`.`some_model_id`) AS _ID_ FROM `some_model` as `SomeModel`
LEFT JOIN `related_one` AS `RelatedOne` ON `SomeModel`.`some_model_id` = `RelatedOne`.`some_model_id`
LEFT JOIN `related_two` AS `RelatedTwo` ON `SomeModel`.`some_model_id` = `RelatedOne`.`some_model_id`
GROUP BY `SomeModel`.`some_model_id`
ORDER BY related_one_count DESC
```

This query fails since `related_one_count` is no longer a valid field.

Unsetting the `order` param in this query seems like the obvious fix, since order is not needed for this first query. The only downside could be that for particular queries, the order specified would greatly speed up the execution. I would be open to suggestions for maintaining the user specified order if that is something we don't want to lose.