### PR TITLE
Fix the code attempting to capture the PDO specific error code in Database::connect

### DIFF
--- a/data/source/Database.php
+++ b/data/source/Database.php
@@ -325,8 +325,7 @@ abstract class Database extends \lithium\data\Source {
 			$this->connection = new PDO($dsn, $config['login'], $config['password'], $options);
 		} catch (PDOException $e) {
 			preg_match('/SQLSTATE\[(.+?)\]/', $e->getMessage(), $code);
-			var_dump($e->getMessage());
-			$code = empty($code[1]) ? 0 : $code[0];
+			$code = empty($code[1]) ? 0 : $code[1];
 			switch (true) {
 				case $code === 'HY000' || substr($code, 0, 2) === '08':
 					$msg = "Unable to connect to host `{$config['host']}`.";


### PR DESCRIPTION
Fix the code attempting to capture the PDO specific error code from the PDOException message. Currently, if the first capture group of the regex is empty, it reassigns `$code` to the entire message string, which is not what any of the logic following it is expecting. If the first capture group is not empty, `$code` should be assigned to its contents.

I am also removing the `var_dump` call, as I think that was probably debug code
left in the main line by accident.