### PR TITLE
Change curly braces to brackets for offset

### DIFF
--- a/util/Text.php
+++ b/util/Text.php
@@ -287,7 +287,7 @@ class Text {
 				$results[] = $buffer;
 				$buffer = '';
 			} else {
-				$buffer .= $data{$tmpOffset};
+				$buffer .= $data[$tmpOffset];
 			}
 
 			if ($options['leftBound'] !== $options['rightBound']) {


### PR DESCRIPTION
* PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in util/Text.php on line 290
* Resolves issues with Form helper.