### PR TITLE
Fix braces used for array access, which is deprecated for PHP 7.4

### DIFF
--- a/util/Text.php
+++ b/util/Text.php
@@ -287,7 +287,7 @@ class Text {
 				$results[] = $buffer;
 				$buffer = '';
 			} else {
-				$buffer .= $data{$tmpOffset};
+				$buffer .= $data[$tmpOffset];
 			}
 
 			if ($options['leftBound'] !== $options['rightBound']) {


### PR DESCRIPTION
This should probably be merged into all branches.